### PR TITLE
feat(shell): detect commands through wrappers and shell -c patterns

### DIFF
--- a/internal/rules/hadolint/dl3004_test.go
+++ b/internal/rules/hadolint/dl3004_test.go
@@ -134,6 +134,49 @@ RUN apt-get update \
 `,
 			wantCount: 1,
 		},
+		// Command wrapper tests - ensure sudo is detected through wrappers
+		{
+			name: "sudo via env wrapper",
+			dockerfile: `FROM ubuntu:22.04
+RUN env sudo apt-get update
+`,
+			wantCount: 1,
+		},
+		{
+			name: "sudo via nice wrapper",
+			dockerfile: `FROM ubuntu:22.04
+RUN nice -n 10 sudo apt-get update
+`,
+			wantCount: 1,
+		},
+		{
+			name: "sudo via timeout wrapper",
+			dockerfile: `FROM ubuntu:22.04
+RUN timeout 60 sudo apt-get update
+`,
+			wantCount: 1,
+		},
+		{
+			name: "sudo via sh -c wrapper",
+			dockerfile: `FROM ubuntu:22.04
+RUN sh -c 'sudo apt-get update'
+`,
+			wantCount: 1,
+		},
+		{
+			name: "sudo via bash -c wrapper",
+			dockerfile: `FROM ubuntu:22.04
+RUN bash -c "sudo apt-get update"
+`,
+			wantCount: 1,
+		},
+		{
+			name: "sudo via nested wrappers",
+			dockerfile: `FROM ubuntu:22.04
+RUN env nice sudo apt-get update
+`,
+			wantCount: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -175,6 +218,14 @@ func TestContainsSudo(t *testing.T) {
 		{"DEBIAN_FRONTEND=noninteractive sudo apt", true},
 		{"", false},
 		{"  sudo  ", true},
+		// Command wrapper tests
+		{"env sudo apt-get", true},
+		{"nice sudo apt-get", true},
+		{"nice -n 10 sudo apt-get", true},
+		{"timeout 60 sudo apt-get", true},
+		{"sh -c 'sudo apt-get'", true},
+		{"bash -c 'sudo apt-get'", true},
+		{"env nice sudo apt-get", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Improve shell command detection to find commands executed through command wrappers (`env`, `nice`, `nohup`, `timeout`, `xargs`, `strace`, etc.) and shell wrappers (`sh -c`, `bash -c`, etc.)
- Fixes DL3004 detection for patterns like `env sudo apt-get`, `nice -n 10 sudo`, `sh -c 'sudo ...'`, and nested wrappers

## Changes

**shell.go:**
- Add `commandWrappers` map for commands that wrap other commands
- Add `shellWrappers` map for shells that can execute code via `-c`
- Add `extractWrappedCommands()` to find commands in wrapper arguments
- Add `extractShellWrapperCommands()` to parse `sh -c 'code'` patterns
- Add `extractQuotedContent()` to extract content from quoted shell words
- Add `isNumeric()` helper to skip numeric flag arguments

**Tests:**
- Add `TestCommandWrappers` with 11 test cases
- Add `TestShellWrappers` with 6 test cases
- Add 7 wrapper-related cases to `TestContainsCommand`
- Add 6 DL3004 test cases for command/shell wrapper scenarios

## Test plan

- [x] All existing tests pass
- [x] New wrapper tests pass
- [x] Linting passes
- [x] DL3004 now detects sudo in wrapper patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced command detection to recognize commands wrapped by utilities such as env, nice, timeout, and shell invocations (sh -c, bash -c).
  * Added support for detecting commands nested inside multiple wrapper layers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->