### PR TITLE
feat(version): show BuildKit version instead of commit hash

### DIFF
--- a/internal/integration/__snapshots__/TestCheck_format-sarif_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_format-sarif_1.snap.json
@@ -23,7 +23,7 @@
               "helpUri": "https://docs.docker.com/go/dockerfile/rule/stage-name-casing/"
             }
           ],
-          "version": "dev"
+          "version": "dev (buildkit v0.27.1)"
         }
       },
       "artifacts": [

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,20 +1,30 @@
 package version
 
-var (
-	version = "dev"
-	commit  = "unknown"
+import (
+	"runtime/debug"
 )
+
+var version = "dev"
 
 // Version returns the current version string
 func Version() string {
-	commitHash := Commit()
-	if commitHash != "unknown" && len(commitHash) > 7 {
-		return version + " (" + commitHash[:7] + ")"
+	bkVersion := BuildKitVersion()
+	if bkVersion != "" {
+		return version + " (buildkit " + bkVersion + ")"
 	}
 	return version
 }
 
-// Commit returns the git commit hash.
-func Commit() string {
-	return commit
+// BuildKitVersion returns the linked BuildKit version from build info.
+func BuildKitVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == "github.com/moby/buildkit" {
+			return dep.Version
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

- Replace git commit hash in version output with linked BuildKit version
- More useful for understanding compatibility and debugging issues
- Uses `runtime/debug.ReadBuildInfo()` to extract dependency version

**Before:** `tally version dev (abc1234)`
**After:** `tally version dev (buildkit v0.27.1)`

## Test plan

- [x] `go test ./...` passes
- [x] `make lint` passes
- [x] Manual verification: `go run . version` outputs BuildKit version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version reporting to include BuildKit version information in the tool's version output, providing enhanced visibility into the build environment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->