### PR TITLE
feat(rules): implement DL3021 COPY destination must end with /

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,11 @@ uv/bun, line-length and layer optimizations).
 tally integrates rules from multiple sources:
 
 <!-- BEGIN RULES_TABLE -->
-
-| Source                                                          | Rules    | Description                                                                                   |
-| --------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| **[BuildKit](https://docs.docker.com/reference/build-checks/)** | 22 rules | Docker's official Dockerfile checks (automatically captured)                                  |
-| **tally**                                                       | 3 rules  | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
-| **[Hadolint](https://github.com/hadolint/hadolint)**            | 22 rules | Hadolint-compatible Dockerfile rules (expanding)                                              |
-
+| Source | Rules | Description |
+|--------|-------|-------------|
+| **[BuildKit](https://docs.docker.com/reference/build-checks/)** | 22 rules | Docker's official Dockerfile checks (automatically captured) |
+| **tally** | 3 rules | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
+| **[Hadolint](https://github.com/hadolint/hadolint)** | 23 rules | Hadolint-compatible Dockerfile rules (expanding) |
 <!-- END RULES_TABLE -->
 
 **See [RULES.md](RULES.md) for the complete rules reference.**

--- a/RULES.md
+++ b/RULES.md
@@ -144,7 +144,7 @@ See the [Hadolint Wiki](https://github.com/hadolint/hadolint/wiki) for detailed 
 | [DL3018](https://github.com/hadolint/hadolint/wiki/DL3018) | Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`. | Warning | ⏳ |
 | [DL3019](https://github.com/hadolint/hadolint/wiki/DL3019) | Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages. | Info | ⏳ |
 | [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) | Use `COPY` instead of `ADD` for files and folders. | Error | ✅ `hadolint/DL3020` |
-| [DL3021](https://github.com/hadolint/hadolint/wiki/DL3021) | `COPY` with more than 2 arguments requires the last argument to end with `/` | Error | ⏳ |
+| [DL3021](https://github.com/hadolint/hadolint/wiki/DL3021) | `COPY` with more than 2 arguments requires the last argument to end with `/` | Error | ✅ `hadolint/DL3021` |
 | [DL3022](https://github.com/hadolint/hadolint/wiki/DL3022) | `COPY --from` should reference a previously defined `FROM` alias | Warning | ⏳ |
 | [DL3023](https://github.com/hadolint/hadolint/wiki/DL3023) | `COPY --from` cannot reference its own `FROM` alias | Error | ✅ `hadolint/DL3023` |
 | [DL3024](https://github.com/hadolint/hadolint/wiki/DL3024) | `FROM` aliases (stage names) must be unique | Error | ✅ `hadolint/DL3024` |

--- a/internal/integration/__snapshots__/TestCheck_avoid-latest-tag_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_avoid-latest-tag_1.snap.json
@@ -34,6 +34,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_buildkit-warnings_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_buildkit-warnings_1.snap.json
@@ -93,6 +93,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_cli-overrides-config_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_cli-overrides-config_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_config-cascading-discovery_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_config-cascading-discovery_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_config-file-discovery_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_config-file-discovery_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_config-skip-options_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_config-skip-options_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_consistent-instruction-casing_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_consistent-instruction-casing_1.snap.json
@@ -91,6 +91,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_context-copy-heredoc_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_context-copy-heredoc_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_context-copy-ignored_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_context-copy-ignored_1.snap.json
@@ -34,6 +34,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_context-no-context-flag_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_context-no-context-flag_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_copy-from-own-alias_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_copy-from-own-alias_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_discovery-directory_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_discovery-directory_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 3,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_discovery-exclude_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_discovery-exclude_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_dl3003_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_dl3003_1.snap.json
@@ -54,6 +54,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_dl3021_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_dl3021_1.snap.json
@@ -1,0 +1,39 @@
+{
+  "files": [
+    {
+      "file": "testdata/dl3021/Dockerfile",
+      "violations": [
+        {
+          "location": {
+            "file": "testdata/dl3021/Dockerfile",
+            "start": {
+              "line": 4,
+              "column": 0
+            },
+            "end": {
+              "line": 4,
+              "column": 0
+            }
+          },
+          "rule": "hadolint/DL3021",
+          "message": "COPY with more than 2 arguments requires the last argument to end with /",
+          "detail": "When copying multiple source files, the destination must be a directory (indicated by a trailing /). Without it, the build will fail.",
+          "severity": "error",
+          "docUrl": "https://github.com/hadolint/hadolint/wiki/DL3021",
+          "sourceCode": "COPY foo bar baz"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total": 1,
+    "errors": 1,
+    "warnings": 0,
+    "info": 0,
+    "style": 0,
+    "files": 1
+  },
+  "files_scanned": 1,
+  "rules_enabled": 39
+}
+

--- a/internal/integration/__snapshots__/TestCheck_dl3027_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_dl3027_1.snap.json
@@ -167,6 +167,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_duplicate-stage-name_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_duplicate-stage-name_1.snap.json
@@ -52,6 +52,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_empty-continuation_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_empty-continuation_1.snap.json
@@ -54,6 +54,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_env-var-override_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_env-var-override_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_fail-level-error_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_fail-level-error_1.snap.json
@@ -93,5 +93,5 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_fail-level-none_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_fail-level-none_1.snap.json
@@ -93,5 +93,5 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_fail-level-warning_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_fail-level-warning_1.snap.json
@@ -93,6 +93,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_inline-buildx-compat_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_inline-buildx-compat_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_inline-directives-disabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_inline-directives-disabled_1.snap.json
@@ -73,6 +73,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_inline-hadolint-compat_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_inline-hadolint-compat_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_inline-ignore-global_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_inline-ignore-global_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_inline-ignore-multiple-max-lines_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_inline-ignore-multiple-max-lines_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_inline-ignore-single_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_inline-ignore-single_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_inline-require-reason_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_inline-require-reason_1.snap.json
@@ -90,6 +90,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_inline-unused-directive_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_inline-unused-directive_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_invalid-instruction-order_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_invalid-instruction-order_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_maintainer-deprecated_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_maintainer-deprecated_1.snap.json
@@ -54,6 +54,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_multiple-healthcheck_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_multiple-healthcheck_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_no-from-instruction_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_no-from-instruction_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_non-posix-shell_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_non-posix-shell_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_onbuild-forbidden_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_onbuild-forbidden_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_per-file-configs_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_per-file-configs_1.snap.json
@@ -76,6 +76,6 @@
     "files": 2
   },
   "files_scanned": 2,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_simple-max-lines-fail_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_simple-max-lines-fail_1.snap.json
@@ -33,6 +33,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/__snapshots__/TestCheck_simple-max-lines-pass_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_simple-max-lines-pass_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_simple_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_simple_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }

--- a/internal/integration/__snapshots__/TestCheck_trusted-registries-allowed_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_trusted-registries-allowed_1.snap.json
@@ -9,5 +9,5 @@
     "files": 0
   },
   "files_scanned": 1,
-  "rules_enabled": 39
+  "rules_enabled": 40
 }

--- a/internal/integration/__snapshots__/TestCheck_trusted-registries-untrusted_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_trusted-registries-untrusted_1.snap.json
@@ -52,6 +52,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 39
+  "rules_enabled": 40
 }
 

--- a/internal/integration/__snapshots__/TestCheck_unreachable-stage_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_unreachable-stage_1.snap.json
@@ -34,6 +34,6 @@
     "files": 1
   },
   "files_scanned": 1,
-  "rules_enabled": 38
+  "rules_enabled": 39
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -136,6 +136,7 @@ func TestCheck(t *testing.T) {
 
 		// Hadolint rule tests
 		{name: "dl3003", dir: "dl3003", args: []string{"--format", "json"}, wantExit: 1},
+		{name: "dl3021", dir: "dl3021", args: []string{"--format", "json"}, wantExit: 1},
 		{name: "dl3027", dir: "dl3027", args: []string{"--format", "json"}, wantExit: 1},
 		{name: "inline-ignore-multiple-max-lines", dir: "inline-ignore-multiple", args: []string{"--format", "json"}},
 		{

--- a/internal/integration/testdata/dl3021/Dockerfile
+++ b/internal/integration/testdata/dl3021/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.18
+
+# DL3021: Should trigger - multiple sources without trailing slash
+COPY foo bar baz
+
+# This is fine - multiple sources with trailing slash
+COPY a b c /dest/
+
+# This is fine - single source
+COPY single /dest

--- a/internal/rules/hadolint-status.json
+++ b/internal/rules/hadolint-status.json
@@ -35,6 +35,10 @@
       "status": "implemented",
       "tally_rule": "hadolint/DL3020"
     },
+    "DL3021": {
+      "status": "implemented",
+      "tally_rule": "hadolint/DL3021"
+    },
     "DL3023": {
       "status": "implemented",
       "tally_rule": "hadolint/DL3023"

--- a/internal/rules/hadolint/dl3021.go
+++ b/internal/rules/hadolint/dl3021.go
@@ -1,0 +1,76 @@
+package hadolint
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/tinovyatkin/tally/internal/rules"
+)
+
+// DL3021Rule implements the DL3021 linting rule.
+// COPY with more than 2 arguments requires the last argument to end with /.
+type DL3021Rule struct{}
+
+// NewDL3021Rule creates a new DL3021 rule instance.
+func NewDL3021Rule() *DL3021Rule {
+	return &DL3021Rule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *DL3021Rule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            rules.HadolintRulePrefix + "DL3021",
+		Name:            "COPY destination must end with /",
+		Description:     "COPY with more than 2 arguments requires the last argument to end with /",
+		DocURL:          "https://github.com/hadolint/hadolint/wiki/DL3021",
+		DefaultSeverity: rules.SeverityError,
+		Category:        "correctness",
+		IsExperimental:  false,
+	}
+}
+
+// Check runs the DL3021 rule.
+// It warns when a COPY instruction has more than 2 arguments and the
+// destination does not end with /.
+func (r *DL3021Rule) Check(input rules.LintInput) []rules.Violation {
+	var violations []rules.Violation
+	meta := r.Metadata()
+
+	for _, stage := range input.Stages {
+		for _, cmd := range stage.Commands {
+			copyCmd, ok := cmd.(*instructions.CopyCommand)
+			if !ok {
+				continue
+			}
+
+			// Only check when there are more than 1 source (i.e., more than 2 args total)
+			if len(copyCmd.SourcePaths) <= 1 {
+				continue
+			}
+
+			// Check if destination ends with /
+			// Strip quotes if present (handles "dest" case)
+			dest := stripQuotes(copyCmd.DestPath)
+			if dest != "" && !strings.HasSuffix(dest, "/") {
+				loc := rules.NewLocationFromRanges(input.File, copyCmd.Location())
+				violations = append(violations, rules.NewViolation(
+					loc,
+					meta.Code,
+					"COPY with more than 2 arguments requires the last argument to end with /",
+					meta.DefaultSeverity,
+				).WithDocURL(meta.DocURL).WithDetail(
+					"When copying multiple source files, the destination must be a directory "+
+						"(indicated by a trailing /). Without it, the build will fail.",
+				))
+			}
+		}
+	}
+
+	return violations
+}
+
+// init registers the rule with the default registry.
+func init() {
+	rules.Register(NewDL3021Rule())
+}

--- a/internal/rules/hadolint/dl3021_test.go
+++ b/internal/rules/hadolint/dl3021_test.go
@@ -1,0 +1,154 @@
+package hadolint
+
+import (
+	"testing"
+
+	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/tinovyatkin/tally/internal/testutil"
+)
+
+func TestDL3021Rule_Metadata(t *testing.T) {
+	r := NewDL3021Rule()
+	meta := r.Metadata()
+
+	if meta.Code != rules.HadolintRulePrefix+"DL3021" {
+		t.Errorf("Code = %q, want %q", meta.Code, rules.HadolintRulePrefix+"DL3021")
+	}
+	if meta.DefaultSeverity != rules.SeverityError {
+		t.Errorf("DefaultSeverity = %v, want %v", meta.DefaultSeverity, rules.SeverityError)
+	}
+	if meta.Category != "correctness" {
+		t.Errorf("Category = %q, want %q", meta.Category, "correctness")
+	}
+}
+
+func TestDL3021Rule_Check(t *testing.T) {
+	tests := []struct {
+		name       string
+		dockerfile string
+		wantCount  int
+	}{
+		// Original Hadolint test cases
+		{
+			name: "no warn on 2 args",
+			dockerfile: `FROM alpine
+COPY foo bar
+`,
+			wantCount: 0,
+		},
+		{
+			name: "warn on 3 args",
+			dockerfile: `FROM alpine
+COPY foo bar baz
+`,
+			wantCount: 1,
+		},
+		{
+			name: "no warn on 3 args with trailing slash",
+			dockerfile: `FROM alpine
+COPY foo bar baz/
+`,
+			wantCount: 0,
+		},
+		{
+			name: "warn on 3 args with quotes",
+			dockerfile: `FROM alpine
+COPY foo bar "baz"
+`,
+			wantCount: 1,
+		},
+		{
+			name: "no warn on 3 args with quotes and trailing slash",
+			dockerfile: `FROM alpine
+COPY foo bar "baz/"
+`,
+			wantCount: 0,
+		},
+		// Additional edge cases
+		{
+			name: "no warn on single source",
+			dockerfile: `FROM alpine
+COPY src /dest
+`,
+			wantCount: 0,
+		},
+		{
+			name: "warn on 4 args without trailing slash",
+			dockerfile: `FROM alpine
+COPY a b c dest
+`,
+			wantCount: 1,
+		},
+		{
+			name: "no warn on 4 args with trailing slash",
+			dockerfile: `FROM alpine
+COPY a b c dest/
+`,
+			wantCount: 0,
+		},
+		{
+			name: "multiple COPY instructions",
+			dockerfile: `FROM alpine
+COPY a b c dest
+COPY x y z dir/
+COPY p q r target
+`,
+			wantCount: 2,
+		},
+		{
+			name: "COPY with --from does not exempt from rule",
+			dockerfile: `FROM alpine AS builder
+COPY a b c dest
+
+FROM alpine
+COPY --from=builder a b c /dest
+`,
+			wantCount: 2,
+		},
+		{
+			name: "single source with dest ending in slash is fine",
+			dockerfile: `FROM alpine
+COPY src /dest/
+`,
+			wantCount: 0,
+		},
+		{
+			name: "no warn with single quoted destination",
+			dockerfile: `FROM alpine
+COPY foo bar 'baz/'
+`,
+			wantCount: 0,
+		},
+		{
+			name: "warn with single quoted destination without slash",
+			dockerfile: `FROM alpine
+COPY foo bar 'baz'
+`,
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := testutil.MakeLintInput(t, "Dockerfile", tt.dockerfile)
+
+			r := NewDL3021Rule()
+			violations := r.Check(input)
+
+			if len(violations) != tt.wantCount {
+				t.Errorf("got %d violations, want %d", len(violations), tt.wantCount)
+				for _, v := range violations {
+					t.Logf("  - %s: %s", v.RuleCode, v.Message)
+				}
+			}
+
+			// Verify rule code for violations
+			for _, v := range violations {
+				if v.RuleCode != rules.HadolintRulePrefix+"DL3021" {
+					t.Errorf("RuleCode = %q, want %q", v.RuleCode, rules.HadolintRulePrefix+"DL3021")
+				}
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary

- Port Hadolint rule DL3021 to Go
- Checks that `COPY` with multiple sources (more than 2 arguments) has a destination ending with `/`
- Without the trailing slash, Docker builds fail when copying multiple files to a non-directory destination

## Test plan

- [x] Unit tests cover all original Hadolint test cases
- [x] Integration test with snapshot verification
- [x] All existing tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented Hadolint rule DL3021 to validate COPY instructions with multiple source arguments in Dockerfiles. The rule ensures destinations are properly designated as directories with a trailing slash, preventing build failures and improving container configuration consistency.

* **Documentation**
  * Updated rule documentation and registry status to reflect the newly implemented DL3021 rule, increasing the total available rules count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->