### PR TITLE
feat: implement DL3022 COPY --from alias validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tally integrates rules from multiple sources:
 |--------|-------|-------------|
 | **[BuildKit](https://docs.docker.com/reference/build-checks/)** | 13/22 rules | Docker's official Dockerfile checks (captured + reimplemented) |
 | **tally** | 7 rules | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
-| **[Hadolint](https://github.com/hadolint/hadolint)** | 28 rules | Hadolint-compatible Dockerfile rules (expanding) |
+| **[Hadolint](https://github.com/hadolint/hadolint)** | 29 rules | Hadolint-compatible Dockerfile rules (expanding) |
 <!-- END RULES_TABLE -->
 
 **See [RULES.md](RULES.md) for the complete rules reference.**

--- a/RULES.md
+++ b/RULES.md
@@ -17,7 +17,7 @@ tally supports rules from multiple sources, each with its own namespace prefix.
 |-----------|-------------|---------------------|-------|
 | tally | 7 | - | 7 |
 | buildkit | 8 + 5 captured | - | 22 |
-| hadolint | 19 | 9 | 66 |
+| hadolint | 20 | 9 | 66 |
 <!-- END RULES_SUMMARY -->
 
 ---
@@ -324,7 +324,7 @@ See the [Hadolint Wiki](https://github.com/hadolint/hadolint/wiki) for detailed 
 | [DL3019](https://github.com/hadolint/hadolint/wiki/DL3019) | Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages. | Info | ⏳ |
 | [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) | Use `COPY` instead of `ADD` for files and folders. | Error | ✅ `hadolint/DL3020` |
 | [DL3021](https://github.com/hadolint/hadolint/wiki/DL3021) | `COPY` with more than 2 arguments requires the last argument to end with `/` | Error | ✅ `hadolint/DL3021` |
-| [DL3022](https://github.com/hadolint/hadolint/wiki/DL3022) | `COPY --from` should reference a previously defined `FROM` alias | Warning | ⏳ |
+| [DL3022](https://github.com/hadolint/hadolint/wiki/DL3022) | `COPY --from` should reference a previously defined `FROM` alias | Warning | ✅ `hadolint/DL3022` |
 | [DL3023](https://github.com/hadolint/hadolint/wiki/DL3023) | `COPY --from` cannot reference its own `FROM` alias | Error | ✅ `hadolint/DL3023` |
 | [DL3024](https://github.com/hadolint/hadolint/wiki/DL3024) | `FROM` aliases (stage names) must be unique | Error | 🔄 `buildkit/DuplicateStageName` |
 | [DL3025](https://github.com/hadolint/hadolint/wiki/DL3025) | Use arguments JSON notation for CMD and ENTRYPOINT arguments | Warning | 🔄 `buildkit/JSONArgsRecommended` |

--- a/internal/integration/__snapshots__/TestCheck_copy-from-own-alias_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_copy-from-own-alias_1.snap.json
@@ -4,6 +4,24 @@
       "file": "testdata/copy-from-own-alias/Dockerfile",
       "violations": [
         {
+          "docUrl": "https://github.com/hadolint/hadolint/wiki/DL3022",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 2
+            },
+            "file": "testdata/copy-from-own-alias/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 2
+            }
+          },
+          "message": "`COPY --from` should reference a previously defined `FROM` alias",
+          "rule": "hadolint/DL3022",
+          "severity": "error",
+          "sourceCode": "COPY --from=foo bar ."
+        },
+        {
           "docUrl": "https://github.com/hadolint/hadolint/wiki/DL3023",
           "location": {
             "end": {
@@ -27,11 +45,11 @@
   "files_scanned": 1,
   "rules_enabled": 37,
   "summary": {
-    "errors": 1,
+    "errors": 2,
     "files": 1,
     "info": 0,
     "style": 0,
-    "total": 1,
+    "total": 2,
     "warnings": 0
   }
 }

--- a/internal/integration/__snapshots__/TestCheck_dl3022_1.snap.json
+++ b/internal/integration/__snapshots__/TestCheck_dl3022_1.snap.json
@@ -1,0 +1,37 @@
+{
+  "files": [
+    {
+      "file": "testdata/dl3022/Dockerfile",
+      "violations": [
+        {
+          "docUrl": "https://github.com/hadolint/hadolint/wiki/DL3022",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 6
+            },
+            "file": "testdata/dl3022/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 6
+            }
+          },
+          "message": "`COPY --from` should reference a previously defined `FROM` alias",
+          "rule": "hadolint/DL3022",
+          "severity": "error",
+          "sourceCode": "COPY --from=runtime foo ."
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 0,
+  "summary": {
+    "errors": 1,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -268,6 +268,12 @@ func TestCheck(t *testing.T) {
 			wantExit: 1,
 		},
 		{
+			name:     "dl3022",
+			dir:      "dl3022",
+			args:     append([]string{"--format", "json"}, selectRules("hadolint/DL3022")...),
+			wantExit: 1,
+		},
+		{
 			name:     "dl3027",
 			dir:      "dl3027",
 			args:     append([]string{"--format", "json"}, selectRules("hadolint/DL3027")...),

--- a/internal/integration/testdata/dl3022/Dockerfile
+++ b/internal/integration/testdata/dl3022/Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch as build
+RUN echo "building"
+
+FROM node
+# DL3022: Should trigger - forward reference to later stage
+COPY --from=runtime foo .
+
+# This is fine - references a previously defined alias
+COPY --from=build bar .
+
+FROM alpine as runtime
+RUN echo "runtime"

--- a/internal/rules/hadolint-status.json
+++ b/internal/rules/hadolint-status.json
@@ -48,6 +48,10 @@
       "status": "implemented",
       "tally_rule": "hadolint/DL3021"
     },
+    "DL3022": {
+      "status": "implemented",
+      "tally_rule": "hadolint/DL3022"
+    },
     "DL3023": {
       "status": "implemented",
       "tally_rule": "hadolint/DL3023"

--- a/internal/rules/hadolint/dl3022.go
+++ b/internal/rules/hadolint/dl3022.go
@@ -1,0 +1,21 @@
+package hadolint
+
+// DL3022: COPY --from should reference a previously defined FROM alias.
+//
+// The COPY --from flag should reference either a named stage alias defined
+// in a previous FROM instruction, a valid numeric stage index, or an external
+// image (containing ":""). Using an undefined reference is likely a typo or
+// indicates a stage that was removed or renamed.
+//
+// IMPLEMENTATION: This rule is detected during semantic analysis in
+// internal/semantic/builder.go when processing COPY instructions. The semantic
+// builder resolves --from references against known stage names and indices,
+// and reports a violation when the reference cannot be resolved and doesn't
+// look like an external image.
+//
+// See: https://github.com/hadolint/hadolint/wiki/DL3022
+
+const (
+	DL3022Code   = "hadolint/DL3022"
+	DL3022DocURL = "https://github.com/hadolint/hadolint/wiki/DL3022"
+)

--- a/internal/rules/hadolint/dl3022_test.go
+++ b/internal/rules/hadolint/dl3022_test.go
@@ -1,0 +1,108 @@
+package hadolint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tinovyatkin/tally/internal/dockerfile"
+	"github.com/tinovyatkin/tally/internal/semantic"
+)
+
+func TestDL3022_CopyFromUndefinedAlias(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		dockerfile string
+		shouldFail bool
+	}{
+		{
+			name:       "warn on missing alias",
+			dockerfile: "FROM scratch\nCOPY --from=foo bar .",
+			shouldFail: true,
+		},
+		{
+			name: "warn on alias defined after",
+			dockerfile: strings.Join([]string{
+				"FROM scratch",
+				"COPY --from=build foo .",
+				"FROM node as build",
+				"RUN baz",
+			}, "\n"),
+			shouldFail: true,
+		},
+		{
+			name: "don't warn on correctly defined aliases",
+			dockerfile: strings.Join([]string{
+				"FROM scratch as build",
+				"RUN foo",
+				"FROM node",
+				"COPY --from=build foo .",
+				"RUN baz",
+			}, "\n"),
+			shouldFail: false,
+		},
+		{
+			name:       "don't warn on external images",
+			dockerfile: `COPY --from=haskell:latest bar .`,
+			shouldFail: false,
+		},
+		{
+			name:       "warn on out-of-range numeric stage index",
+			dockerfile: "FROM scratch\nCOPY --from=1 bar .",
+			shouldFail: true,
+		},
+		{
+			name:       "warn on self-referencing numeric stage index",
+			dockerfile: "FROM scratch\nCOPY --from=0 bar .",
+			shouldFail: true,
+		},
+		{
+			name: "don't warn on valid stage count with named stage",
+			dockerfile: strings.Join([]string{
+				"FROM scratch as build",
+				"RUN foo",
+				"FROM node",
+				"COPY --from=0 foo .",
+			}, "\n"),
+			shouldFail: false,
+		},
+		{
+			name: "don't warn on valid stage count with unnamed stage",
+			dockerfile: strings.Join([]string{
+				"FROM scratch",
+				"RUN foo",
+				"FROM node",
+				"COPY --from=0 foo .",
+			}, "\n"),
+			shouldFail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := dockerfile.Parse(strings.NewReader(tt.dockerfile), nil)
+			if err != nil {
+				t.Fatalf("failed to parse Dockerfile: %v", err)
+			}
+
+			model := semantic.NewModel(result, nil, "Dockerfile")
+			issues := model.ConstructionIssues()
+
+			var foundDL3022 bool
+			for _, issue := range issues {
+				if issue.Code == DL3022Code {
+					foundDL3022 = true
+					break
+				}
+			}
+
+			if tt.shouldFail && !foundDL3022 {
+				t.Errorf("expected DL3022 violation but none found")
+			}
+			if !tt.shouldFail && foundDL3022 {
+				t.Errorf("unexpected DL3022 violation")
+			}
+		})
+	}
+}

--- a/internal/semantic/semantic_test.go
+++ b/internal/semantic/semantic_test.go
@@ -197,14 +197,21 @@ COPY --from=foo bar .
 	model := NewModel(pr, nil, "Dockerfile")
 
 	violations := model.ConstructionIssues()
-	if len(violations) != 1 {
-		t.Fatalf("expected 1 violation, got %d", len(violations))
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(violations))
 	}
+	// DL3023 fires first (checked before processCopyFrom), then DL3022
 	if violations[0].Code != "hadolint/DL3023" {
 		t.Errorf("expected hadolint/DL3023, got %q", violations[0].Code)
 	}
-	if violations[0].Location.Start.Line != 2 {
-		t.Errorf("expected violation on line 2, got %d", violations[0].Location.Start.Line)
+	// DL3022: COPY --from references undefined alias (self-reference is not "previously defined")
+	if violations[1].Code != "hadolint/DL3022" {
+		t.Errorf("expected hadolint/DL3022, got %q", violations[1].Code)
+	}
+	for _, v := range violations {
+		if v.Location.Start.Line != 2 {
+			t.Errorf("expected %s violation on line 2, got %d", v.Code, v.Location.Start.Line)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Port Hadolint rule DL3022 which validates that `COPY --from` references a previously defined `FROM` alias, valid numeric stage index, or external image (containing `:`)
- Implemented as a semantic model check in `internal/semantic/builder.go`, following the same pattern as DL3023 and DL3012
- Bumps Hadolint-compatible rule count from 28 to 29

## Details

The rule detects:
- `COPY --from=foo` where `foo` is not a defined stage alias
- `COPY --from=build` where `build` is defined in a later stage (forward reference)
- `COPY --from=N` where N is out of range or self-referencing

The rule does NOT flag:
- `COPY --from=nginx:latest` (external image references containing `:`)
- `COPY --from=build` where `build` is defined in a previous `FROM ... AS build`
- `COPY --from=0` referencing a valid earlier stage index

## Test plan

- [x] Unit tests covering all original Hadolint spec test cases (`go test ./internal/rules/hadolint/... -run DL3022`)
- [x] Integration test with testdata fixture and snapshot
- [x] Existing semantic test for DL3023 updated to account for co-firing
- [x] `make lint` passes cleanly
- [x] Full test suite passes (`go test ./...`)
- [x] `hadolint-status.json` updated, docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Hadolint rule DL3022 validation to detect when COPY --from references undefined stage aliases, improving Dockerfile validation coverage.

* **Documentation**
  * Updated documentation to reflect the new DL3022 rule and expanded Hadolint rules list.

* **Tests**
  * Added comprehensive test suite for the new DL3022 validation rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->