### PR TITLE
feat(vscode): implement phases 3 + 3.5 — fixAll, executeCommand, logo

### DIFF
--- a/extensions/vscode-tally/package.json
+++ b/extensions/vscode-tally/package.json
@@ -5,6 +5,7 @@
   "description": "Dockerfile and Containerfile linter/formatter powered by tally",
   "version": "0.0.0",
   "license": "MIT",
+  "icon": "assets/logo.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/tinovyatkin/tally"
@@ -25,6 +26,14 @@
       {
         "command": "tally.restartServer",
         "title": "Tally: Restart server"
+      },
+      {
+        "command": "tally.applyAllFixes",
+        "title": "Tally: Apply all safe fixes"
+      },
+      {
+        "command": "tally.configureDefaultFormatterForDockerfile",
+        "title": "Tally: Set as default Dockerfile formatter"
       }
     ],
     "configuration": {
@@ -69,6 +78,49 @@
             "editorOnly"
           ],
           "description": "How to merge VS Code settings with `.tally.toml` / `tally.toml`."
+        },
+        "tally.fixAll": {
+          "type": "boolean",
+          "default": true,
+          "description": "Apply safe auto-fixes via code actions on save."
+        },
+        "tally.fixUnsafe": {
+          "type": "boolean",
+          "default": false,
+          "description": "Also apply unsafe fixes during fixAll."
+        },
+        "tally.lint.run": {
+          "type": "string",
+          "default": "onType",
+          "enum": [
+            "onType",
+            "onSave"
+          ],
+          "description": "When to run the linter."
+        },
+        "tally.format.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable document formatting."
+        },
+        "tally.trace.server": {
+          "type": "string",
+          "default": "off",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "description": "Trace LSP communication."
+        }
+      }
+    },
+    "configurationDefaults": {
+      "[dockerfile]": {
+        "editor.defaultFormatter": "wharflab.tally",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.fixAll.tally": "explicit"
         }
       }
     }

--- a/extensions/vscode-tally/src/config/vscodeConfig.ts
+++ b/extensions/vscode-tally/src/config/vscodeConfig.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 export type ImportStrategy = 'fromEnvironment' | 'useBundled';
 export type ConfigurationPreference = 'editorFirst' | 'filesystemFirst' | 'editorOnly';
+export type LintRun = 'onType' | 'onSave';
 
 export interface TallySettings {
   enable: boolean;
@@ -9,6 +10,10 @@ export interface TallySettings {
   importStrategy: ImportStrategy;
   configuration: unknown | null;
   configurationPreference: ConfigurationPreference;
+  fixAll: boolean;
+  fixUnsafe: boolean;
+  lintRun: LintRun;
+  formatEnable: boolean;
 }
 
 export interface BinaryResolutionSettings {
@@ -22,6 +27,10 @@ const DEFAULTS: TallySettings = {
   importStrategy: 'fromEnvironment',
   configuration: null,
   configurationPreference: 'editorFirst',
+  fixAll: true,
+  fixUnsafe: false,
+  lintRun: 'onType',
+  formatEnable: true,
 };
 
 export function readEffectiveSettings(scope?: vscode.ConfigurationScope): TallySettings {
@@ -35,6 +44,10 @@ export function readEffectiveSettings(scope?: vscode.ConfigurationScope): TallyS
       'configurationPreference',
       DEFAULTS.configurationPreference,
     ),
+    fixAll: cfg.get<boolean>('fixAll', DEFAULTS.fixAll),
+    fixUnsafe: cfg.get<boolean>('fixUnsafe', DEFAULTS.fixUnsafe),
+    lintRun: cfg.get<LintRun>('lint.run', DEFAULTS.lintRun),
+    formatEnable: cfg.get<boolean>('format.enable', DEFAULTS.formatEnable),
   };
 }
 

--- a/extensions/vscode-tally/src/extension.ts
+++ b/extensions/vscode-tally/src/extension.ts
@@ -67,6 +67,37 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('tally.restartServer', async () => {
       await startOrRestart('manual restart');
     }),
+
+    vscode.commands.registerCommand('tally.applyAllFixes', async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || !client) {
+        return;
+      }
+      const uri = editor.document.uri.toString();
+      const edit = await client.executeApplyAllFixes(uri);
+      if (edit) {
+        await vscode.workspace.applyEdit(edit);
+      }
+    }),
+
+    vscode.commands.registerCommand('tally.configureDefaultFormatterForDockerfile', async () => {
+      const config = vscode.workspace.getConfiguration(undefined, { languageId: 'dockerfile' });
+      await config.update(
+        'editor.defaultFormatter',
+        'wharflab.tally',
+        vscode.ConfigurationTarget.Global,
+        true,
+      );
+      await config.update(
+        'editor.formatOnSave',
+        true,
+        vscode.ConfigurationTarget.Global,
+        true,
+      );
+      void vscode.window.showInformationMessage(
+        'Tally is now the default Dockerfile formatter with format-on-save enabled.',
+      );
+    }),
   );
 
   configService.onDidChange(async (change) => {

--- a/extensions/vscode-tally/src/lsp/client.ts
+++ b/extensions/vscode-tally/src/lsp/client.ts
@@ -4,6 +4,8 @@ import {
   LanguageClient,
   type LanguageClientOptions,
   type ServerOptions,
+  ExecuteCommandRequest,
+  type WorkspaceEdit as LspWorkspaceEdit,
 } from 'vscode-languageclient/node';
 
 import { type ResolvedBinary } from '../binary/findBinary';
@@ -57,5 +59,19 @@ export class TallyLanguageClient {
 
   public async sendConfiguration(settings: unknown): Promise<void> {
     await this.client.sendNotification('workspace/didChangeConfiguration', { settings });
+  }
+
+  public async executeApplyAllFixes(documentUri: string): Promise<vscode.WorkspaceEdit | undefined> {
+    const result: LspWorkspaceEdit | null = await this.client.sendRequest(
+      ExecuteCommandRequest.type,
+      {
+        command: 'tally.applyAllFixes',
+        arguments: [documentUri],
+      },
+    );
+    if (result == null) {
+      return undefined;
+    }
+    return this.client.protocol2CodeConverter.asWorkspaceEdit(result);
   }
 }

--- a/internal/lspserver/commands.go
+++ b/internal/lspserver/commands.go
@@ -1,0 +1,56 @@
+package lspserver
+
+import (
+	"github.com/sourcegraph/jsonrpc2"
+
+	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+)
+
+const commandApplyAllFixes = "tally.applyAllFixes"
+
+// handleExecuteCommand dispatches workspace/executeCommand requests.
+func (s *Server) handleExecuteCommand(params *protocol.ExecuteCommandParams) (any, error) {
+	switch params.Command {
+	case commandApplyAllFixes:
+		return s.executeApplyAllFixes(params)
+	default:
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: "unknown command: " + params.Command,
+		}
+	}
+}
+
+// executeApplyAllFixes applies all safe fixes to the document specified in Arguments[0].
+func (s *Server) executeApplyAllFixes(params *protocol.ExecuteCommandParams) (any, error) {
+	if params.Arguments == nil || len(*params.Arguments) == 0 {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: "tally.applyAllFixes requires a document URI argument",
+		}
+	}
+
+	uri, ok := (*params.Arguments)[0].(string)
+	if !ok {
+		return nil, &jsonrpc2.Error{
+			Code:    jsonrpc2.CodeInvalidParams,
+			Message: "tally.applyAllFixes: argument must be a document URI string",
+		}
+	}
+
+	doc := s.documents.Get(uri)
+	if doc == nil {
+		return nil, nil //nolint:nilnil // LSP: null result is valid for "no edits"
+	}
+
+	edits := s.computeSafeFixes(doc)
+	if len(edits) == 0 {
+		return nil, nil //nolint:nilnil // no changes
+	}
+
+	return &protocol.WorkspaceEdit{
+		Changes: ptrTo(map[protocol.DocumentUri][]*protocol.TextEdit{
+			protocol.DocumentUri(uri): edits,
+		}),
+	}, nil
+}

--- a/internal/lspserver/formatting.go
+++ b/internal/lspserver/formatting.go
@@ -13,20 +13,16 @@ import (
 	"github.com/tinovyatkin/tally/internal/rules"
 )
 
-// handleFormatting handles textDocument/formatting by applying safe auto-fixes.
-func (s *Server) handleFormatting(params *protocol.DocumentFormattingParams) (any, error) {
-	doc := s.documents.Get(string(params.TextDocument.Uri))
-	if doc == nil {
-		return nil, nil //nolint:nilnil // LSP: null result is valid for "no edits"
-	}
-
+// computeSafeFixes runs the full lint+fix pipeline and returns LSP TextEdits
+// for all safe auto-fixes applicable to the document. Returns nil if no fixes.
+func (s *Server) computeSafeFixes(doc *Document) []*protocol.TextEdit {
 	content := []byte(doc.Content)
 	input := s.lintInput(doc.URI, content)
 
 	// 1. Lint + filter: reuse shared pipeline.
 	result, err := linter.LintFile(input)
 	if err != nil {
-		return nil, nil //nolint:nilnil,nilerr // gracefully return no edits on lint error
+		return nil
 	}
 
 	chain := linter.LSPProcessors()
@@ -42,7 +38,7 @@ func (s *Server) handleFormatting(params *protocol.DocumentFormattingParams) (an
 	fixer := &fix.Fixer{SafetyThreshold: fix.FixSafe}
 	fixResult, err := fixer.Apply(context.Background(), violations, map[string][]byte{input.FilePath: content})
 	if err != nil {
-		return nil, nil //nolint:nilnil,nilerr // gracefully return no edits on fix error
+		return nil
 	}
 
 	// 3. Collect original edits from applied fixes and convert to LSP TextEdits.
@@ -50,12 +46,26 @@ func (s *Server) handleFormatting(params *protocol.DocumentFormattingParams) (an
 	// which reference positions in the original document — exactly what LSP needs.
 	change := fixResult.Changes[filepath.Clean(input.FilePath)]
 	if change == nil || !change.HasChanges() {
-		return nil, nil //nolint:nilnil // no changes
+		return nil
 	}
 
 	var allEdits []rules.TextEdit
 	for _, af := range change.FixesApplied {
 		allEdits = append(allEdits, af.Edits...)
 	}
-	return convertTextEdits(allEdits), nil
+	return convertTextEdits(allEdits)
+}
+
+// handleFormatting handles textDocument/formatting by applying safe auto-fixes.
+func (s *Server) handleFormatting(params *protocol.DocumentFormattingParams) (any, error) {
+	doc := s.documents.Get(string(params.TextDocument.Uri))
+	if doc == nil {
+		return nil, nil //nolint:nilnil // LSP: null result is valid for "no edits"
+	}
+
+	edits := s.computeSafeFixes(doc)
+	if len(edits) == 0 {
+		return nil, nil //nolint:nilnil // LSP: null result is valid for "no edits"
+	}
+	return edits, nil
 }

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -103,6 +103,9 @@ func (s *Server) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.
 	case string(protocol.MethodTextDocumentFormatting):
 		return unmarshalAndCall(req, s.handleFormatting)
 
+	case string(protocol.MethodWorkspaceExecuteCommand):
+		return unmarshalAndCall(req, s.handleExecuteCommand)
+
 	// Workspace
 	case "workspace/didChangeConfiguration":
 		return nil, unmarshalAndNotify(req, func(p *protocol.DidChangeConfigurationParams) {
@@ -191,6 +194,9 @@ func (s *Server) handleInitialize(params *protocol.InitializeParams) (any, error
 			},
 			DocumentFormattingProvider: &protocol.BooleanOrDocumentFormattingOptions{
 				Boolean: ptrTo(true),
+			},
+			ExecuteCommandProvider: &protocol.ExecuteCommandOptions{
+				Commands: []string{commandApplyAllFixes},
 			},
 			DiagnosticProvider: &protocol.DiagnosticOptionsOrRegistrationOptions{
 				Options: &protocol.DiagnosticOptions{

--- a/internal/lsptest/__snapshots__/TestLSP_ExecuteCommandApplyAllFixes_1.snap.Dockerfile
+++ b/internal/lsptest/__snapshots__/TestLSP_ExecuteCommandApplyAllFixes_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.18
+LABEL org.opencontainers.image.authors="test@example.com"

--- a/internal/lsptest/__snapshots__/TestLSP_Initialize_1.snap.json
+++ b/internal/lsptest/__snapshots__/TestLSP_Initialize_1.snap.json
@@ -12,6 +12,11 @@
    "workspaceDiagnostics": false
   },
   "documentFormattingProvider": true,
+  "executeCommandProvider": {
+   "commands": [
+    "tally.applyAllFixes"
+   ]
+  },
   "textDocumentSync": {
    "change": 1,
    "openClose": true,

--- a/internal/lsptest/__snapshots__/TestLSP_SourceFixAllCodeAction_1.snap.Dockerfile
+++ b/internal/lsptest/__snapshots__/TestLSP_SourceFixAllCodeAction_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.18
+LABEL org.opencontainers.image.authors="test@example.com"

--- a/internal/lsptest/setup_test.go
+++ b/internal/lsptest/setup_test.go
@@ -375,6 +375,7 @@ type codeActionParams struct {
 
 type codeActionContext struct {
 	Diagnostics []diagnostic `json:"diagnostics"`
+	Only        []string     `json:"only,omitempty"`
 }
 
 type codeAction struct {
@@ -445,4 +446,11 @@ type formattingOptions struct {
 	TrimTrailingWhitespace bool   `json:"trimTrailingWhitespace,omitempty"`
 	InsertFinalNewline     bool   `json:"insertFinalNewline,omitempty"`
 	TrimFinalNewlines      bool   `json:"trimFinalNewlines,omitempty"`
+}
+
+// workspace/executeCommand types.
+
+type executeCommandParams struct {
+	Command   string `json:"command"`
+	Arguments []any  `json:"arguments,omitempty"`
 }


### PR DESCRIPTION
## Summary

- **Go LSP server**: Extract `computeSafeFixes` helper, add `source.fixAll.tally` code action support (inspects `Context.Only`), add `workspace/executeCommand` handler with `tally.applyAllFixes`, advertise `ExecuteCommandProvider` in capabilities
- **VS Code extension**: Wire `assets/logo.png`, add 5 new settings (`fixAll`, `fixUnsafe`, `lint.run`, `format.enable`, `trace.server`), add `configurationDefaults` for `[dockerfile]`, register `tally.applyAllFixes` + `tally.configureDefaultFormatterForDockerfile` commands
- **Tests**: 4 new black-box LSP tests, VS Code e2e `runFixAllCommand` test, updated initialize snapshot

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./internal/lspserver/...` — unit tests pass
- [x] `UPDATE_SNAPS=true GOEXPERIMENT=jsonv2 go test ./internal/lsptest/...` — all 4 new tests pass, snapshots created/updated
- [x] `make test` — full suite (2359 tests pass, 1 pre-existing skip)
- [x] `cd extensions/vscode-tally && bun run typecheck` — passes
- [ ] VS Code e2e (`bun run test:e2e`) — requires display environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Apply All Fixes command to automatically resolve all auto-fixable issues in a document
  * Added one-click Dockerfile formatter configuration option
  * Introduced configurable lint timing: on-type or on-save execution
  * Extended settings for controlling fix behaviors, unsafe fixes, and formatting options
  * Extension now displays an icon in the marketplace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->