### PR TITLE
chore: migrate repo from tinovyatkin to wharflab org

### DIFF
--- a/.claude/skills/add-buildkit-fix/SKILL.md
+++ b/.claude/skills/add-buildkit-fix/SKILL.md
@@ -57,7 +57,7 @@ Create `internal/rules/buildkit/fixes/$ARGUMENTS_snake_case.go`:
 package fixes
 
 import (
-    "github.com/tinovyatkin/tally/internal/rules"
+    "github.com/wharflab/tally/internal/rules"
 )
 
 // enrich${ARGUMENTS}Fix adds auto-fix for BuildKit's $ARGUMENTS rule.

--- a/.claude/skills/create-tally-rule/SKILL.md
+++ b/.claude/skills/create-tally-rule/SKILL.md
@@ -70,7 +70,7 @@ Use this structure:
 package tally
 
 import (
-    "github.com/tinovyatkin/tally/internal/rules"
+    "github.com/wharflab/tally/internal/rules"
 )
 
 type MyRule struct{}
@@ -82,7 +82,7 @@ func (r *MyRule) Metadata() rules.RuleMetadata {
         Code:            rules.TallyRulePrefix + "<rule_slug>",
         Name:            "...",
         Description:     "...",
-        DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/<rule_slug>.md",
+        DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/tally/<rule_slug>.md",
         DefaultSeverity: rules.SeverityStyle,
         Category:        "style",
         IsExperimental:  false,

--- a/.claude/skills/port-hadolint-rule/SKILL.md
+++ b/.claude/skills/port-hadolint-rule/SKILL.md
@@ -87,7 +87,7 @@ Decide where to implement based on rule nature:
 Always use the `internal/shell` package:
 
 ```go
-import "github.com/tinovyatkin/tally/internal/shell"
+import "github.com/wharflab/tally/internal/shell"
 
 // To check if a command contains a specific command name:
 if shell.ContainsCommandWithVariant(cmdStr, "sudo", shellVariant) {
@@ -145,9 +145,9 @@ package hadolint
 import (
     "github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-    "github.com/tinovyatkin/tally/internal/rules"
-    "github.com/tinovyatkin/tally/internal/semantic"
-    "github.com/tinovyatkin/tally/internal/shell"
+    "github.com/wharflab/tally/internal/rules"
+    "github.com/wharflab/tally/internal/semantic"
+    "github.com/wharflab/tally/internal/shell"
 )
 
 // $ARGUMENTSRule implements the $ARGUMENTS linting rule.

--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -3,6 +3,6 @@
 version: v2.9.0
 destination: ./bin
 plugins:
-  - module: 'github.com/tinovyatkin/tally/_tools'
-    import: 'github.com/tinovyatkin/tally/_tools/customlint'
+  - module: 'github.com/wharflab/tally/_tools'
+    import: 'github.com/wharflab/tally/_tools/customlint'
     path: ./_tools

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    if: github.repository == 'tinovyatkin/tally'
+    if: github.repository == 'wharflab/tally'
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
           # Clone the tap repository using SSH
-          git clone git@github.com-tap:tinovyatkin/homebrew-tap.git tap
+          git clone git@github.com-tap:wharflab/homebrew-tap.git tap
 
           # Ensure Formula directory exists and copy formula
           mkdir -p tap/Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X github.com/tinovyatkin/tally/internal/version.version={{.Version}} -X github.com/tinovyatkin/tally/internal/version.commit={{.Commit}}
+      - -s -w -X github.com/wharflab/tally/internal/version.version={{.Version}} -X github.com/wharflab/tally/internal/version.commit={{.Commit}}
 archives:
   - id: tally
     format_overrides:

--- a/.serena/memories/tally_buildkit_violation_pattern.md
+++ b/.serena/memories/tally_buildkit_violation_pattern.md
@@ -366,7 +366,7 @@ Tally implements rules that only exist in phase 2:
 package buildkit
 
 import (
-    "github.com/tinovyatkin/tally/internal/rules"
+    "github.com/wharflab/tally/internal/rules"
 )
 
 type MyNewRule struct{}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ skip-blank-lines = true
 
 ## Coding Style & Naming Conventions
 
-- Format: `gofmt` + `goimports` (configured via `.golangci.yaml`, with `github.com/tinovyatkin/tally` as the local import prefix).
+- Format: `gofmt` + `goimports` (configured via `.golangci.yaml`, with `github.com/wharflab/tally` as the local import prefix).
 - Prefer small, focused packages under `internal/`; keep CLI wiring in `cmd/`.
 - Tests use standard Go conventions: filenames end in `*_test.go`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tally
 
-[![codecov](https://codecov.io/gh/tinovyatkin/tally/graph/badge.svg?token=J3vK0hyLkf)](https://codecov.io/gh/tinovyatkin/tally)
+[![codecov](https://codecov.io/gh/wharflab/tally/graph/badge.svg?token=J3vK0hyLkf)](https://codecov.io/gh/wharflab/tally)
 
 tally keeps Dockerfiles and Containerfiles clean, modern, and consistent — using BuildKit's own parser and checks (the same foundation behind
 `docker buildx`) plus safe auto-fixes. It runs fast, doesn't require Docker Desktop or a daemon, and fits neatly into CI. If that sounds like your
@@ -53,7 +53,7 @@ tally integrates rules from multiple sources:
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew install tinovyatkin/tap/tally
+brew install wharflab/tap/tally
 ```
 
 ### NPM
@@ -77,13 +77,13 @@ gem install tally-cli
 ### Go
 
 ```bash
-go install github.com/tinovyatkin/tally@latest
+go install github.com/wharflab/tally@latest
 ```
 
 ### From Source
 
 ```bash
-git clone https://github.com/tinovyatkin/tally.git
+git clone https://github.com/wharflab/tally.git
 cd tally
 go build .
 ```

--- a/_tools/customlint/README.md
+++ b/_tools/customlint/README.md
@@ -88,8 +88,8 @@ And `.custom-gcl.yml`:
 version: v2.8.0
 destination: ./bin
 plugins:
-  - module: 'github.com/tinovyatkin/tally/_tools'
-    import: 'github.com/tinovyatkin/tally/_tools/customlint'
+  - module: 'github.com/wharflab/tally/_tools'
+    import: 'github.com/wharflab/tally/_tools/customlint'
     path: ./_tools
 ```
 

--- a/_tools/go.mod
+++ b/_tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/tinovyatkin/tally/_tools
+module github.com/wharflab/tally/_tools
 
 go 1.26.0
 

--- a/cmd/tally/cmd/acp_progress.go
+++ b/cmd/tally/cmd/acp_progress.go
@@ -10,10 +10,10 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/mattn/go-isatty"
 
-	"github.com/tinovyatkin/tally/internal/ai/autofixdata"
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/fix"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/ai/autofixdata"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func planAcpFixSpinner(

--- a/cmd/tally/cmd/lint.go
+++ b/cmd/tally/cmd/lint.go
@@ -14,20 +14,20 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/tinovyatkin/tally/internal/ai/autofix"
-	"github.com/tinovyatkin/tally/internal/ai/autofixdata"
-	"github.com/tinovyatkin/tally/internal/async"
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/context"
-	"github.com/tinovyatkin/tally/internal/discovery"
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/fix"
-	"github.com/tinovyatkin/tally/internal/linter"
-	"github.com/tinovyatkin/tally/internal/processor"
-	"github.com/tinovyatkin/tally/internal/registry"
-	"github.com/tinovyatkin/tally/internal/reporter"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/version"
+	"github.com/wharflab/tally/internal/ai/autofix"
+	"github.com/wharflab/tally/internal/ai/autofixdata"
+	"github.com/wharflab/tally/internal/async"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/context"
+	"github.com/wharflab/tally/internal/discovery"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/linter"
+	"github.com/wharflab/tally/internal/processor"
+	"github.com/wharflab/tally/internal/registry"
+	"github.com/wharflab/tally/internal/reporter"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/version"
 )
 
 // Exit codes
@@ -460,7 +460,7 @@ func writeReport(
 		ShowSource:  outCfg.showSource,
 		ToolName:    "tally",
 		ToolVersion: version.Version(),
-		ToolURI:     "https://github.com/tinovyatkin/tally",
+		ToolURI:     "https://github.com/wharflab/tally",
 	}
 
 	if cmd.IsSet("no-color") && cmd.Bool("no-color") {

--- a/cmd/tally/cmd/lint_registry_insights_test.go
+++ b/cmd/tally/cmd/lint_registry_insights_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tinovyatkin/tally/internal/async"
-	"github.com/tinovyatkin/tally/internal/registry"
+	"github.com/wharflab/tally/internal/async"
+	"github.com/wharflab/tally/internal/registry"
 )
 
 func TestCollectRegistryInsights_SortsAndDedupes(t *testing.T) {

--- a/cmd/tally/cmd/lsp.go
+++ b/cmd/tally/cmd/lsp.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/tinovyatkin/tally/internal/lspserver"
+	"github.com/wharflab/tally/internal/lspserver"
 )
 
 func lspCommand() *cli.Command {

--- a/cmd/tally/cmd/root.go
+++ b/cmd/tally/cmd/root.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/tinovyatkin/tally/internal/version"
+	"github.com/wharflab/tally/internal/version"
 )
 
 // NewApp creates the CLI application

--- a/cmd/tally/cmd/version.go
+++ b/cmd/tally/cmd/version.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
-	"github.com/tinovyatkin/tally/internal/version"
+	"github.com/wharflab/tally/internal/version"
 )
 
 func versionCommand() *cli.Command {

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,12 +21,12 @@ ignore:
   - "**/internal/integration/testdata/**"
   # Generated LSP protocol types.
   - "internal/lsp/protocol/lsp_generated.go"
-  - "github.com/tinovyatkin/tally/internal/lsp/protocol/lsp_generated.go"
+  - "github.com/wharflab/tally/internal/lsp/protocol/lsp_generated.go"
   - "*_generated.go"
   - "scripts/**"
   # Go coverage profiles can use module-prefixed paths.
-  - "github.com/tinovyatkin/tally/internal/lsp/protocol/*_generated.go"
-  - "github.com/tinovyatkin/tally/scripts/**"
+  - "github.com/wharflab/tally/internal/lsp/protocol/*_generated.go"
+  - "github.com/wharflab/tally/scripts/**"
 # Test analytics configuration
 # https://docs.codecov.com/docs/test-analytics
 test_analytics:

--- a/design-docs/04-inline-disables.md
+++ b/design-docs/04-inline-disables.md
@@ -544,8 +544,8 @@ func ternary(cond bool, a, b int) int {
 package main
 
 import (
-    "github.com/tinovyatkin/tally/internal/inline"
-    "github.com/tinovyatkin/tally/internal/lint"
+    "github.com/wharflab/tally/internal/inline"
+    "github.com/wharflab/tally/internal/lint"
 )
 
 func lintFile(path string, rules []lint.Rule) ([]lint.Violation, error) {

--- a/design-docs/05-reporters-and-output.md
+++ b/design-docs/05-reporters-and-output.md
@@ -270,7 +270,7 @@ func (r *SARIFReporter) Report(violations []Violation) error {
     // Create run with tool driver that includes version
     driver := sarif.NewDriver("tally").
         WithVersion(r.toolVersion).
-        WithInformationURI("https://github.com/tinovyatkin/tally")
+        WithInformationURI("https://github.com/wharflab/tally")
 
     run := sarif.NewRun(*sarif.NewTool(driver))
 

--- a/design-docs/06-code-organization.md
+++ b/design-docs/06-code-organization.md
@@ -133,8 +133,8 @@ package base
 import (
     "strings"
 
-    "github.com/tinovyatkin/tally/internal/linter"
-    "github.com/tinovyatkin/tally/internal/parser"
+    "github.com/wharflab/tally/internal/linter"
+    "github.com/wharflab/tally/internal/parser"
 )
 
 // Metadata
@@ -190,7 +190,7 @@ package base
 import (
     "testing"
 
-    "github.com/tinovyatkin/tally/internal/testutil"
+    "github.com/wharflab/tally/internal/testutil"
 )
 
 func TestPinVersion(t *testing.T) {
@@ -243,13 +243,13 @@ FROM alpine:3.18
 // internal/rules/registry.go
 package rules
 
-import "github.com/tinovyatkin/tally/internal/linter"
+import "github.com/wharflab/tally/internal/linter"
 
 // Import all rule packages
 import (
-    _ "github.com/tinovyatkin/tally/internal/rules/base"
-    _ "github.com/tinovyatkin/tally/internal/rules/security"
-    _ "github.com/tinovyatkin/tally/internal/rules/stage"
+    _ "github.com/wharflab/tally/internal/rules/base"
+    _ "github.com/wharflab/tally/internal/rules/security"
+    _ "github.com/wharflab/tally/internal/rules/stage"
     // ...
 )
 
@@ -289,7 +289,7 @@ func GetRulesByCategory(category string) []*linter.Rule {
 // internal/rules/base/pin_version.go
 package base
 
-import "github.com/tinovyatkin/tally/internal/rules"
+import "github.com/wharflab/tally/internal/rules"
 
 func init() {
     rules.Register(PinVersionRule)
@@ -304,7 +304,7 @@ func init() {
 // internal/linter/rule.go
 package linter
 
-import "github.com/tinovyatkin/tally/internal/parser"
+import "github.com/wharflab/tally/internal/parser"
 
 // Rule represents a linting rule
 type Rule struct {
@@ -431,8 +431,8 @@ func TestCheck(t *testing.T) {
 package testutil
 
 import (
-    "github.com/tinovyatkin/tally/internal/linter"
-    "github.com/tinovyatkin/tally/internal/parser"
+    "github.com/wharflab/tally/internal/linter"
+    "github.com/wharflab/tally/internal/parser"
 )
 
 // LintString lints a Dockerfile string with given rules
@@ -473,7 +473,7 @@ import (
     "path/filepath"
     "text/template"
 
-    "github.com/tinovyatkin/tally/internal/rules"
+    "github.com/wharflab/tally/internal/rules"
 )
 
 const docTemplate = `# {{ .Code }}: {{ .Name }}
@@ -608,7 +608,7 @@ touch internal/rules/security/no_root_user.go
 ```go
 package security
 
-import "github.com/tinovyatkin/tally/internal/rules"
+import "github.com/wharflab/tally/internal/rules"
 
 const NoRootUserCode = "DL3002"
 

--- a/design-docs/07-context-aware-foundation.md
+++ b/design-docs/07-context-aware-foundation.md
@@ -340,9 +340,9 @@ func (r *Rule) Execute(ast *parser.AST, semantic *parser.SemanticModel, ctx *con
 package copy
 
 import (
-    "github.com/tinovyatkin/tally/internal/context"
-    "github.com/tinovyatkin/tally/internal/linter"
-    "github.com/tinovyatkin/tally/internal/parser"
+    "github.com/wharflab/tally/internal/context"
+    "github.com/wharflab/tally/internal/linter"
+    "github.com/wharflab/tally/internal/parser"
 )
 
 var CopyIgnoredFileRule = &linter.Rule{

--- a/design-docs/11-vscode-extension-architecture.md
+++ b/design-docs/11-vscode-extension-architecture.md
@@ -274,7 +274,7 @@ cmd/tally/cmd/lsp.go # CLI entrypoint: `tally lsp --stdio`
 
 ### 5.3 Extension toolchain pattern (adapted from `amazon-bedrock-copilot-chat`)
 
-Use the same Bun-based pattern already proven in `https://github.com/tinovyatkin/amazon-bedrock-copilot-chat`:
+Use the same Bun-based pattern already proven in `https://github.com/wharflab/amazon-bedrock-copilot-chat`:
 
 - `extensions/vscode-tally/package.json`:
   - `packageManager: "bun"`

--- a/design-docs/MACOS_SIGNING.md
+++ b/design-docs/MACOS_SIGNING.md
@@ -89,7 +89,7 @@ Notarization requires an app-specific password (not your Apple ID password).
 
 Add these secrets to your GitHub repository:
 
-Go to: <https://github.com/tinovyatkin/tally/settings/secrets/actions>
+Go to: <https://github.com/wharflab/tally/settings/secrets/actions>
 
 | Secret Name | Value | Description |
 |------------|-------|-------------|

--- a/design-docs/buildkit-getmounts-behavior.md
+++ b/design-docs/buildkit-getmounts-behavior.md
@@ -10,7 +10,7 @@ This is intentional design, not a bug.
 We created the `internal/runmount` package that provides a proper API for working with mounts in static analysis:
 
 ```go
-import "github.com/tinovyatkin/tally/internal/runmount"
+import "github.com/wharflab/tally/internal/runmount"
 
 // Get properly parsed mounts from a RUN command
 mounts := runmount.GetMounts(run)
@@ -95,8 +95,10 @@ Formats multiple mounts for a RUN instruction.
 
 ## References
 
-- Source: [moby/buildkit/frontend/dockerfile/instructions/commands_runmount.go](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/instructions/commands_runmount.go)
-- Mount expansion: [moby/buildkit/frontend/dockerfile/instructions/commands.go#RunCommand.Expand](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/instructions/commands.go)
+- Source:
+  [moby/buildkit/frontend/dockerfile/instructions/commands_runmount.go](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/instructions/commands_runmount.go)
+- Mount expansion:
+  [moby/buildkit/frontend/dockerfile/instructions/commands.go#RunCommand.Expand](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/instructions/commands.go)
 
 ---
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -5,7 +5,7 @@ tally is a single binary you can install in whatever way best fits your environm
 ## Homebrew (macOS/Linux)
 
 ```bash
-brew install tinovyatkin/tap/tally
+brew install wharflab/tap/tally
 ```
 
 ## npm
@@ -29,13 +29,13 @@ gem install tally-cli
 ## Go
 
 ```bash
-go install github.com/tinovyatkin/tally@latest
+go install github.com/wharflab/tally@latest
 ```
 
 ## From source
 
 ```bash
-git clone https://github.com/tinovyatkin/tally.git
+git clone https://github.com/wharflab/tally.git
 cd tally
 go build .
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ tally keeps Dockerfiles and Containerfiles clean, modern, and consistent — usi
 
 ```bash
 # Install via Homebrew
-brew install tinovyatkin/tap/tally
+brew install wharflab/tap/tally
 
 # Or via npm/pip/gem
 npm install -g tally-cli

--- a/extensions/vscode-tally/package.json
+++ b/extensions/vscode-tally/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tinovyatkin/tally"
+    "url": "https://github.com/wharflab/tally"
   },
   "publisher": "wharflab",
   "main": "./dist/extension.cjs",

--- a/extensions/vscode-tally/test/e2e/smoke.test.ts
+++ b/extensions/vscode-tally/test/e2e/smoke.test.ts
@@ -46,7 +46,7 @@ test(
     if (process.env.GOCOVERDIR) {
       goBuildArgs.push("-cover");
     }
-    goBuildArgs.push("-o", binaryPath, "github.com/tinovyatkin/tally");
+    goBuildArgs.push("-o", binaryPath, "github.com/wharflab/tally");
 
     runOrThrow(goBuildArgs, {
       cwd: repoRoot,

--- a/gen/jsonschema.go
+++ b/gen/jsonschema.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/invopop/jsonschema"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/rules"
 
 	// Import all rules to register them
-	_ "github.com/tinovyatkin/tally/internal/rules/all"
+	_ "github.com/wharflab/tally/internal/rules/all"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tinovyatkin/tally
+module github.com/wharflab/tally
 
 go 1.26.0
 

--- a/internal/ai/autofix/blocking.go
+++ b/internal/ai/autofix/blocking.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 type blockingIssue struct {

--- a/internal/ai/autofix/prompt.go
+++ b/internal/ai/autofix/prompt.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/ai/autofixdata"
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/ai/autofixdata"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/dockerfile"
 )
 
 func buildRound1Prompt(

--- a/internal/ai/autofix/prompt_test.go
+++ b/internal/ai/autofix/prompt_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tinovyatkin/tally/internal/ai/autofixdata"
-	tallyrules "github.com/tinovyatkin/tally/internal/rules/tally"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/ai/autofixdata"
+	tallyrules "github.com/wharflab/tally/internal/rules/tally"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestBuildRound1Prompt_PreferMultiStageBuild_Snapshot(t *testing.T) {

--- a/internal/ai/autofix/register.go
+++ b/internal/ai/autofix/register.go
@@ -1,8 +1,8 @@
 package autofix
 
 import (
-	"github.com/tinovyatkin/tally/internal/ai/autofixdata"
-	"github.com/tinovyatkin/tally/internal/fix"
+	"github.com/wharflab/tally/internal/ai/autofixdata"
+	"github.com/wharflab/tally/internal/fix"
 )
 
 // Register registers the AI AutoFix resolver.

--- a/internal/ai/autofix/resolver.go
+++ b/internal/ai/autofix/resolver.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/zricethezav/gitleaks/v8/detect"
 
-	"github.com/tinovyatkin/tally/internal/ai/acp"
-	"github.com/tinovyatkin/tally/internal/ai/autofixdata"
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/fix"
-	"github.com/tinovyatkin/tally/internal/linter"
-	"github.com/tinovyatkin/tally/internal/processor"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/ai/acp"
+	"github.com/wharflab/tally/internal/ai/autofixdata"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/linter"
+	"github.com/wharflab/tally/internal/processor"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 const (

--- a/internal/ai/autofix/resolver_test.go
+++ b/internal/ai/autofix/resolver_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tinovyatkin/tally/internal/ai/acp"
-	"github.com/tinovyatkin/tally/internal/config"
+	"github.com/wharflab/tally/internal/ai/acp"
+	"github.com/wharflab/tally/internal/config"
 )
 
 type stubAgentRunner struct {

--- a/internal/ai/autofix/validate.go
+++ b/internal/ai/autofix/validate.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 func countFromInstructions(pr *dockerfile.ParseResult) int {

--- a/internal/ai/autofix/validate_test.go
+++ b/internal/ai/autofix/validate_test.go
@@ -3,8 +3,8 @@ package autofix
 import (
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/dockerfile"
 )
 
 func mustParseDockerfile(t *testing.T, content string) *dockerfile.ParseResult {

--- a/internal/ai/autofixdata/autofixdata.go
+++ b/internal/ai/autofixdata/autofixdata.go
@@ -1,8 +1,8 @@
 package autofixdata
 
 import (
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // ResolverID is the FixResolver identifier for AI AutoFix.

--- a/internal/config/rules.go
+++ b/internal/config/rules.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/rules/configutil"
 )
 
 // FixMode controls when auto-fixes are applied for a rule.

--- a/internal/directive/directive_test.go
+++ b/internal/directive/directive_test.go
@@ -4,8 +4,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 func TestParseTallyNextLine(t *testing.T) {

--- a/internal/directive/filter.go
+++ b/internal/directive/filter.go
@@ -1,6 +1,6 @@
 package directive
 
-import "github.com/tinovyatkin/tally/internal/rules"
+import "github.com/wharflab/tally/internal/rules"
 
 // FilterResult contains the results of filtering violations through directives.
 type FilterResult struct {

--- a/internal/directive/parser.go
+++ b/internal/directive/parser.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // Regex patterns for directive parsing.

--- a/internal/dockerfile/parser.go
+++ b/internal/dockerfile/parser.go
@@ -12,7 +12,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/config"
+	"github.com/wharflab/tally/internal/config"
 )
 
 // LintWarning captures parameters from BuildKit's linter.LintWarnFunc callback.

--- a/internal/dockerfile/parser_test.go
+++ b/internal/dockerfile/parser_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/config"
+	"github.com/wharflab/tally/internal/config"
 )
 
 func TestParse_BasicParsing(t *testing.T) {

--- a/internal/fix/conflict.go
+++ b/internal/fix/conflict.go
@@ -1,6 +1,6 @@
 package fix
 
-import "github.com/tinovyatkin/tally/internal/rules"
+import "github.com/wharflab/tally/internal/rules"
 
 // editsOverlap checks if two edits overlap in their locations.
 // Overlapping edits cannot both be applied safely.

--- a/internal/fix/conflict_test.go
+++ b/internal/fix/conflict_test.go
@@ -3,7 +3,7 @@ package fix
 import (
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestEditsOverlap(t *testing.T) {

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -3,8 +3,8 @@
 package fix
 
 import (
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // Re-export FixSafety from rules package for convenience.

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -3,7 +3,7 @@ package fix
 import (
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestSkipReason_String(t *testing.T) {

--- a/internal/fix/fixer.go
+++ b/internal/fix/fixer.go
@@ -8,8 +8,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // normalizePath ensures consistent path format for map lookups.

--- a/internal/fix/fixer_test.go
+++ b/internal/fix/fixer_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestApplyEdit_SingleLine(t *testing.T) {

--- a/internal/fix/fixmodes.go
+++ b/internal/fix/fixmodes.go
@@ -1,6 +1,6 @@
 package fix
 
-import "github.com/tinovyatkin/tally/internal/config"
+import "github.com/wharflab/tally/internal/config"
 
 // BuildFixModes extracts per-rule fix mode settings from a config.
 // Returned keys use the canonical rule code format: "<namespace>/<ruleName>".

--- a/internal/fix/heredoc_resolver.go
+++ b/internal/fix/heredoc_resolver.go
@@ -9,11 +9,11 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/heredoc"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/runmount"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/heredoc"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/runmount"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // heredocResolver implements FixResolver for prefer-run-heredoc fixes.

--- a/internal/fix/heredoc_resolver_test.go
+++ b/internal/fix/heredoc_resolver_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 func TestHeredocResolver_ID(t *testing.T) {

--- a/internal/fix/resolver.go
+++ b/internal/fix/resolver.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // ResolveContext provides context for fix resolution.

--- a/internal/fix/resolver_test.go
+++ b/internal/fix/resolver_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // mockResolver is a test resolver that returns predefined edits.

--- a/internal/heredoc/format.go
+++ b/internal/heredoc/format.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/runmount"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/runmount"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // FormatWithMounts formats commands as a heredoc RUN instruction.

--- a/internal/integration/__snapshots__/TestLint_config-cascading-discovery_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_config-cascading-discovery_1.snap.json
@@ -4,7 +4,7 @@
       "file": "testdata/nested/subdir/Dockerfile",
       "violations": [
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/max-lines.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/max-lines.md",
           "location": {
             "end": {
               "column": -1,

--- a/internal/integration/__snapshots__/TestLint_config-file-discovery_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_config-file-discovery_1.snap.json
@@ -4,7 +4,7 @@
       "file": "testdata/with-config/Dockerfile",
       "violations": [
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/max-lines.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/max-lines.md",
           "location": {
             "end": {
               "column": -1,

--- a/internal/integration/__snapshots__/TestLint_consistent-indentation_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_consistent-indentation_1.snap.json
@@ -4,7 +4,7 @@
       "file": "testdata/consistent-indentation/Dockerfile",
       "violations": [
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -43,7 +43,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -82,7 +82,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -121,7 +121,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -160,7 +160,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -199,7 +199,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -238,7 +238,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -361,7 +361,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -400,7 +400,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -439,7 +439,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,
@@ -478,7 +478,7 @@
           }
         },
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
           "location": {
             "end": {
               "column": 0,

--- a/internal/integration/__snapshots__/TestLint_dl4006-cross-rules_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_dl4006-cross-rules_1.snap.json
@@ -24,7 +24,7 @@
         },
         {
           "detail": "2 consecutive RUN instructions with 4 total commands can be combined into a single heredoc RUN",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
           "location": {
             "end": {
               "column": 0,

--- a/internal/integration/__snapshots__/TestLint_duplicate-stage-name_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_duplicate-stage-name_1.snap.json
@@ -5,7 +5,7 @@
       "violations": [
         {
           "detail": "Consider removing this stage or using COPY --from to include its artifacts in the final image",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/no-unreachable-stages.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/no-unreachable-stages.md",
           "location": {
             "end": {
               "column": 0,

--- a/internal/integration/__snapshots__/TestLint_env-var-override_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_env-var-override_1.snap.json
@@ -4,7 +4,7 @@
       "file": "testdata/simple/Dockerfile",
       "violations": [
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/max-lines.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/max-lines.md",
           "location": {
             "end": {
               "column": -1,

--- a/internal/integration/__snapshots__/TestLint_format-sarif_1.snap.sarif
+++ b/internal/integration/__snapshots__/TestLint_format-sarif_1.snap.sarif
@@ -204,7 +204,7 @@
             "localizedData",
             "nonLocalizedData"
           ],
-          "informationUri": "https://github.com/tinovyatkin/tally",
+          "informationUri": "https://github.com/wharflab/tally",
           "isComprehensive": false,
           "language": "en-US",
           "locations": [],

--- a/internal/integration/__snapshots__/TestLint_heredoc-combined_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_heredoc-combined_1.snap.json
@@ -5,7 +5,7 @@
       "violations": [
         {
           "detail": "Creating /etc/nginx/conf.d/default.conf with RUN can be replaced with COPY heredoc for better performance",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
           "location": {
             "end": {
               "column": 0,
@@ -45,7 +45,7 @@
         },
         {
           "detail": "12 consecutive RUN instructions with 15 total commands can be combined into a single heredoc RUN",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
           "location": {
             "end": {
               "column": 0,
@@ -71,7 +71,7 @@
         },
         {
           "detail": "RUN has 3 chained commands; consider using heredoc syntax for better readability",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
           "location": {
             "end": {
               "column": 0,
@@ -97,7 +97,7 @@
         },
         {
           "detail": "2 consecutive RUN instructions write to /app/data.txt; combine into single COPY \u003c\u003cEOF",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
           "location": {
             "end": {
               "column": 0,
@@ -137,7 +137,7 @@
         },
         {
           "detail": "Creating /etc/motd with RUN can be replaced with COPY heredoc for better performance",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
           "location": {
             "end": {
               "column": 0,
@@ -177,7 +177,7 @@
         },
         {
           "detail": "Creating /entrypoint.sh with RUN can be replaced with COPY heredoc for better performance",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
           "location": {
             "end": {
               "column": 0,
@@ -217,7 +217,7 @@
         },
         {
           "detail": "2 consecutive RUN instructions with 5 total commands can be combined into a single heredoc RUN",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
           "location": {
             "end": {
               "column": 0,
@@ -243,7 +243,7 @@
         },
         {
           "detail": "RUN has 3 chained commands; consider using heredoc syntax for better readability",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
           "location": {
             "end": {
               "column": 0,

--- a/internal/integration/__snapshots__/TestLint_prefer-add-unpack-heredoc_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-add-unpack-heredoc_1.snap.json
@@ -23,7 +23,7 @@
         },
         {
           "detail": "RUN has 4 chained commands; consider using heredoc syntax for better readability",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
           "location": {
             "end": {
               "column": 0,

--- a/internal/integration/__snapshots__/TestLint_prefer-run-heredoc_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-run-heredoc_1.snap.json
@@ -5,7 +5,7 @@
       "violations": [
         {
           "detail": "3 consecutive RUN instructions with 3 total commands can be combined into a single heredoc RUN",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
           "location": {
             "end": {
               "column": 0,
@@ -31,7 +31,7 @@
         },
         {
           "detail": "RUN has 3 chained commands; consider using heredoc syntax for better readability",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
           "location": {
             "end": {
               "column": 0,

--- a/internal/integration/__snapshots__/TestLint_prefer-vex-attestation_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-vex-attestation_1.snap.json
@@ -5,7 +5,7 @@
       "violations": [
         {
           "detail": "VEX documents are supply-chain metadata. Embedding them in the runtime image requires rebuilding to update statements and makes discovery less consistent. Attach OpenVEX as an OCI attestation (in-toto predicate) instead.",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/prefer-vex-attestation.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/prefer-vex-attestation.md",
           "location": {
             "end": {
               "column": 0,

--- a/internal/integration/__snapshots__/TestLint_simple-max-lines-fail_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_simple-max-lines-fail_1.snap.json
@@ -4,7 +4,7 @@
       "file": "testdata/simple/Dockerfile",
       "violations": [
         {
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/max-lines.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/max-lines.md",
           "location": {
             "end": {
               "column": -1,

--- a/internal/integration/__snapshots__/TestLint_unreachable-stage_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_unreachable-stage_1.snap.json
@@ -5,7 +5,7 @@
       "violations": [
         {
           "detail": "Consider removing this stage or using COPY --from to include its artifacts in the final image",
-          "docUrl": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/no-unreachable-stages.md",
+          "docUrl": "https://github.com/wharflab/tally/blob/main/docs/rules/no-unreachable-stages.md",
           "location": {
             "end": {
               "column": 0,

--- a/internal/integration/benchmark_test.go
+++ b/internal/integration/benchmark_test.go
@@ -35,7 +35,7 @@ func ensureBinary(b *testing.B) {
 	}
 	benchBinaryPath = filepath.Join(tmpDir, binaryName)
 
-	cmd := exec.Command("go", "build", "-o", benchBinaryPath, "github.com/tinovyatkin/tally")
+	cmd := exec.Command("go", "build", "-o", benchBinaryPath, "github.com/wharflab/tally")
 	cmd.Env = append(os.Environ(), "GOEXPERIMENT=jsonv2")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		b.Fatalf("failed to build binary: %s", out)

--- a/internal/integration/gemini_smoke_test.go
+++ b/internal/integration/gemini_smoke_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/dockerfile"
 )
 
 func TestGeminiSmoke_FixPreferMultiStageBuild(t *testing.T) {

--- a/internal/integration/main_test.go
+++ b/internal/integration/main_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tinovyatkin/tally/internal/registry/testutil"
+	"github.com/wharflab/tally/internal/registry/testutil"
 )
 
 var (
@@ -85,7 +85,7 @@ func buildIntegrationBinary(tmpDir string) error {
 	}
 	buildArgs = append(buildArgs,
 		"-tags", "containers_image_openpgp,containers_image_storage_stub,containers_image_docker_daemon_stub",
-		"-o", binaryPath, "github.com/tinovyatkin/tally")
+		"-o", binaryPath, "github.com/wharflab/tally")
 
 	cmd := exec.Command("go", buildArgs...)
 	cmd.Env = append(os.Environ(), "GOEXPERIMENT=jsonv2")
@@ -103,7 +103,7 @@ func buildIntegrationAcpAgent(tmpDir string) error {
 	}
 	acpAgentPath = filepath.Join(tmpDir, binName)
 
-	cmd := exec.Command("go", "build", "-trimpath", "-o", acpAgentPath, "github.com/tinovyatkin/tally/internal/ai/acp/testdata/testagent")
+	cmd := exec.Command("go", "build", "-trimpath", "-o", acpAgentPath, "github.com/wharflab/tally/internal/ai/acp/testdata/testagent")
 	cmd.Env = append(os.Environ(), "GOEXPERIMENT=jsonv2")
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/linter/config.go
+++ b/internal/linter/config.go
@@ -3,10 +3,10 @@ package linter
 import (
 	"sort"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/buildkit"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/buildkit"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 type heredocRuleOptions struct {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -10,15 +10,15 @@ import (
 	"log"
 	"os"
 
-	"github.com/tinovyatkin/tally/internal/async"
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/directive"
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	_ "github.com/tinovyatkin/tally/internal/rules/all" // Register all rules.
-	"github.com/tinovyatkin/tally/internal/rules/buildkit/fixes"
-	"github.com/tinovyatkin/tally/internal/semantic"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/async"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/directive"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	_ "github.com/wharflab/tally/internal/rules/all" // Register all rules.
+	"github.com/wharflab/tally/internal/rules/buildkit/fixes"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // Level is a log level for the Channel interface.

--- a/internal/linter/processors.go
+++ b/internal/linter/processors.go
@@ -1,6 +1,6 @@
 package linter
 
-import "github.com/tinovyatkin/tally/internal/processor"
+import "github.com/wharflab/tally/internal/processor"
 
 // CLIProcessors returns the standard CLI processor chain and the inline directive
 // filter (the caller needs it for [processor.InlineDirectiveFilter.AdditionalViolations]).

--- a/internal/lspserver/codeactions.go
+++ b/internal/lspserver/codeactions.go
@@ -3,9 +3,9 @@ package lspserver
 import (
 	"strings"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // codeActionsForDocument returns quick-fix code actions for the given range.

--- a/internal/lspserver/diagnostic_mode.go
+++ b/internal/lspserver/diagnostic_mode.go
@@ -3,7 +3,7 @@ package lspserver
 import (
 	"log"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 )
 
 func (s *Server) configureDiagnosticsMode(params *protocol.InitializeParams) {

--- a/internal/lspserver/diagnostics.go
+++ b/internal/lspserver/diagnostics.go
@@ -15,12 +15,12 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/linter"
-	"github.com/tinovyatkin/tally/internal/processor"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/linter"
+	"github.com/wharflab/tally/internal/processor"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // lintResultCache caches lint results keyed by document URI + version

--- a/internal/lspserver/execute_command.go
+++ b/internal/lspserver/execute_command.go
@@ -5,9 +5,9 @@ import (
 
 	"golang.org/x/exp/jsonrpc2"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 
-	"github.com/tinovyatkin/tally/internal/fix"
+	"github.com/wharflab/tally/internal/fix"
 )
 
 const applyAllFixesCommand = "tally.applyAllFixes"

--- a/internal/lspserver/execute_command_test.go
+++ b/internal/lspserver/execute_command_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 )
 
 func TestParseApplyAllFixesArgs(t *testing.T) {

--- a/internal/lspserver/fixall.go
+++ b/internal/lspserver/fixall.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"path/filepath"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/fix"
-	"github.com/tinovyatkin/tally/internal/linter"
-	"github.com/tinovyatkin/tally/internal/processor"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/linter"
+	"github.com/wharflab/tally/internal/processor"
 )
 
 const fixAllCodeActionKind = protocol.CodeActionKind("source.fixAll.tally")

--- a/internal/lspserver/formatting.go
+++ b/internal/lspserver/formatting.go
@@ -6,12 +6,12 @@ import (
 	"path/filepath"
 	"unicode/utf8"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/fix"
-	"github.com/tinovyatkin/tally/internal/linter"
-	"github.com/tinovyatkin/tally/internal/processor"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/linter"
+	"github.com/wharflab/tally/internal/processor"
 )
 
 // handleFormatting handles textDocument/formatting by applying safe auto-fixes.

--- a/internal/lspserver/formatting_position_test.go
+++ b/internal/lspserver/formatting_position_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 )
 
 func TestPositionAtOffset_UsesUTF16CodeUnits(t *testing.T) {

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -20,8 +20,8 @@ import (
 	jsonv2 "encoding/json/v2"
 	"golang.org/x/exp/jsonrpc2"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
-	"github.com/tinovyatkin/tally/internal/version"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
+	"github.com/wharflab/tally/internal/version"
 )
 
 const serverName = "tally"

--- a/internal/lspserver/server_test.go
+++ b/internal/lspserver/server_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/assert"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
-	"github.com/tinovyatkin/tally/internal/rules"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestViolationRangeConversion(t *testing.T) {

--- a/internal/lspserver/settings.go
+++ b/internal/lspserver/settings.go
@@ -11,9 +11,9 @@ import (
 
 	jsonv2 "encoding/json/v2"
 
-	protocol "github.com/tinovyatkin/tally/internal/lsp/protocol"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
 
-	"github.com/tinovyatkin/tally/internal/config"
+	"github.com/wharflab/tally/internal/config"
 )
 
 type clientSettings struct {

--- a/internal/lsptest/setup_test.go
+++ b/internal/lsptest/setup_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 		}
 		buildArgs = append(buildArgs, "-cover")
 	}
-	buildArgs = append(buildArgs, "-o", binaryPath, "github.com/tinovyatkin/tally")
+	buildArgs = append(buildArgs, "-o", binaryPath, "github.com/wharflab/tally")
 
 	cmd := exec.Command("go", buildArgs...)
 	cmd.Env = append(os.Environ(), "GOEXPERIMENT=jsonv2")

--- a/internal/processor/dedup.go
+++ b/internal/processor/dedup.go
@@ -3,7 +3,7 @@ package processor
 import (
 	"path/filepath"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // violationKey uniquely identifies a violation for deduplication.

--- a/internal/processor/directive.go
+++ b/internal/processor/directive.go
@@ -3,8 +3,8 @@ package processor
 import (
 	"path/filepath"
 
-	"github.com/tinovyatkin/tally/internal/directive"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/directive"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // InlineDirectiveFilter applies inline ignore directives.

--- a/internal/processor/enable.go
+++ b/internal/processor/enable.go
@@ -1,7 +1,7 @@
 package processor
 
 import (
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // EnableFilter removes violations for disabled rules.

--- a/internal/processor/exclude.go
+++ b/internal/processor/exclude.go
@@ -3,7 +3,7 @@ package processor
 import (
 	"github.com/bmatcuk/doublestar/v4"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // PathExclusionFilter removes violations based on per-rule path exclusions.

--- a/internal/processor/path.go
+++ b/internal/processor/path.go
@@ -3,7 +3,7 @@ package processor
 import (
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // PathNormalization converts file paths to forward slashes for cross-platform consistency.

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -18,9 +18,9 @@ package processor
 import (
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // Processor transforms a slice of violations.

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -3,8 +3,8 @@ package processor
 import (
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestChain(t *testing.T) {

--- a/internal/processor/severity.go
+++ b/internal/processor/severity.go
@@ -1,7 +1,7 @@
 package processor
 
 import (
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // SeverityOverride applies severity overrides from configuration.

--- a/internal/processor/snippet.go
+++ b/internal/processor/snippet.go
@@ -1,7 +1,7 @@
 package processor
 
 import (
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // SnippetAttachment populates the SourceCode field of violations.

--- a/internal/processor/snippet_test.go
+++ b/internal/processor/snippet_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/config"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestSnippetAttachment_Name(t *testing.T) {

--- a/internal/processor/sort.go
+++ b/internal/processor/sort.go
@@ -1,8 +1,8 @@
 package processor
 
 import (
-	"github.com/tinovyatkin/tally/internal/reporter"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/reporter"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // Sorting ensures stable, deterministic output ordering.

--- a/internal/processor/supersede.go
+++ b/internal/processor/supersede.go
@@ -3,7 +3,7 @@ package processor
 import (
 	"path/filepath"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // Supersession suppresses lower-severity violations when an error-level

--- a/internal/processor/supersede_test.go
+++ b/internal/processor/supersede_test.go
@@ -3,7 +3,7 @@ package processor
 import (
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestSupersession_ErrorSuppressesLower(t *testing.T) {

--- a/internal/registry/mock_resolve_test.go
+++ b/internal/registry/mock_resolve_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tinovyatkin/tally/internal/registry/testutil"
+	"github.com/wharflab/tally/internal/registry/testutil"
 	"go.podman.io/image/v5/types"
 )
 

--- a/internal/registry/resolver.go
+++ b/internal/registry/resolver.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/tinovyatkin/tally/internal/async"
+	"github.com/wharflab/tally/internal/async"
 )
 
 const registryResolverID = "registry"

--- a/internal/registry/resolver_test.go
+++ b/internal/registry/resolver_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tinovyatkin/tally/internal/async"
+	"github.com/wharflab/tally/internal/async"
 )
 
 // mockImageResolver implements ImageResolver for testing.

--- a/internal/reporter/github_actions.go
+++ b/internal/reporter/github_actions.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // GitHubActionsReporter formats violations as GitHub Actions workflow commands.

--- a/internal/reporter/github_actions_test.go
+++ b/internal/reporter/github_actions_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestGitHubActionsReporter(t *testing.T) {

--- a/internal/reporter/json.go
+++ b/internal/reporter/json.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // JSONOutput is the top-level structure for JSON output.

--- a/internal/reporter/json_test.go
+++ b/internal/reporter/json_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestJSONReporter(t *testing.T) {

--- a/internal/reporter/markdown.go
+++ b/internal/reporter/markdown.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // MarkdownReporter formats violations as concise markdown tables.

--- a/internal/reporter/markdown_test.go
+++ b/internal/reporter/markdown_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestMarkdownReporterSingleFile(t *testing.T) {

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // ReportMetadata contains contextual information about the lint run.
@@ -120,7 +120,7 @@ func DefaultOptions() Options {
 		Color:       nil, // auto-detect
 		ShowSource:  true,
 		ToolName:    "tally",
-		ToolURI:     "https://github.com/tinovyatkin/tally",
+		ToolURI:     "https://github.com/wharflab/tally",
 		ToolVersion: "dev",
 	}
 }

--- a/internal/reporter/sarif.go
+++ b/internal/reporter/sarif.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // Default SARIF tool information.
 const (
 	defaultToolName = "tally"
-	defaultToolURI  = "https://github.com/tinovyatkin/tally"
+	defaultToolURI  = "https://github.com/wharflab/tally"
 )
 
 // SARIFReporter formats violations as SARIF (Static Analysis Results Interchange Format).

--- a/internal/reporter/sarif_test.go
+++ b/internal/reporter/sarif_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json/v2"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestSARIFReporter(t *testing.T) {
@@ -36,7 +36,7 @@ func TestSARIFReporter(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	reporter := NewSARIFReporter(&buf, "tally", "1.0.0", "https://github.com/tinovyatkin/tally")
+	reporter := NewSARIFReporter(&buf, "tally", "1.0.0", "https://github.com/wharflab/tally")
 
 	err := reporter.Report(violations, nil, ReportMetadata{})
 	if err != nil {

--- a/internal/reporter/text.go
+++ b/internal/reporter/text.go
@@ -17,7 +17,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // Styles for different parts of the output

--- a/internal/reporter/text_test.go
+++ b/internal/reporter/text_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestPrintTextPlain_SingleViolation(t *testing.T) {

--- a/internal/rules/all/all.go
+++ b/internal/rules/all/all.go
@@ -1,12 +1,12 @@
 // Package all imports all rule packages to register them.
 // Import this package with a blank identifier to enable all rules:
 //
-//	import _ "github.com/tinovyatkin/tally/internal/rules/all"
+//	import _ "github.com/wharflab/tally/internal/rules/all"
 package all
 
 import (
 	// Import all rule packages to trigger their init() registration
-	_ "github.com/tinovyatkin/tally/internal/rules/buildkit"
-	_ "github.com/tinovyatkin/tally/internal/rules/hadolint"
-	_ "github.com/tinovyatkin/tally/internal/rules/tally"
+	_ "github.com/wharflab/tally/internal/rules/buildkit"
+	_ "github.com/wharflab/tally/internal/rules/hadolint"
+	_ "github.com/wharflab/tally/internal/rules/tally"
 )

--- a/internal/rules/async.go
+++ b/internal/rules/async.go
@@ -1,6 +1,6 @@
 package rules
 
-import "github.com/tinovyatkin/tally/internal/async"
+import "github.com/wharflab/tally/internal/async"
 
 // AsyncRule is an optional interface for rules that require slow I/O (registry,
 // network, filesystem). Rules implementing this interface participate in the

--- a/internal/rules/asyncutil/plan.go
+++ b/internal/rules/asyncutil/plan.go
@@ -2,10 +2,10 @@
 package asyncutil
 
 import (
-	"github.com/tinovyatkin/tally/internal/async"
-	"github.com/tinovyatkin/tally/internal/registry"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/async"
+	"github.com/wharflab/tally/internal/registry"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // HandlerFactory creates a ResultHandler for a specific stage and platform.

--- a/internal/rules/buildkit/async_helpers.go
+++ b/internal/rules/buildkit/async_helpers.go
@@ -1,6 +1,6 @@
 package buildkit
 
-import "github.com/tinovyatkin/tally/internal/rules/asyncutil"
+import "github.com/wharflab/tally/internal/rules/asyncutil"
 
 // planExternalImageChecks delegates to asyncutil.PlanExternalImageChecks.
 var planExternalImageChecks = asyncutil.PlanExternalImageChecks //nolint:gochecknoglobals // package-local alias

--- a/internal/rules/buildkit/consistent_instruction_casing.go
+++ b/internal/rules/buildkit/consistent_instruction_casing.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // ConsistentInstructionCasingRule implements the ConsistentInstructionCasing linting rule.

--- a/internal/rules/buildkit/consistent_instruction_casing_test.go
+++ b/internal/rules/buildkit/consistent_instruction_casing_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestConsistentInstructionCasingRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/copy_ignored_file.go
+++ b/internal/rules/buildkit/copy_ignored_file.go
@@ -7,9 +7,9 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // CopyIgnoredFileRule implements the copy-ignored-file linting rule.

--- a/internal/rules/buildkit/copy_ignored_file_test.go
+++ b/internal/rules/buildkit/copy_ignored_file_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // mockBuildContext implements rules.BuildContext for testing.

--- a/internal/rules/buildkit/duplicate_stage_name.go
+++ b/internal/rules/buildkit/duplicate_stage_name.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // DuplicateStageNameRule implements BuildKit's DuplicateStageName check.

--- a/internal/rules/buildkit/duplicate_stage_name_test.go
+++ b/internal/rules/buildkit/duplicate_stage_name_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestDuplicateStageNameRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/expose_invalid_format.go
+++ b/internal/rules/buildkit/expose_invalid_format.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // ExposeInvalidFormatRule implements BuildKit's ExposeInvalidFormat check.

--- a/internal/rules/buildkit/expose_invalid_format_test.go
+++ b/internal/rules/buildkit/expose_invalid_format_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestExposeInvalidFormatRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/expose_proto_casing.go
+++ b/internal/rules/buildkit/expose_proto_casing.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // ExposeProtoCasingRule implements the ExposeProtoCasing linting rule.

--- a/internal/rules/buildkit/expose_proto_casing_test.go
+++ b/internal/rules/buildkit/expose_proto_casing_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestExposeProtoCasingRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/fixes/consistent_instruction_casing.go
+++ b/internal/rules/buildkit/fixes/consistent_instruction_casing.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // casingMessageRegex extracts the instruction name and expected casing from BuildKit's message.

--- a/internal/rules/buildkit/fixes/enricher.go
+++ b/internal/rules/buildkit/fixes/enricher.go
@@ -6,8 +6,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 var fixableRuleNames = []string{

--- a/internal/rules/buildkit/fixes/expose_proto_casing.go
+++ b/internal/rules/buildkit/fixes/expose_proto_casing.go
@@ -3,7 +3,7 @@ package fixes
 import (
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // enrichExposeProtoCasingFix adds auto-fix for BuildKit's ExposeProtoCasing rule.

--- a/internal/rules/buildkit/fixes/fixes_test.go
+++ b/internal/rules/buildkit/fixes/fixes_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 func TestFromAsCasingFix(t *testing.T) {

--- a/internal/rules/buildkit/fixes/from_as_casing.go
+++ b/internal/rules/buildkit/fixes/from_as_casing.go
@@ -3,7 +3,7 @@ package fixes
 import (
 	"fmt"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // enrichFromAsCasingFix adds auto-fix for BuildKit's FromAsCasing rule.

--- a/internal/rules/buildkit/fixes/invalid_definition_description.go
+++ b/internal/rules/buildkit/fixes/invalid_definition_description.go
@@ -3,7 +3,7 @@ package fixes
 import (
 	"bytes"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // enrichInvalidDefinitionDescriptionFix adds auto-fix for BuildKit's InvalidDefinitionDescription rule.

--- a/internal/rules/buildkit/fixes/json_args_recommended.go
+++ b/internal/rules/buildkit/fixes/json_args_recommended.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 func enrichJSONArgsRecommendedFix(v *rules.Violation, source []byte) {

--- a/internal/rules/buildkit/fixes/json_args_recommended_test.go
+++ b/internal/rules/buildkit/fixes/json_args_recommended_test.go
@@ -3,7 +3,7 @@ package fixes
 import (
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestFindDockerfileInlineCommentStart(t *testing.T) {

--- a/internal/rules/buildkit/fixes/legacy_key_value_format.go
+++ b/internal/rules/buildkit/fixes/legacy_key_value_format.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // enrichLegacyKeyValueFormatFix adds auto-fix for BuildKit's LegacyKeyValueFormat rule.

--- a/internal/rules/buildkit/fixes/maintainer_deprecated.go
+++ b/internal/rules/buildkit/fixes/maintainer_deprecated.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // maintainerRegex extracts the maintainer value from a MAINTAINER instruction.

--- a/internal/rules/buildkit/fixes/multiple_instructions_disallowed.go
+++ b/internal/rules/buildkit/fixes/multiple_instructions_disallowed.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // multiInstrRegex extracts the instruction name from the violation message.

--- a/internal/rules/buildkit/fixes/no_empty_continuation.go
+++ b/internal/rules/buildkit/fixes/no_empty_continuation.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"slices"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // enrichNoEmptyContinuationFix adds auto-fix for BuildKit's NoEmptyContinuation rule.

--- a/internal/rules/buildkit/fixes/position.go
+++ b/internal/rules/buildkit/fixes/position.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // getLine extracts a single line from source (0-based line index).

--- a/internal/rules/buildkit/fixes/stage_name_casing.go
+++ b/internal/rules/buildkit/fixes/stage_name_casing.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // stageCasingRegex extracts the stage name from BuildKit's warning message.

--- a/internal/rules/buildkit/from_platform_flag_const_disallowed.go
+++ b/internal/rules/buildkit/from_platform_flag_const_disallowed.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // FromPlatformFlagConstDisallowedRule implements BuildKit's FromPlatformFlagConstDisallowed check.

--- a/internal/rules/buildkit/from_platform_flag_const_disallowed_test.go
+++ b/internal/rules/buildkit/from_platform_flag_const_disallowed_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestFromPlatformFlagConstDisallowedRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/invalid_base_image_platform.go
+++ b/internal/rules/buildkit/invalid_base_image_platform.go
@@ -10,10 +10,10 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/tinovyatkin/tally/internal/async"
-	"github.com/tinovyatkin/tally/internal/registry"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/async"
+	"github.com/wharflab/tally/internal/registry"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // InvalidBaseImagePlatformRule implements BuildKit's InvalidBaseImagePlatform check.

--- a/internal/rules/buildkit/invalid_base_image_platform_test.go
+++ b/internal/rules/buildkit/invalid_base_image_platform_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/gkampitakis/go-snaps/snaps"
 
-	"github.com/tinovyatkin/tally/internal/registry"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/registry"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestInvalidBaseImagePlatformRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/invalid_default_arg_in_from.go
+++ b/internal/rules/buildkit/invalid_default_arg_in_from.go
@@ -3,8 +3,8 @@ package buildkit
 import (
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // InvalidDefaultArgInFromRule implements BuildKit's InvalidDefaultArgInFrom check.

--- a/internal/rules/buildkit/invalid_default_arg_in_from_test.go
+++ b/internal/rules/buildkit/invalid_default_arg_in_from_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gkampitakis/go-snaps/snaps"
 
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestInvalidDefaultArgInFromRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/json_args_recommended.go
+++ b/internal/rules/buildkit/json_args_recommended.go
@@ -7,7 +7,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // JSONArgsRecommendedRule implements BuildKit's JSONArgsRecommended check.

--- a/internal/rules/buildkit/json_args_recommended_test.go
+++ b/internal/rules/buildkit/json_args_recommended_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/buildkit/fixes"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/buildkit/fixes"
 )
 
 func TestJSONArgsRecommendedRule_Check_AndFix(t *testing.T) {

--- a/internal/rules/buildkit/legacy_key_value_format.go
+++ b/internal/rules/buildkit/legacy_key_value_format.go
@@ -4,7 +4,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // LegacyKeyValueFormatRule implements the LegacyKeyValueFormat linting rule.

--- a/internal/rules/buildkit/multiple_instructions_disallowed.go
+++ b/internal/rules/buildkit/multiple_instructions_disallowed.go
@@ -1,6 +1,6 @@
 package buildkit
 
-import "github.com/tinovyatkin/tally/internal/rules"
+import "github.com/wharflab/tally/internal/rules"
 
 // MultipleInstructionsDisallowedRule registers BuildKit's MultipleInstructionsDisallowed check.
 //

--- a/internal/rules/buildkit/redundant_target_platform.go
+++ b/internal/rules/buildkit/redundant_target_platform.go
@@ -3,7 +3,7 @@ package buildkit
 import (
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // RedundantTargetPlatformRule implements the RedundantTargetPlatform linting rule.

--- a/internal/rules/buildkit/redundant_target_platform_test.go
+++ b/internal/rules/buildkit/redundant_target_platform_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestRedundantTargetPlatformRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/registry.go
+++ b/internal/rules/buildkit/registry.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // CapturedRuleNames lists BuildKit rule names that can be captured by tally during parsing.

--- a/internal/rules/buildkit/reserved_stage_name.go
+++ b/internal/rules/buildkit/reserved_stage_name.go
@@ -3,7 +3,7 @@ package buildkit
 import (
 	"fmt"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // reservedStageNames matches BuildKit's set exactly (case-sensitive).

--- a/internal/rules/buildkit/reserved_stage_name_test.go
+++ b/internal/rules/buildkit/reserved_stage_name_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestReservedStageNameRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/secrets_in_arg_or_env.go
+++ b/internal/rules/buildkit/secrets_in_arg_or_env.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // SecretsInArgOrEnvRule implements the SecretsUsedInArgOrEnv linting rule.

--- a/internal/rules/buildkit/secrets_in_arg_or_env_test.go
+++ b/internal/rules/buildkit/secrets_in_arg_or_env_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestSecretsInArgOrEnvRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/undefined_arg_in_from.go
+++ b/internal/rules/buildkit/undefined_arg_in_from.go
@@ -3,8 +3,8 @@ package buildkit
 import (
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // UndefinedArgInFromRule implements BuildKit's UndefinedArgInFrom check.

--- a/internal/rules/buildkit/undefined_arg_in_from_test.go
+++ b/internal/rules/buildkit/undefined_arg_in_from_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gkampitakis/go-snaps/snaps"
 
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestUndefinedArgInFromRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/undefined_var.go
+++ b/internal/rules/buildkit/undefined_var.go
@@ -3,10 +3,10 @@ package buildkit
 import (
 	"github.com/moby/buildkit/frontend/dockerfile/linter"
 
-	"github.com/tinovyatkin/tally/internal/async"
-	"github.com/tinovyatkin/tally/internal/registry"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/async"
+	"github.com/wharflab/tally/internal/registry"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // UndefinedVarRule implements BuildKit's UndefinedVar check.

--- a/internal/rules/buildkit/undefined_var_test.go
+++ b/internal/rules/buildkit/undefined_var_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gkampitakis/go-snaps/snaps"
 
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestUndefinedVarRule_Metadata(t *testing.T) {

--- a/internal/rules/buildkit/workdir_relative_path.go
+++ b/internal/rules/buildkit/workdir_relative_path.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // WorkdirRelativePathRule implements the WorkdirRelativePath linting rule.

--- a/internal/rules/buildkit/workdir_relative_path_test.go
+++ b/internal/rules/buildkit/workdir_relative_path_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestWorkdirRelativePathRule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3001.go
+++ b/internal/rules/hadolint/dl3001.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // defaultInvalidCommands are commands that make no sense inside a Docker container.

--- a/internal/rules/hadolint/dl3001_test.go
+++ b/internal/rules/hadolint/dl3001_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3001Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3002.go
+++ b/internal/rules/hadolint/dl3002.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // DL3002Rule implements the DL3002 linting rule.

--- a/internal/rules/hadolint/dl3002_test.go
+++ b/internal/rules/hadolint/dl3002_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3002Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3003.go
+++ b/internal/rules/hadolint/dl3003.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3003Rule implements the DL3003 linting rule.

--- a/internal/rules/hadolint/dl3003_test.go
+++ b/internal/rules/hadolint/dl3003_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3003Rule_Check(t *testing.T) {

--- a/internal/rules/hadolint/dl3004.go
+++ b/internal/rules/hadolint/dl3004.go
@@ -3,9 +3,9 @@ package hadolint
 import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3004Rule implements the DL3004 linting rule.

--- a/internal/rules/hadolint/dl3004_test.go
+++ b/internal/rules/hadolint/dl3004_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3004Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3006.go
+++ b/internal/rules/hadolint/dl3006.go
@@ -3,8 +3,8 @@ package hadolint
 import (
 	"fmt"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // DL3006Rule implements the DL3006 linting rule.

--- a/internal/rules/hadolint/dl3006_test.go
+++ b/internal/rules/hadolint/dl3006_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3006Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3007.go
+++ b/internal/rules/hadolint/dl3007.go
@@ -3,8 +3,8 @@ package hadolint
 import (
 	"fmt"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // DL3007Rule implements the DL3007 linting rule.

--- a/internal/rules/hadolint/dl3007_test.go
+++ b/internal/rules/hadolint/dl3007_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3007Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3010.go
+++ b/internal/rules/hadolint/dl3010.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3010Rule implements the DL3010 linting rule.

--- a/internal/rules/hadolint/dl3010_test.go
+++ b/internal/rules/hadolint/dl3010_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3010Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3011.go
+++ b/internal/rules/hadolint/dl3011.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // DL3011Rule implements the DL3011 linting rule.

--- a/internal/rules/hadolint/dl3011_test.go
+++ b/internal/rules/hadolint/dl3011_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3011Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3014.go
+++ b/internal/rules/hadolint/dl3014.go
@@ -1,8 +1,8 @@
 package hadolint
 
 import (
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3014Rule implements the DL3014 linting rule.

--- a/internal/rules/hadolint/dl3014_test.go
+++ b/internal/rules/hadolint/dl3014_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3014Rule_Check(t *testing.T) {

--- a/internal/rules/hadolint/dl3020.go
+++ b/internal/rules/hadolint/dl3020.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3020Rule implements the DL3020 linting rule.

--- a/internal/rules/hadolint/dl3020_test.go
+++ b/internal/rules/hadolint/dl3020_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3020Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3021.go
+++ b/internal/rules/hadolint/dl3021.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3021Rule implements the DL3021 linting rule.

--- a/internal/rules/hadolint/dl3021_test.go
+++ b/internal/rules/hadolint/dl3021_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3021Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3022_test.go
+++ b/internal/rules/hadolint/dl3022_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 func TestDL3022_CopyFromUndefinedAlias(t *testing.T) {

--- a/internal/rules/hadolint/dl3023_test.go
+++ b/internal/rules/hadolint/dl3023_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 func TestDL3023_SelfReferencingCopy(t *testing.T) {

--- a/internal/rules/hadolint/dl3026.go
+++ b/internal/rules/hadolint/dl3026.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
 )
 
 // DL3026Config is the configuration for the trusted-base-image rule.

--- a/internal/rules/hadolint/dl3026_test.go
+++ b/internal/rules/hadolint/dl3026_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3026Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3027.go
+++ b/internal/rules/hadolint/dl3027.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // getRunSourceScript extracts the original source for a RUN instruction

--- a/internal/rules/hadolint/dl3027_test.go
+++ b/internal/rules/hadolint/dl3027_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3027Rule_Check(t *testing.T) {

--- a/internal/rules/hadolint/dl3030.go
+++ b/internal/rules/hadolint/dl3030.go
@@ -1,8 +1,8 @@
 package hadolint
 
 import (
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3030Rule implements the DL3030 linting rule.

--- a/internal/rules/hadolint/dl3030_test.go
+++ b/internal/rules/hadolint/dl3030_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3030Rule_Check(t *testing.T) {

--- a/internal/rules/hadolint/dl3034.go
+++ b/internal/rules/hadolint/dl3034.go
@@ -1,8 +1,8 @@
 package hadolint
 
 import (
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3034Rule implements the DL3034 linting rule.

--- a/internal/rules/hadolint/dl3034_test.go
+++ b/internal/rules/hadolint/dl3034_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3034Rule_Check(t *testing.T) {

--- a/internal/rules/hadolint/dl3038.go
+++ b/internal/rules/hadolint/dl3038.go
@@ -1,8 +1,8 @@
 package hadolint
 
 import (
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3038Rule implements the DL3038 linting rule.

--- a/internal/rules/hadolint/dl3038_test.go
+++ b/internal/rules/hadolint/dl3038_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3038Rule_Check(t *testing.T) {

--- a/internal/rules/hadolint/dl3043_test.go
+++ b/internal/rules/hadolint/dl3043_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 func TestDL3043_ForbiddenOnbuildTriggers(t *testing.T) {

--- a/internal/rules/hadolint/dl3046.go
+++ b/internal/rules/hadolint/dl3046.go
@@ -3,9 +3,9 @@ package hadolint
 import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3046Rule implements the DL3046 linting rule.

--- a/internal/rules/hadolint/dl3046_test.go
+++ b/internal/rules/hadolint/dl3046_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3046Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3047.go
+++ b/internal/rules/hadolint/dl3047.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL3047Rule implements the DL3047 linting rule.

--- a/internal/rules/hadolint/dl3047_test.go
+++ b/internal/rules/hadolint/dl3047_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3047Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3057.go
+++ b/internal/rules/hadolint/dl3057.go
@@ -4,11 +4,11 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/async"
-	"github.com/tinovyatkin/tally/internal/registry"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/asyncutil"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/async"
+	"github.com/wharflab/tally/internal/registry"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/asyncutil"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // DL3057Rule implements the DL3057 linting rule.

--- a/internal/rules/hadolint/dl3057_test.go
+++ b/internal/rules/hadolint/dl3057_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/async"
-	"github.com/tinovyatkin/tally/internal/registry"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/async"
+	"github.com/wharflab/tally/internal/registry"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL3057Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl3061_test.go
+++ b/internal/rules/hadolint/dl3061_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 func TestDL3061_InvalidInstructionOrder(t *testing.T) {

--- a/internal/rules/hadolint/dl4001.go
+++ b/internal/rules/hadolint/dl4001.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL4001Rule implements the DL4001 linting rule.

--- a/internal/rules/hadolint/dl4001_test.go
+++ b/internal/rules/hadolint/dl4001_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL4001Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl4005.go
+++ b/internal/rules/hadolint/dl4005.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL4005Rule implements the DL4005 linting rule.

--- a/internal/rules/hadolint/dl4005_test.go
+++ b/internal/rules/hadolint/dl4005_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL4005Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/dl4006.go
+++ b/internal/rules/hadolint/dl4006.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DL4006Rule implements the DL4006 linting rule.

--- a/internal/rules/hadolint/dl4006_test.go
+++ b/internal/rules/hadolint/dl4006_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestDL4006Rule_Metadata(t *testing.T) {

--- a/internal/rules/hadolint/helpers.go
+++ b/internal/rules/hadolint/helpers.go
@@ -3,10 +3,10 @@ package hadolint
 import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // RunCommandCallback is a function that checks a RUN command with the given shell variant.

--- a/internal/rules/hadolint/helpers_test.go
+++ b/internal/rules/hadolint/helpers_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestRunCommandString(t *testing.T) {

--- a/internal/rules/heredoc_data.go
+++ b/internal/rules/heredoc_data.go
@@ -1,6 +1,6 @@
 package rules
 
-import "github.com/tinovyatkin/tally/internal/shell"
+import "github.com/wharflab/tally/internal/shell"
 
 // HeredocResolverID is the unique identifier for the heredoc fix resolver.
 const HeredocResolverID = "prefer-run-heredoc"

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // BuildContext is an interface for build-time context awareness.

--- a/internal/rules/tally/__snapshots__/TestConsistentIndentationMetadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestConsistentIndentationMetadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/consistent-indentation",
  "DefaultSeverity": "off",
  "Description": "Enforces consistent indentation for Dockerfile build stages",
- "DocURL": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+ "DocURL": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
  "FixPriority": 50,
  "IsExperimental": true,
  "Name": "Consistent Indentation"

--- a/internal/rules/tally/__snapshots__/TestMaxLinesRule_Metadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestMaxLinesRule_Metadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/max-lines",
  "DefaultSeverity": "error",
  "Description": "Limits the maximum number of lines in a Dockerfile",
- "DocURL": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/max-lines.md",
+ "DocURL": "https://github.com/wharflab/tally/blob/main/docs/rules/max-lines.md",
  "FixPriority": 0,
  "IsExperimental": false,
  "Name": "Maximum Lines"

--- a/internal/rules/tally/__snapshots__/TestPreferAddUnpackRule_Metadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestPreferAddUnpackRule_Metadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/prefer-add-unpack",
  "DefaultSeverity": "info",
  "Description": "Use `ADD --unpack` instead of downloading and extracting remote archives in `RUN`",
- "DocURL": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/prefer-add-unpack.md",
+ "DocURL": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/prefer-add-unpack.md",
  "FixPriority": 95,
  "IsExperimental": false,
  "Name": "Prefer ADD --unpack for remote archives"

--- a/internal/rules/tally/__snapshots__/TestPreferCopyHeredocRule_Metadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestPreferCopyHeredocRule_Metadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/prefer-copy-heredoc",
  "DefaultSeverity": "style",
  "Description": "Use COPY \u003c\u003cEOF syntax instead of RUN echo/cat for creating files",
- "DocURL": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
+ "DocURL": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
  "FixPriority": 99,
  "IsExperimental": true,
  "Name": "Prefer COPY heredoc for file creation"

--- a/internal/rules/tally/__snapshots__/TestPreferHeredocRule_Metadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestPreferHeredocRule_Metadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/prefer-run-heredoc",
  "DefaultSeverity": "style",
  "Description": "Use heredoc syntax for multi-command RUN instructions",
- "DocURL": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+ "DocURL": "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
  "FixPriority": 100,
  "IsExperimental": true,
  "Name": "Prefer RUN heredoc syntax"

--- a/internal/rules/tally/__snapshots__/TestPreferMultiStageBuildRule_Metadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestPreferMultiStageBuildRule_Metadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/prefer-multi-stage-build",
  "DefaultSeverity": "info",
  "Description": "Suggests converting single-stage builds into multi-stage builds to reduce final image size",
- "DocURL": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/prefer-multi-stage-build.md",
+ "DocURL": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/prefer-multi-stage-build.md",
  "FixPriority": 150,
  "IsExperimental": true,
  "Name": "Prefer Multi-Stage Build"

--- a/internal/rules/tally/__snapshots__/TestPreferVEXAttestationRule_Metadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestPreferVEXAttestationRule_Metadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/prefer-vex-attestation",
  "DefaultSeverity": "info",
  "Description": "Prefer attaching OpenVEX as an OCI attestation instead of copying VEX JSON into the image",
- "DocURL": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/prefer-vex-attestation.md",
+ "DocURL": "https://github.com/wharflab/tally/blob/main/docs/rules/tally/prefer-vex-attestation.md",
  "FixPriority": 0,
  "IsExperimental": false,
  "Name": "Prefer VEX attestation"

--- a/internal/rules/tally/__snapshots__/TestSecretsInCodeRule_Metadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestSecretsInCodeRule_Metadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/secrets-in-code",
  "DefaultSeverity": "error",
  "Description": "Detects hardcoded secrets, API keys, and credentials in Dockerfile content",
- "DocURL": "https://github.com/tinovyatkin/tally#secrets-in-code",
+ "DocURL": "https://github.com/wharflab/tally#secrets-in-code",
  "FixPriority": 0,
  "IsExperimental": true,
  "Name": "Secrets in Dockerfile Content"

--- a/internal/rules/tally/__snapshots__/TestUnreachableStagesRule_Metadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestUnreachableStagesRule_Metadata_1.snap.json
@@ -3,7 +3,7 @@
  "Code": "tally/no-unreachable-stages",
  "DefaultSeverity": "warning",
  "Description": "Disallows build stages that don't contribute to the final image",
- "DocURL": "https://github.com/tinovyatkin/tally/blob/main/docs/rules/no-unreachable-stages.md",
+ "DocURL": "https://github.com/wharflab/tally/blob/main/docs/rules/no-unreachable-stages.md",
  "FixPriority": 0,
  "IsExperimental": false,
  "Name": "No Unreachable Stages"

--- a/internal/rules/tally/consistent_indentation.go
+++ b/internal/rules/tally/consistent_indentation.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // expectedIndent is the indentation string used by this rule: a single tab.
@@ -33,7 +33,7 @@ func (r *ConsistentIndentationRule) Metadata() rules.RuleMetadata {
 		Code:            rules.TallyRulePrefix + "consistent-indentation",
 		Name:            "Consistent Indentation",
 		Description:     "Enforces consistent indentation for Dockerfile build stages",
-		DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/consistent-indentation.md",
+		DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/tally/consistent-indentation.md",
 		DefaultSeverity: rules.SeverityOff,
 		Category:        "style",
 		IsExperimental:  true,

--- a/internal/rules/tally/consistent_indentation_test.go
+++ b/internal/rules/tally/consistent_indentation_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestConsistentIndentationMetadata(t *testing.T) {

--- a/internal/rules/tally/max_lines.go
+++ b/internal/rules/tally/max_lines.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
 )
 
 // MaxLinesConfig is the configuration for the max-lines rule.
@@ -55,7 +55,7 @@ func (r *MaxLinesRule) Metadata() rules.RuleMetadata {
 		Code:            rules.TallyRulePrefix + "max-lines",
 		Name:            "Maximum Lines",
 		Description:     "Limits the maximum number of lines in a Dockerfile",
-		DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/max-lines.md",
+		DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/max-lines.md",
 		DefaultSeverity: rules.SeverityError,
 		Category:        "maintainability",
 		IsExperimental:  false,

--- a/internal/rules/tally/max_lines_test.go
+++ b/internal/rules/tally/max_lines_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 // Helper functions for pointer values in tests.

--- a/internal/rules/tally/prefer_add_unpack.go
+++ b/internal/rules/tally/prefer_add_unpack.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
-	"github.com/tinovyatkin/tally/internal/semantic"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // PreferAddUnpackConfig is the configuration for the prefer-add-unpack rule.
@@ -45,7 +45,7 @@ func (r *PreferAddUnpackRule) Metadata() rules.RuleMetadata {
 		Code:            rules.TallyRulePrefix + "prefer-add-unpack",
 		Name:            "Prefer ADD --unpack for remote archives",
 		Description:     "Use `ADD --unpack` instead of downloading and extracting remote archives in `RUN`",
-		DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/prefer-add-unpack.md",
+		DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/tally/prefer-add-unpack.md",
 		DefaultSeverity: rules.SeverityInfo,
 		Category:        "performance",
 		IsExperimental:  false,

--- a/internal/rules/tally/prefer_add_unpack_test.go
+++ b/internal/rules/tally/prefer_add_unpack_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestPreferAddUnpackRule_Metadata(t *testing.T) {

--- a/internal/rules/tally/prefer_copy_heredoc.go
+++ b/internal/rules/tally/prefer_copy_heredoc.go
@@ -9,12 +9,12 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
-	"github.com/tinovyatkin/tally/internal/runmount"
-	"github.com/tinovyatkin/tally/internal/semantic"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/runmount"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // PreferCopyHeredocRuleCode is the full rule code for the prefer-copy-heredoc rule.
@@ -56,7 +56,7 @@ func (r *PreferCopyHeredocRule) Metadata() rules.RuleMetadata {
 		Code:            PreferCopyHeredocRuleCode,
 		Name:            "Prefer COPY heredoc for file creation",
 		Description:     "Use COPY <<EOF syntax instead of RUN echo/cat for creating files",
-		DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
+		DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-copy-heredoc.md",
 		DefaultSeverity: rules.SeverityStyle,
 		Category:        "style",
 		IsExperimental:  true,

--- a/internal/rules/tally/prefer_copy_heredoc_test.go
+++ b/internal/rules/tally/prefer_copy_heredoc_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestPreferCopyHeredocRule_Metadata(t *testing.T) {

--- a/internal/rules/tally/prefer_heredoc.go
+++ b/internal/rules/tally/prefer_heredoc.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
-	"github.com/tinovyatkin/tally/internal/runmount"
-	"github.com/tinovyatkin/tally/internal/semantic"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/runmount"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // PreferHeredocConfig is the configuration for the prefer-run-heredoc rule.
@@ -54,7 +54,7 @@ func (r *PreferHeredocRule) Metadata() rules.RuleMetadata {
 		Code:            rules.TallyRulePrefix + "prefer-run-heredoc",
 		Name:            "Prefer RUN heredoc syntax",
 		Description:     "Use heredoc syntax for multi-command RUN instructions",
-		DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/prefer-run-heredoc.md",
+		DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/prefer-run-heredoc.md",
 		DefaultSeverity: rules.SeverityStyle,
 		Category:        "style",
 		IsExperimental:  true,

--- a/internal/rules/tally/prefer_heredoc_test.go
+++ b/internal/rules/tally/prefer_heredoc_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/heredoc"
-	"github.com/tinovyatkin/tally/internal/shell"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/heredoc"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestPreferHeredocRule_Metadata(t *testing.T) {

--- a/internal/rules/tally/prefer_multi_stage_build.go
+++ b/internal/rules/tally/prefer_multi_stage_build.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/ai/autofixdata"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/ai/autofixdata"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
 )
 
 // PreferMultiStageBuildConfig configures the prefer-multi-stage-build rule.
@@ -33,7 +33,7 @@ func (r *PreferMultiStageBuildRule) Metadata() rules.RuleMetadata {
 		Code:            rules.TallyRulePrefix + "prefer-multi-stage-build",
 		Name:            "Prefer Multi-Stage Build",
 		Description:     "Suggests converting single-stage builds into multi-stage builds to reduce final image size",
-		DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/prefer-multi-stage-build.md",
+		DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/tally/prefer-multi-stage-build.md",
 		DefaultSeverity: rules.SeverityInfo,
 		Category:        "performance",
 		IsExperimental:  true,

--- a/internal/rules/tally/prefer_multi_stage_build_test.go
+++ b/internal/rules/tally/prefer_multi_stage_build_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/gkampitakis/go-snaps/snaps"
 
-	"github.com/tinovyatkin/tally/internal/ai/autofixdata"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/ai/autofixdata"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestPreferMultiStageBuildRule_Metadata(t *testing.T) {

--- a/internal/rules/tally/prefer_vex_attestation.go
+++ b/internal/rules/tally/prefer_vex_attestation.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // PreferVEXAttestationRule flags COPY instructions that embed OpenVEX documents
@@ -25,7 +25,7 @@ func (r *PreferVEXAttestationRule) Metadata() rules.RuleMetadata {
 		Code:            rules.TallyRulePrefix + "prefer-vex-attestation",
 		Name:            "Prefer VEX attestation",
 		Description:     "Prefer attaching OpenVEX as an OCI attestation instead of copying VEX JSON into the image",
-		DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/tally/prefer-vex-attestation.md",
+		DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/tally/prefer-vex-attestation.md",
 		DefaultSeverity: rules.SeverityInfo,
 		Category:        "security",
 		IsExperimental:  false,

--- a/internal/rules/tally/prefer_vex_attestation_test.go
+++ b/internal/rules/tally/prefer_vex_attestation_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestPreferVEXAttestationRule_Metadata(t *testing.T) {

--- a/internal/rules/tally/secrets_in_code.go
+++ b/internal/rules/tally/secrets_in_code.go
@@ -8,7 +8,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/zricethezav/gitleaks/v8/detect"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 var (
@@ -30,7 +30,7 @@ func (r *SecretsInCodeRule) Metadata() rules.RuleMetadata {
 		Code:            rules.TallyRulePrefix + "secrets-in-code",
 		Name:            "Secrets in Dockerfile Content",
 		Description:     "Detects hardcoded secrets, API keys, and credentials in Dockerfile content",
-		DocURL:          "https://github.com/tinovyatkin/tally#secrets-in-code",
+		DocURL:          "https://github.com/wharflab/tally#secrets-in-code",
 		DefaultSeverity: rules.SeverityError, // Secrets are serious
 		Category:        "security",
 		IsExperimental:  true, // New rule, mark as experimental initially

--- a/internal/rules/tally/secrets_in_code_test.go
+++ b/internal/rules/tally/secrets_in_code_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestSecretsInCodeRule_Metadata(t *testing.T) {

--- a/internal/rules/tally/unreachable_stages.go
+++ b/internal/rules/tally/unreachable_stages.go
@@ -3,8 +3,8 @@ package tally
 import (
 	"fmt"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // UnreachableStagesRule implements the no-unreachable-stages linting rule.
@@ -23,7 +23,7 @@ func (r *UnreachableStagesRule) Metadata() rules.RuleMetadata {
 		Code:            rules.TallyRulePrefix + "no-unreachable-stages",
 		Name:            "No Unreachable Stages",
 		Description:     "Disallows build stages that don't contribute to the final image",
-		DocURL:          "https://github.com/tinovyatkin/tally/blob/main/docs/rules/no-unreachable-stages.md",
+		DocURL:          "https://github.com/wharflab/tally/blob/main/docs/rules/no-unreachable-stages.md",
 		DefaultSeverity: rules.SeverityWarning,
 		Category:        "best-practices",
 		IsExperimental:  false,

--- a/internal/rules/tally/unreachable_stages_test.go
+++ b/internal/rules/tally/unreachable_stages_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/testutil"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
 )
 
 func TestUnreachableStagesRule_Metadata(t *testing.T) {

--- a/internal/semantic/builder.go
+++ b/internal/semantic/builder.go
@@ -10,10 +10,10 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	dfshell "github.com/moby/buildkit/frontend/dockerfile/shell"
 
-	"github.com/tinovyatkin/tally/internal/directive"
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/directive"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // Builder constructs a semantic model from a parse result.

--- a/internal/semantic/builder_test.go
+++ b/internal/semantic/builder_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/directive"
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/directive"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 func TestBuilderWithShellDirectivesAppliesToFollowingStages(t *testing.T) {

--- a/internal/semantic/construction_rules.go
+++ b/internal/semantic/construction_rules.go
@@ -1,6 +1,6 @@
 package semantic
 
-import "github.com/tinovyatkin/tally/internal/rules"
+import "github.com/wharflab/tally/internal/rules"
 
 // ConstructionRuleCodes returns rule codes that can be emitted during semantic model construction.
 //

--- a/internal/semantic/issue.go
+++ b/internal/semantic/issue.go
@@ -3,7 +3,7 @@ package semantic
 import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 // Issue represents a semantic problem detected during model construction.

--- a/internal/semantic/multiple_instructions_test.go
+++ b/internal/semantic/multiple_instructions_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 const multipleInstructionsCode = rules.BuildKitRulePrefix + "MultipleInstructionsDisallowed"

--- a/internal/semantic/semantic.go
+++ b/internal/semantic/semantic.go
@@ -11,7 +11,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	dfshell "github.com/moby/buildkit/frontend/dockerfile/shell"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/dockerfile"
 )
 
 // Model represents the semantic analysis of a Dockerfile.

--- a/internal/semantic/semantic_test.go
+++ b/internal/semantic/semantic_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/dockerfile"
 )
 
 // parseDockerfile is a test helper that parses a Dockerfile string.

--- a/internal/semantic/stage_info.go
+++ b/internal/semantic/stage_info.go
@@ -6,7 +6,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
-	"github.com/tinovyatkin/tally/internal/shell"
+	"github.com/wharflab/tally/internal/shell"
 )
 
 // DefaultShell is the default shell used by Docker for RUN instructions.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/dockerfile"
-	"github.com/tinovyatkin/tally/internal/rules"
-	"github.com/tinovyatkin/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
 )
 
 // ParseDockerfile parses a Dockerfile from a string using the full parsing pipeline.

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -3,7 +3,7 @@ package testutil
 import (
 	"testing"
 
-	"github.com/tinovyatkin/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules"
 )
 
 func TestParseDockerfile(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/tinovyatkin/tally/cmd/tally/cmd"
+	"github.com/wharflab/tally/cmd/tally/cmd"
 )
 
 func main() {

--- a/packaging/homebrew/generate-formula.sh
+++ b/packaging/homebrew/generate-formula.sh
@@ -22,7 +22,7 @@ if [[ ! -f "$TEMPLATE_FILE" ]]; then
 fi
 
 # Fetch checksums from GitHub release if not provided via env vars
-BASE_URL="https://github.com/tinovyatkin/tally/releases/download/v${VERSION}"
+BASE_URL="https://github.com/wharflab/tally/releases/download/v${VERSION}"
 
 fetch_checksum() {
     local archive_name="$1"

--- a/packaging/homebrew/tally.rb.template
+++ b/packaging/homebrew/tally.rb.template
@@ -4,26 +4,26 @@
 # Homebrew formula for tally - auto-generated, do not edit manually
 class Tally < Formula
   desc "Fast, configurable linter for Dockerfiles and Containerfiles"
-  homepage "https://github.com/tinovyatkin/tally"
+  homepage "https://github.com/wharflab/tally"
   license "Apache-2.0"
   version "{{VERSION}}"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/tinovyatkin/tally/releases/download/v{{VERSION}}/tally_{{VERSION}}_MacOS_arm64.tar.gz"
+      url "https://github.com/wharflab/tally/releases/download/v{{VERSION}}/tally_{{VERSION}}_MacOS_arm64.tar.gz"
       sha256 "{{SHA256_DARWIN_ARM64}}"
     else
-      url "https://github.com/tinovyatkin/tally/releases/download/v{{VERSION}}/tally_{{VERSION}}_MacOS_x86_64.tar.gz"
+      url "https://github.com/wharflab/tally/releases/download/v{{VERSION}}/tally_{{VERSION}}_MacOS_x86_64.tar.gz"
       sha256 "{{SHA256_DARWIN_AMD64}}"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/tinovyatkin/tally/releases/download/v{{VERSION}}/tally_{{VERSION}}_Linux_arm64.tar.gz"
+      url "https://github.com/wharflab/tally/releases/download/v{{VERSION}}/tally_{{VERSION}}_Linux_arm64.tar.gz"
       sha256 "{{SHA256_LINUX_ARM64}}"
     else
-      url "https://github.com/tinovyatkin/tally/releases/download/v{{VERSION}}/tally_{{VERSION}}_Linux_x86_64.tar.gz"
+      url "https://github.com/wharflab/tally/releases/download/v{{VERSION}}/tally_{{VERSION}}_Linux_x86_64.tar.gz"
       sha256 "{{SHA256_LINUX_AMD64}}"
     end
   end

--- a/packaging/npm/tally-darwin-arm64/package.json
+++ b/packaging/npm/tally-darwin-arm64/package.json
@@ -4,13 +4,13 @@
   "description": "tally binary for darwin-arm64",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinovyatkin/tally.git"
+    "url": "git+https://github.com/wharflab/tally.git"
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tinovyatkin/tally/issues"
+    "url": "https://github.com/wharflab/tally/issues"
   },
-  "homepage": "https://github.com/tinovyatkin/tally#readme",
+  "homepage": "https://github.com/wharflab/tally#readme",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "files": [

--- a/packaging/npm/tally-darwin-x64/package.json
+++ b/packaging/npm/tally-darwin-x64/package.json
@@ -4,13 +4,13 @@
   "description": "tally binary for darwin-x64",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinovyatkin/tally.git"
+    "url": "git+https://github.com/wharflab/tally.git"
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tinovyatkin/tally/issues"
+    "url": "https://github.com/wharflab/tally/issues"
   },
-  "homepage": "https://github.com/tinovyatkin/tally#readme",
+  "homepage": "https://github.com/wharflab/tally#readme",
   "os": ["darwin"],
   "cpu": ["x64"],
   "files": [

--- a/packaging/npm/tally-freebsd-x64/package.json
+++ b/packaging/npm/tally-freebsd-x64/package.json
@@ -4,13 +4,13 @@
   "description": "tally binary for freebsd-x64",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinovyatkin/tally.git"
+    "url": "git+https://github.com/wharflab/tally.git"
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tinovyatkin/tally/issues"
+    "url": "https://github.com/wharflab/tally/issues"
   },
-  "homepage": "https://github.com/tinovyatkin/tally#readme",
+  "homepage": "https://github.com/wharflab/tally#readme",
   "os": ["freebsd"],
   "cpu": ["x64"],
   "files": [

--- a/packaging/npm/tally-linux-arm64/package.json
+++ b/packaging/npm/tally-linux-arm64/package.json
@@ -4,13 +4,13 @@
   "description": "tally binary for linux-arm64",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinovyatkin/tally.git"
+    "url": "git+https://github.com/wharflab/tally.git"
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tinovyatkin/tally/issues"
+    "url": "https://github.com/wharflab/tally/issues"
   },
-  "homepage": "https://github.com/tinovyatkin/tally#readme",
+  "homepage": "https://github.com/wharflab/tally#readme",
   "os": ["linux"],
   "cpu": ["arm64"],
   "files": [

--- a/packaging/npm/tally-linux-x64/package.json
+++ b/packaging/npm/tally-linux-x64/package.json
@@ -4,13 +4,13 @@
   "description": "tally binary for linux-x64",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinovyatkin/tally.git"
+    "url": "git+https://github.com/wharflab/tally.git"
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tinovyatkin/tally/issues"
+    "url": "https://github.com/wharflab/tally/issues"
   },
-  "homepage": "https://github.com/tinovyatkin/tally#readme",
+  "homepage": "https://github.com/wharflab/tally#readme",
   "os": ["linux"],
   "cpu": ["x64"],
   "files": [

--- a/packaging/npm/tally-windows-arm64/package.json
+++ b/packaging/npm/tally-windows-arm64/package.json
@@ -4,13 +4,13 @@
   "description": "tally binary for windows-arm64",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinovyatkin/tally.git"
+    "url": "git+https://github.com/wharflab/tally.git"
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tinovyatkin/tally/issues"
+    "url": "https://github.com/wharflab/tally/issues"
   },
-  "homepage": "https://github.com/tinovyatkin/tally#readme",
+  "homepage": "https://github.com/wharflab/tally#readme",
   "os": ["win32"],
   "cpu": ["arm64"],
   "files": [

--- a/packaging/npm/tally-windows-x64/package.json
+++ b/packaging/npm/tally-windows-x64/package.json
@@ -4,13 +4,13 @@
   "description": "tally binary for windows-x64",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinovyatkin/tally.git"
+    "url": "git+https://github.com/wharflab/tally.git"
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tinovyatkin/tally/issues"
+    "url": "https://github.com/wharflab/tally/issues"
   },
-  "homepage": "https://github.com/tinovyatkin/tally#readme",
+  "homepage": "https://github.com/wharflab/tally#readme",
   "os": ["win32"],
   "cpu": ["x64"],
   "files": [

--- a/packaging/npm/tally/package.json
+++ b/packaging/npm/tally/package.json
@@ -4,7 +4,7 @@
   "description": "A fast, configurable linter for Dockerfiles and Containerfiles",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tinovyatkin/tally.git"
+    "url": "git+https://github.com/wharflab/tally.git"
   },
   "bin": {
     "tally": "./bin/cli.js"
@@ -24,9 +24,9 @@
   "author": "tinovyatkin",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tinovyatkin/tally/issues"
+    "url": "https://github.com/wharflab/tally/issues"
   },
-  "homepage": "https://github.com/tinovyatkin/tally#readme",
+  "homepage": "https://github.com/wharflab/tally#readme",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packaging/pypi/README.md
+++ b/packaging/pypi/README.md
@@ -17,4 +17,4 @@ tally lint --max-lines 100 Dockerfile
 
 ## Documentation
 
-See the [GitHub repository](https://github.com/tinovyatkin/tally) for full documentation.
+See the [GitHub repository](https://github.com/wharflab/tally) for full documentation.

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/tinovyatkin/tally"
+Homepage = "https://github.com/wharflab/tally"
 
 [project.scripts]
 tally = "tally_cli.main:main"

--- a/packaging/pypi/tally_cli/main.py
+++ b/packaging/pypi/tally_cli/main.py
@@ -3,7 +3,7 @@ import sys
 import platform
 import subprocess
 
-ISSUE_URL = "https://github.com/tinovyatkin/tally/issues/new"
+ISSUE_URL = "https://github.com/wharflab/tally/issues/new"
 ARCH_MAPPING = {
     'amd64': 'x86_64',
     'aarch64': 'arm64',

--- a/packaging/rubygems/tally-cli.gemspec
+++ b/packaging/rubygems/tally-cli.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["tino@vtkn.io"]
 
   spec.summary       = "A fast, configurable linter for Dockerfiles and Containerfiles"
-  spec.homepage      = "https://github.com/tinovyatkin/tally"
+  spec.homepage      = "https://github.com/wharflab/tally"
   spec.post_install_message = "tally installed! Run 'tally --help' to see usage."
 
   spec.bindir        = "bin"

--- a/schema.json
+++ b/schema.json
@@ -37,7 +37,7 @@
     },
     "DL3001Config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://github.com/tinovyatkin/tally/internal/rules/hadolint/dl3001-config",
+      "$id": "https://github.com/wharflab/tally/internal/rules/hadolint/dl3001-config",
       "properties": {
         "invalid-commands": {
           "items": {
@@ -52,7 +52,7 @@
     },
     "DL3026Config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://github.com/tinovyatkin/tally/internal/rules/hadolint/dl3026-config",
+      "$id": "https://github.com/wharflab/tally/internal/rules/hadolint/dl3026-config",
       "properties": {
         "trusted-registries": {
           "items": {
@@ -243,7 +243,7 @@
     },
     "max-linesConfig": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://github.com/tinovyatkin/tally/internal/rules/tally/max-lines-config",
+      "$id": "https://github.com/wharflab/tally/internal/rules/tally/max-lines-config",
       "properties": {
         "max": {
           "type": "integer",
@@ -268,7 +268,7 @@
     },
     "prefer-add-unpackConfig": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://github.com/tinovyatkin/tally/internal/rules/tally/prefer-add-unpack-config",
+      "$id": "https://github.com/wharflab/tally/internal/rules/tally/prefer-add-unpack-config",
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -280,7 +280,7 @@
     },
     "prefer-copy-heredocConfig": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://github.com/tinovyatkin/tally/internal/rules/tally/prefer-copy-heredoc-config",
+      "$id": "https://github.com/wharflab/tally/internal/rules/tally/prefer-copy-heredoc-config",
       "properties": {
         "check-single-run": {
           "type": "boolean"
@@ -295,7 +295,7 @@
     },
     "prefer-multi-stage-buildConfig": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://github.com/tinovyatkin/tally/internal/rules/tally/prefer-multi-stage-build-config",
+      "$id": "https://github.com/wharflab/tally/internal/rules/tally/prefer-multi-stage-build-config",
       "properties": {
         "min-score": {
           "type": "integer",
@@ -310,7 +310,7 @@
     },
     "prefer-run-heredocConfig": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "https://github.com/tinovyatkin/tally/internal/rules/tally/prefer-heredoc-config",
+      "$id": "https://github.com/wharflab/tally/internal/rules/tally/prefer-heredoc-config",
       "properties": {
         "min-commands": {
           "type": "integer"

--- a/scripts/sync-buildkit-rules/main.go
+++ b/scripts/sync-buildkit-rules/main.go
@@ -18,10 +18,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tinovyatkin/tally/internal/rules"
-	_ "github.com/tinovyatkin/tally/internal/rules/all"
-	bkregistry "github.com/tinovyatkin/tally/internal/rules/buildkit"
-	buildkitfixes "github.com/tinovyatkin/tally/internal/rules/buildkit/fixes"
+	"github.com/wharflab/tally/internal/rules"
+	_ "github.com/wharflab/tally/internal/rules/all"
+	bkregistry "github.com/wharflab/tally/internal/rules/buildkit"
+	buildkitfixes "github.com/wharflab/tally/internal/rules/buildkit/fixes"
 )
 
 const (

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,12 +1,12 @@
 [project]
 site_name = "tally"
-site_url = "https://tinovyatkin.github.io/tally/"
+site_url = "https://wharflab.github.io/tally/"
 site_description = "Fast, modern Dockerfile linter with auto-fixes"
 docs_dir = "docs"
 site_dir = "site"
 
-repo_url = "https://github.com/tinovyatkin/tally"
-repo_name = "tinovyatkin/tally"
+repo_url = "https://github.com/wharflab/tally"
+repo_name = "wharflab/tally"
 
 [theme]
 name = "zensical"


### PR DESCRIPTION
## Summary

- Rename Go module from `github.com/tinovyatkin/tally` to `github.com/wharflab/tally` and update all 212 Go import paths
- Update GitHub Actions workflows (`codeql.yml` repo guard, `release.yml` homebrew tap clone)
- Update all packaging metadata (npm, PyPI, RubyGems, Homebrew formula/template)
- Update documentation URLs (README, docs, design docs, AGENTS.md, skill files)
- Update config files (`.goreleaser.yml`, `codecov.yml`, `zensical.toml`, `schema.json`)
- Update VSCode extension repository reference and compiled bundle
- Update test snapshots (SARIF, integration, rule metadata)
- Personal attribution kept as `tinovyatkin` (FUNDING.yml sponsor, npm author)

All secrets verified present on `wharflab/tally`. `wharflab/homebrew-tap` exists with write deploy key.

## External services to verify after merge

- [ ] Codecov — ensure `wharflab/tally` is connected
- [ ] CodSpeed — enable benchmarking for new repo
- [ ] NPM/PyPI/RubyGems — verify trusted publishing is configured for the org
- [ ] GitHub Pages — already enabled

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] No remaining `tinovyatkin` references in source files (only in gitignored build artifacts)
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)