### PR TITLE
feat(fix): add autofix for hadolint/DL3020 (ADD → COPY)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -151,7 +151,7 @@ See the [Hadolint Wiki](https://github.com/hadolint/hadolint/wiki) for detailed 
 | [DL3016](https://github.com/hadolint/hadolint/wiki/DL3016) | Pin versions in `npm`. | Warning | ⏳ |
 | [DL3018](https://github.com/hadolint/hadolint/wiki/DL3018) | Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`. | Warning | ⏳ |
 | [DL3019](https://github.com/hadolint/hadolint/wiki/DL3019) | Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages. | Info | ⛔ Not planned (`tally/prefer-package-cache-mounts`) |
-| [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) | Use `COPY` instead of `ADD` for files and folders. | Error | ✅ `hadolint/DL3020` |
+| [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) | Use `COPY` instead of `ADD` for files and folders. | Error | ✅🔧 `hadolint/DL3020` |
 | [DL3021](https://github.com/hadolint/hadolint/wiki/DL3021) | `COPY` with more than 2 arguments requires the last argument to end with `/` | Error | ✅ `hadolint/DL3021` |
 | [DL3022](https://github.com/hadolint/hadolint/wiki/DL3022) | `COPY --from` should reference a previously defined `FROM` alias | Warning | ✅ `hadolint/DL3022` |
 | [DL3023](https://github.com/hadolint/hadolint/wiki/DL3023) | `COPY --from` cannot reference its own `FROM` alias | Error | ✅ `hadolint/DL3023` |

--- a/docs/rules/hadolint/DL3020.md
+++ b/docs/rules/hadolint/DL3020.md
@@ -7,6 +7,7 @@ Use `COPY` instead of `ADD` for files and folders.
 | Severity | Error |
 | Category | Best Practice |
 | Default | Enabled |
+| Auto-fix | Yes (`--fix`) |
 
 ## Description
 
@@ -30,6 +31,22 @@ ADD requirements.txt /usr/src/app/
 FROM python:3.4
 COPY requirements.txt /usr/src/app/
 ```
+
+## Auto-fix
+
+Replaces the `ADD` keyword with `COPY`, preserving all flags, sources, and destination unchanged.
+
+- **Safe fix** (`FixSafe`): Always correct for local file/directory sources since `COPY` and `ADD` behave identically for non-URL, non-tar sources.
+
+```dockerfile
+# Before
+ADD --chown=app:app src/ /app/
+
+# After (with --fix)
+COPY --chown=app:app src/ /app/
+```
+
+The fix preserves instruction casing (`ADD` → `COPY`, `add` → `copy`).
 
 ## Reference
 

--- a/internal/integration/__snapshots__/TestFix_dl3020-add-to-copy-multiple_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_dl3020-add-to-copy-multiple_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:22.04
+COPY file1.txt /app/
+COPY file2.txt /app/

--- a/internal/integration/__snapshots__/TestFix_dl3020-add-to-copy-with-flags_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_dl3020-add-to-copy-with-flags_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu:22.04
+COPY --chown=app:app src/ /app/

--- a/internal/integration/__snapshots__/TestFix_dl3020-add-to-copy_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_dl3020-add-to-copy_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu:22.04
+COPY file.txt /app/

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -37,6 +37,25 @@ func fixCases(t *testing.T) []fixCase {
 			args:        []string{"--fix"},
 			wantApplied: 2, // Both FromAsCasing and StageNameCasing
 		},
+		// DL3020: ADD -> COPY for local files
+		{
+			name:        "dl3020-add-to-copy",
+			input:       "FROM ubuntu:22.04\nADD file.txt /app/\n",
+			args:        []string{"--fix"},
+			wantApplied: 1,
+		},
+		{
+			name:        "dl3020-add-to-copy-multiple",
+			input:       "FROM ubuntu:22.04\nADD file1.txt /app/\nADD file2.txt /app/\n",
+			args:        []string{"--fix"},
+			wantApplied: 2,
+		},
+		{
+			name:        "dl3020-add-to-copy-with-flags",
+			input:       "FROM ubuntu:22.04\nADD --chown=app:app src/ /app/\n",
+			args:        []string{"--fix"},
+			wantApplied: 1,
+		},
 		// DL3027: apt -> apt-get (regression test for line number consistency)
 		{
 			name:        "dl3027-apt-to-apt-get",

--- a/internal/rules/hadolint/dl3020.go
+++ b/internal/rules/hadolint/dl3020.go
@@ -5,10 +5,13 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 // DL3020Rule implements the DL3020 linting rule.
@@ -39,6 +42,8 @@ func (r *DL3020Rule) Metadata() rules.RuleMetadata {
 // - Tar archives (recognized by extension or explicit use case)
 // - Git repositories
 func (r *DL3020Rule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	sm := input.SourceMap()
 	var violations []rules.Violation
 
 	for _, stage := range input.Stages {
@@ -67,24 +72,91 @@ func (r *DL3020Rule) Check(input rules.LintInput) []rules.Violation {
 
 				// This is a local file/folder - should use COPY
 				loc := rules.NewLocationFromRanges(input.File, add.Location())
-				violations = append(violations, rules.NewViolation(
+				v := rules.NewViolation(
 					loc,
-					r.Metadata().Code,
+					meta.Code,
 					fmt.Sprintf(
 						"use COPY instead of ADD for local file %q; COPY is more explicit and secure",
 						src,
 					),
-					r.Metadata().DefaultSeverity,
-				).WithDocURL(r.Metadata().DocURL).WithDetail(
-					"ADD has implicit features (auto-extraction, URL fetching) that make builds less predictable. "+
+					meta.DefaultSeverity,
+				).WithDocURL(meta.DocURL).WithDetail(
+					"ADD has implicit features (auto-extraction, URL fetching) that make builds less predictable. " +
 						"Use COPY for simple file copies. Only use ADD when you need tar extraction or URL fetching.",
-				))
+				)
+
+				if fix := buildDL3020Fix(input.File, add.Location(), sm, meta); fix != nil {
+					v = v.WithSuggestedFix(fix)
+				}
+
+				violations = append(violations, v)
 				break // One violation per ADD instruction is enough
 			}
 		}
 	}
 
 	return violations
+}
+
+// buildDL3020Fix generates an auto-fix that replaces "ADD" with "COPY" on the
+// instruction's first source line. The edit targets only the 3-character keyword,
+// preserving all flags, sources, and destination unchanged.
+func buildDL3020Fix(
+	file string,
+	ranges []parser.Range,
+	sm *sourcemap.SourceMap,
+	meta rules.RuleMetadata,
+) *rules.SuggestedFix {
+	if len(ranges) == 0 {
+		return nil
+	}
+
+	startLine := ranges[0].Start.Line // 1-based
+	lineIdx := startLine - 1          // 0-based for SourceMap
+	if lineIdx < 0 || lineIdx >= sm.LineCount() {
+		return nil
+	}
+
+	sourceLine := sm.Line(lineIdx)
+
+	// Find "ADD" keyword in the source line (case-insensitive), matching BuildKit's
+	// convention where the keyword appears at or near the start of the line.
+	upper := strings.ToUpper(sourceLine)
+	addKeyword := strings.ToUpper(command.Add) // "ADD"
+	idx := strings.Index(upper, addKeyword)
+	if idx < 0 {
+		return nil
+	}
+
+	// Verify that the character after "ADD" is whitespace (space or tab) to
+	// avoid matching a word like "ADDRESS".
+	afterAdd := idx + len(addKeyword)
+	if afterAdd >= len(sourceLine) ||
+		(sourceLine[afterAdd] != ' ' && sourceLine[afterAdd] != '\t') {
+		return nil
+	}
+
+	// Preserve the original casing style: if the original keyword is all-lowercase,
+	// use "copy"; otherwise default to "COPY".
+	original := sourceLine[idx : idx+len(addKeyword)]
+	replacement := strings.ToUpper(command.Copy) // "COPY"
+	if original == strings.ToLower(original) {
+		replacement = command.Copy // "copy"
+	}
+
+	return &rules.SuggestedFix{
+		Description: "Replace ADD with COPY",
+		Safety:      rules.FixSafe,
+		Priority:    meta.FixPriority,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(
+				file,
+				startLine, idx,
+				startLine, afterAdd,
+			),
+			NewText: replacement,
+		}},
+	}
 }
 
 // isURLDL3020 checks if a source path is a URL.

--- a/internal/rules/hadolint/dl3020_test.go
+++ b/internal/rules/hadolint/dl3020_test.go
@@ -215,6 +215,101 @@ func TestIsURLDL3020(t *testing.T) {
 	}
 }
 
+func TestDL3020Rule_Fix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		dockerfile string
+		wantFix    bool
+		wantText   string // expected NewText in the first edit
+	}{
+		{
+			name: "simple local file gets fix",
+			dockerfile: `FROM ubuntu:22.04
+ADD file.txt /app/
+`,
+			wantFix:  true,
+			wantText: "COPY",
+		},
+		{
+			name: "lowercase add gets lowercase fix",
+			dockerfile: `FROM ubuntu:22.04
+add file.txt /app/
+`,
+			wantFix:  true,
+			wantText: "copy",
+		},
+		{
+			name: "ADD with flags preserves flags",
+			dockerfile: `FROM ubuntu:22.04
+ADD --chown=app:app file.txt /app/
+`,
+			wantFix:  true,
+			wantText: "COPY",
+		},
+		{
+			name: "ADD with multiple local sources",
+			dockerfile: `FROM ubuntu:22.04
+ADD file1.txt file2.txt /app/
+`,
+			wantFix:  true,
+			wantText: "COPY",
+		},
+		{
+			name:       "URL - no fix",
+			dockerfile: "FROM ubuntu:22.04\nADD https://example.com/file.txt /app/\n",
+			wantFix:    false,
+		},
+		{
+			name:       "tar archive - no fix",
+			dockerfile: "FROM ubuntu:22.04\nADD archive.tar.gz /app/\n",
+			wantFix:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := testutil.MakeLintInput(t, "Dockerfile", tt.dockerfile)
+
+			r := NewDL3020Rule()
+			violations := r.Check(input)
+
+			if !tt.wantFix {
+				// No violation or no fix expected
+				for _, v := range violations {
+					if v.SuggestedFix != nil {
+						t.Errorf("unexpected fix on violation: %s", v.Message)
+					}
+				}
+				return
+			}
+
+			if len(violations) == 0 {
+				t.Fatal("expected at least one violation")
+			}
+
+			v := violations[0]
+			if v.SuggestedFix == nil {
+				t.Fatal("expected SuggestedFix, got nil")
+			}
+
+			fix := v.SuggestedFix
+			if fix.Safety != rules.FixSafe {
+				t.Errorf("Safety = %v, want FixSafe", fix.Safety)
+			}
+
+			if len(fix.Edits) != 1 {
+				t.Fatalf("got %d edits, want 1", len(fix.Edits))
+			}
+
+			if fix.Edits[0].NewText != tt.wantText {
+				t.Errorf("NewText = %q, want %q", fix.Edits[0].NewText, tt.wantText)
+			}
+		})
+	}
+}
+
 func TestIsTarArchiveDL3020(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Add `FixSafe` autofix for `hadolint/DL3020` that replaces `ADD` with `COPY` for local file/directory sources
- The fix targets only the 3-character keyword, preserving all flags (`--chown`, `--chmod`, etc.), sources, and destination unchanged
- Preserves instruction casing (`ADD` → `COPY`, `add` → `copy`)

## Details

Replacing `ADD <local-file>` with `COPY <local-file>` is always semantically identical for non-URL, non-tar, non-heredoc sources, so this is a `FixSafe` fix applied with `--fix`.

### Files changed

| File | Change |
|------|--------|
| `internal/rules/hadolint/dl3020.go` | Add `buildDL3020Fix()` function |
| `internal/rules/hadolint/dl3020_test.go` | Add `TestDL3020Rule_Fix` (6 cases) |
| `internal/integration/fix_cases_test.go` | Add 3 integration test cases |
| `internal/integration/__snapshots__/` | 3 new snapshot files |
| `docs/rules/hadolint/DL3020.md` | Document autofix |
| `RULES.md` | Add 🔧 indicator |

## Test plan

- [x] Unit tests: `TestDL3020Rule_Fix` — verifies fix generation, casing, safety level, no-fix for URLs/tars
- [x] Integration tests: `TestFix/dl3020-*` — end-to-end fix with snapshot verification
- [x] Existing `TestDL3020Rule_Check` still passes (no regressions)
- [x] `make lint` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)