### PR TITLE
feat: enable semantic highlighting in vscode

### DIFF
--- a/_integrations/vscode-tally/README.md
+++ b/_integrations/vscode-tally/README.md
@@ -9,6 +9,7 @@ Lint, format, and auto-fix **Dockerfiles** and **Containerfiles** in VS Code usi
 - **Production-grade**: 92% code coverage and 2,900+ Go tests executed in CI.
 - **Quick Fixes** and a one-shot **Fix All** command to apply auto-fixable improvements.
 - **Formatter support** (format on save) using the same engine as `tally lint --fix`.
+- **Semantic highlighting** for Dockerfile structure and embedded shell snippets via the tally LSP server.
 - **Config-aware**: respects `.tally.toml` / `tally.toml` discovery in your repo.
 - **No daemon**: runs locally without Docker Desktop or a Docker daemon.
 - **Zero setup**: Marketplace builds bundle the `tally` binary for your platform (you can also bring your own).
@@ -38,6 +39,9 @@ Lint, format, and auto-fix **Dockerfiles** and **Containerfiles** in VS Code usi
 - `tally.configurationPreference`: how to merge editor settings with filesystem config (`editorFirst`, `filesystemFirst`, `editorOnly`).
 - `tally.fixUnsafe`: allow "Fix all" to apply unsafe fixes (includes AI AutoFix, if configured).
 - `tally.trace.server`: LSP protocol trace level (`off`, `messages`, `verbose`).
+
+The extension enables `editor.semanticHighlighting.enabled` by default for the `dockerfile` language so the server-provided semantic tokens are shown
+consistently across themes.
 
 ## Python projects
 

--- a/_integrations/vscode-tally/package.json
+++ b/_integrations/vscode-tally/package.json
@@ -76,6 +76,11 @@
         "title": "Tally: Configure as default formatter for Dockerfile"
       }
     ],
+    "configurationDefaults": {
+      "[dockerfile]": {
+        "editor.semanticHighlighting.enabled": true
+      }
+    },
     "configuration": {
       "title": "Tally",
       "properties": {
@@ -135,7 +140,68 @@
           "description": "Trace communication between VS Code and the Tally language server."
         }
       }
-    }
+    },
+    "semanticTokenScopes": [
+      {
+        "language": "dockerfile",
+        "scopes": {
+          "keyword": [
+            "keyword.control.dockerfile",
+            "keyword.control"
+          ],
+          "comment.documentation": [
+            "comment.line.number-sign.dockerfile",
+            "comment.line.number-sign",
+            "comment"
+          ],
+          "comment": [
+            "comment.line.number-sign.dockerfile",
+            "comment.line.number-sign",
+            "comment"
+          ],
+          "string": [
+            "string.quoted.double.dockerfile",
+            "string.quoted.single.dockerfile",
+            "string"
+          ],
+          "number": [
+            "constant.numeric.dockerfile",
+            "constant.numeric"
+          ],
+          "operator": [
+            "keyword.operator.dockerfile",
+            "keyword.operator"
+          ],
+          "variable": [
+            "variable.other.readwrite.dockerfile",
+            "variable.other.readwrite",
+            "variable"
+          ],
+          "variable.declaration": [
+            "variable.other.constant.dockerfile",
+            "variable.other.constant",
+            "variable"
+          ],
+          "parameter": [
+            "variable.parameter.dockerfile",
+            "variable.parameter"
+          ],
+          "property": [
+            "variable.other.property.dockerfile",
+            "variable.other.property"
+          ],
+          "property.readonly": [
+            "variable.other.constant.property.dockerfile",
+            "variable.other.constant.property"
+          ],
+          "function": [
+            "entity.name.function.dockerfile",
+            "entity.name.function",
+            "support.function"
+          ]
+        }
+      }
+    ]
   },
   "activationEvents": [
     "onLanguage:dockerfile",


### PR DESCRIPTION
## Summary
- enable semantic highlighting by default for the dockerfile language in the VS Code extension
- add Dockerfile semantic token scope mappings so server-provided semantic tokens theme well in VS Code
- document semantic highlighting behavior in the VS Code extension README

## Validation
- node -e "JSON.parse(require('node:fs').readFileSync('_integrations/vscode-tally/package.json','utf8'))"
- bun run compile
- bunx @vscode/vsce package --no-dependencies
- GOSUMDB=sum.golang.org GOEXPERIMENT=jsonv2 make test
- GOSUMDB=sum.golang.org GOEXPERIMENT=jsonv2 make deadcode