### PR TITLE
ci: add GitHub Artifact Attestations to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
           cat tally_checksums.txt
       - name: Attest release artifacts
         if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             dist/tally_*.tar.gz
@@ -404,6 +404,11 @@ jobs:
         with:
           name: vsix-${{ matrix.vscode_target }}
           path: _integrations/vscode-tally/tally-${{ matrix.vscode_target }}.vsix
+      - name: Attest VSIX artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: _integrations/vscode-tally/tally-${{ matrix.vscode_target }}.vsix
       - name: Upload VSIX to GitHub release
         if: github.event_name != 'pull_request'
         env:
@@ -506,6 +511,11 @@ jobs:
         with:
           name: intellij-plugin-zip
           path: ${{ steps.intellij_zip.outputs.zip_path }}
+      - name: Attest IntelliJ plugin artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ steps.intellij_zip.outputs.zip_path }}
       - name: Upload IntelliJ plugin to GitHub release
         if: github.event_name != 'pull_request'
         env:


### PR DESCRIPTION
## Summary

- Add `actions/attest-build-provenance@v2` step to generate build provenance attestations for all release artifacts (`.tar.gz`, `.zip`, `.exe`, checksums)
- Add `attestations: write` permission required by the attestation action
- Automatically append a "Verifying GitHub Artifact Attestations" section to the release body with `gh attestation verify` instructions
- When the release already exists (e.g. re-run), the attestation section is appended only if not already present

After this change, users can verify downloaded artifacts:
```shell
gh attestation verify <artifact> --repo wharflab/tally
```

Inspired by [uv's release attestation setup](https://github.com/astral-sh/uv/releases/tag/0.10.10).

## Test plan

- [ ] Trigger a PR dry-run of the release workflow — attestation step is skipped (gated on `github.event_name != 'pull_request'`), no regressions in existing steps
- [ ] Trigger a real release and verify attestation objects are created on the release page
- [ ] Verify the release body includes the attestation verification instructions
- [ ] Run `gh attestation verify` against a downloaded artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added GitHub Artifact Attestations for release artifacts, enabling provenance verification for archives, executables, checksums, VSIX and IntelliJ plugin packages.
  * Release notes now include attestation verification links and instructions.
  * When releases are created or updated, attestation info is appended only if not already present, preserving existing release notes and avoiding duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->