### PR TITLE
fix: build Linux releases in Amazon Linux 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,34 @@ jobs:
               go build -buildvcs=false -tags "${BUILD_TAGS}" -trimpath -ldflags "${LDFLAGS}" -o "${DIST_DIR}/${{ matrix.binary_name }}" .
               chmod 755 "${DIST_DIR}/${{ matrix.binary_name }}"
             '
+      - name: Smoke test Linux binary on host
+        if: matrix.runner_os == 'Linux'
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ env.RELEASE_VERSION }}
+          EXPECTED_GOOS: ${{ matrix.goos }}
+          EXPECTED_GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          BINARY="dist/tally_${{ matrix.goos }}_${{ matrix.goarch }}_${{ matrix.variant }}/${{ matrix.binary_name }}"
+          VERSION_JSON_FILE="$(mktemp)"
+          "${BINARY}" version --json > "${VERSION_JSON_FILE}"
+          cat "${VERSION_JSON_FILE}"
+          python - "${VERSION_JSON_FILE}" <<'PY'
+          import json
+          import os
+          import sys
+
+          version_json_path = sys.argv[1]
+          expected_version = os.environ["EXPECTED_VERSION"].removeprefix("v")
+
+          with open(version_json_path, encoding="utf-8") as fh:
+              payload = json.load(fh)
+
+          assert payload["version"] == expected_version, payload
+          assert payload["platform"]["os"] == os.environ["EXPECTED_GOOS"], payload
+          assert payload["platform"]["arch"] == os.environ["EXPECTED_GOARCH"], payload
+          PY
       - name: Build binary
         if: matrix.runner_os == 'macOS'
         shell: bash

--- a/packaging/pypi/hatch_build.py
+++ b/packaging/pypi/hatch_build.py
@@ -26,8 +26,8 @@ ARCH_MAPPING = {
 
 
 PEP425_TAGS = {
-    ("linux", "x86_64"): "py3-none-manylinux_2_17_x86_64",
-    ("linux", "arm64"): "py3-none-manylinux_2_17_aarch64",
+    ("linux", "x86_64"): "py3-none-manylinux_2_26_x86_64",
+    ("linux", "arm64"): "py3-none-manylinux_2_26_aarch64",
     ("darwin", "x86_64"): "py3-none-macosx_10_15_x86_64",
     ("darwin", "arm64"): "py3-none-macosx_11_0_arm64",
     ("windows", "x86_64"): "py3-none-win_amd64",

--- a/packaging/pypi/test_hatch_build.py
+++ b/packaging/pypi/test_hatch_build.py
@@ -36,10 +36,20 @@ if "hatchling.builders.hooks.plugin.interface" not in sys.modules:
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-from hatch_build import CustomBuildHook
+from hatch_build import CustomBuildHook, PEP425_TAGS
 
 
 class CustomBuildHookTest(unittest.TestCase):
+    def test_linux_wheel_tags_match_glibc_baseline(self):
+        self.assertEqual(
+            PEP425_TAGS[("linux", "x86_64")],
+            "py3-none-manylinux_2_26_x86_64",
+        )
+        self.assertEqual(
+            PEP425_TAGS[("linux", "arm64")],
+            "py3-none-manylinux_2_26_aarch64",
+        )
+
     def test_stage_target_binary_replaces_previous_target(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir) / "repo"


### PR DESCRIPTION
## Summary
Build Linux release binaries inside `public.ecr.aws/amazonlinux/amazonlinux:2` so the shipped GNU/Linux artifacts target an older glibc baseline that runs on Amazon Linux 2.

## Changes
- run Linux release builds in an Amazon Linux 2 container from AWS Public ECR
- keep macOS and Windows builds on their existing native runners
- skip `actions/setup-go` on Linux because Go is installed inside the build container
- keep the existing VS Code extension versioning change, but restore the missing `CLEAN_VERSION` assignment so that step still runs

## Why
The current Linux release artifacts are built on newer Ubuntu runners with `CGO_ENABLED=1`, which raises the glibc floor and breaks execution on Amazon Linux 2.

## Validation
- verified locally that `amazonlinux:2` has glibc 2.26 and can get through a real `CGO_ENABLED=1 go build` for `tally`
- verified the workflow YAML parses cleanly
- verified `manylinux2014_x86_64` is not a drop-in fit for this repo because the current tree-sitter CGO link step fails there


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved Linux builds into containerized, per-architecture workflows with dedicated toolchain archives and container images; made the build step Linux-only and enabled CGO builds inside containers.
  * Conditionalized Go setup to skip containerized Linux runs.
  * Switched VS Code extension and related artifacts to npm-driven versioning from tags.
  * Reworked publishing sequencing, artifact paths, and packaging flows across targets.

* **Refactor**
  * Simplified steps to run in target directories, reduced manual file edits, and tightened workflow conditionals and shell handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->