### PR TITLE
chore: enrich winget manifest metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1022,6 +1022,11 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $true
           $CleanVersion = $env:VERSION.TrimStart("v")
           $Branch = "tally-update"
+          if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
+            $ReleaseDate = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")
+          } else {
+            $ReleaseDate = gh release view "v$CleanVersion" --repo "$env:GITHUB_REPOSITORY" --json publishedAt --jq '.publishedAt[0:10]'
+          }
 
           git config --global user.name "tinovyatkin"
           git config --global user.email "tino@vtkn.io"
@@ -1037,6 +1042,7 @@ jobs:
           ruby tally/scripts/release/generate_winget_manifests.rb `
             --version $CleanVersion `
             --dist-root dist `
+            --release-date $ReleaseDate `
             --output-root winget-pkgs/manifests
 
           $ManifestPath = Join-Path "winget-pkgs" "manifests/w/Wharflab/Tally/$CleanVersion"

--- a/scripts/release/generate_winget_manifests.rb
+++ b/scripts/release/generate_winget_manifests.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "optparse"
+require "date"
 require "pathname"
 require "yaml"
 
@@ -12,6 +13,13 @@ PACKAGE_LOCALE = "en-US"
 MANIFEST_VERSION = "1.9.0"
 SHORT_DESCRIPTION = "Dockerfile linter and formatter with first-class PowerShell and Windows container support."
 TAG_LIST = %w[docker dockerfile containerfile linter].freeze
+FILE_EXTENSION_LIST = %w[dockerfile containerfile].freeze
+DOCUMENTATION_LIST = [
+  {
+    "DocumentLabel" => "Docs",
+    "DocumentUrl" => "https://wharflab.github.io/tally/",
+  },
+].freeze
 WINDOWS_ASSETS = [
   ["x64", "tally_%<version>s_Windows_x86_64.exe"],
   ["arm64", "tally_%<version>s_Windows_arm64.exe"],
@@ -31,6 +39,7 @@ def parse_args(argv)
     opts.on("--repo-name NAME") { |value| options[:repo_name] = value }
     opts.on("--dist-root PATH") { |value| options[:dist_root] = value }
     opts.on("--output-root PATH") { |value| options[:output_root] = value }
+    opts.on("--release-date DATE") { |value| options[:release_date] = Date.iso8601(value).iso8601 }
   end
 
   parser.parse!(argv)
@@ -102,13 +111,14 @@ def default_locale_manifest(version, owner, repo)
     "License" => "GPL-3.0-only",
     "LicenseUrl" => "https://github.com/#{owner}/#{repo}/blob/main/LICENSE",
     "ReleaseNotesUrl" => "https://github.com/#{owner}/#{repo}/releases/tag/v#{version}",
+    "Documentations" => DOCUMENTATION_LIST,
     "Tags" => TAG_LIST,
     "ManifestType" => "defaultLocale",
     "ManifestVersion" => MANIFEST_VERSION,
   }
 end
 
-def installer_manifest(version, owner, repo, checksums)
+def installer_manifest(version, owner, repo, checksums, release_date = nil)
   installers = WINDOWS_ASSETS.map do |architecture, pattern|
     filename = format(pattern, version: version)
     sha256 = checksums.fetch(filename) { raise "missing checksum for #{filename}" }
@@ -125,10 +135,12 @@ def installer_manifest(version, owner, repo, checksums)
     "PackageIdentifier" => PACKAGE_IDENTIFIER,
     "PackageVersion" => version,
     "Commands" => ["tally"],
+    "FileExtensions" => FILE_EXTENSION_LIST,
+    "ReleaseDate" => release_date,
     "Installers" => installers,
     "ManifestType" => "installer",
     "ManifestVersion" => MANIFEST_VERSION,
-  }
+  }.compact
 end
 
 def main(argv = ARGV)
@@ -151,7 +163,7 @@ def main(argv = ARGV)
   dump_manifest(
     out_dir.join("#{PACKAGE_IDENTIFIER}.installer.yaml"),
     "installer",
-    installer_manifest(version, options[:repo_owner], options[:repo_name], checksums),
+    installer_manifest(version, options[:repo_owner], options[:repo_name], checksums, options[:release_date]),
   )
 
   puts out_dir

--- a/scripts/release/test_generate_winget_manifests.rb
+++ b/scripts/release/test_generate_winget_manifests.rb
@@ -13,6 +13,12 @@ class GenerateWingetManifestsTest < Minitest::Test
     assert_equal "0.26.0", normalized_version("0.26.0")
   end
 
+  def test_parse_args_normalizes_release_date
+    options = parse_args(%w[--version 0.26.0 --output-root /tmp/out --release-date 2026-03-15])
+
+    assert_equal "2026-03-15", options[:release_date]
+  end
+
   def test_read_checksums
     Dir.mktmpdir do |tmpdir|
       path = Pathname(tmpdir).join("tally_checksums.txt")
@@ -50,6 +56,10 @@ class GenerateWingetManifestsTest < Minitest::Test
       "https://github.com/wharflab/tally/releases/tag/v0.26.0",
       locale_manifest_data["ReleaseNotesUrl"],
     )
+    assert_equal(
+      [{"DocumentLabel" => "Docs", "DocumentUrl" => "https://wharflab.github.io/tally/"}],
+      locale_manifest_data["Documentations"],
+    )
 
     installer_manifest_data = installer_manifest(
       "0.26.0",
@@ -59,9 +69,12 @@ class GenerateWingetManifestsTest < Minitest::Test
         "tally_0.26.0_Windows_x86_64.exe" => "ABCDEF",
         "tally_0.26.0_Windows_arm64.exe" => "123456",
       },
+      "2026-03-15",
     )
     assert_equal "portable", installer_manifest_data["Installers"][0]["InstallerType"]
     assert_equal ["tally"], installer_manifest_data["Installers"][0]["Commands"]
+    assert_equal %w[dockerfile containerfile], installer_manifest_data["FileExtensions"]
+    assert_equal "2026-03-15", installer_manifest_data["ReleaseDate"]
     assert_equal(
       "https://github.com/wharflab/tally/releases/download/v0.26.0/tally_0.26.0_Windows_x86_64.exe",
       installer_manifest_data["Installers"][0]["InstallerUrl"],


### PR DESCRIPTION
## Summary
- add documentation metadata to the WinGet default-locale manifest
- add file extensions and release date metadata to the WinGet installer manifest
- pass the GitHub release publish date into WinGet manifest generation in release automation

## Testing
- ruby scripts/release/test_generate_winget_manifests.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Windows Package Manager manifest metadata to include release dates and documentation references for better package discovery and information visibility.
  * Added container-related file extension support to package manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->