### PR TITLE
fix: treat stdin closure as clean EOF in LSP stdio transport

### DIFF
--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json/jsontext"
 	"errors"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"strconv"
@@ -563,8 +564,14 @@ func (stdioDialer) Dial(_ context.Context) (io.ReadWriteCloser, error) {
 	pr, pw := io.Pipe()
 	go func() {
 		_, err := io.Copy(pw, os.Stdin)
-		// Propagate the exact error (or clean EOF) to unblock jsonrpc2 readIncoming.
-		_ = pw.CloseWithError(err)
+		// Treat stdin closure as clean EOF, not an error.
+		// When the LSP client stops, it closes stdin, which should trigger
+		// a graceful shutdown without logging errors.
+		if err == nil || errors.Is(err, io.EOF) || errors.Is(err, fs.ErrClosed) || errors.Is(err, io.ErrClosedPipe) {
+			_ = pw.Close() // Clean close triggers EOF on read side
+		} else {
+			_ = pw.CloseWithError(err) // Propagate actual I/O errors
+		}
 	}()
 	return &stdioRWC{pr: pr, pw: pw}, nil
 }


### PR DESCRIPTION
## Summary
Fixes LSP server crash during shutdown/restart with "failed reading header line: io: read/write on closed pipe" errors.

## Problem
When the VSCode extension restarts or stops the LSP server, it closes stdin to signal shutdown. The `stdioDialer` was propagating this closure as an error through `pw.CloseWithError(err)`, causing the JSON-RPC reader to see error messages like:

```
Error: failed reading header line: io: read/write on closed pipe
Server process exited with code 1.
```

This resulted in:
- "Stopping server timed out" warnings
- Non-zero exit codes during normal shutdown
- Confusing error logs in the VSCode output

## Solution
Distinguish between expected stdin closure (during normal shutdown) and actual I/O errors:
- **Expected closures** (stdin close during shutdown) → Clean EOF via `pw.Close()`
- **Real I/O errors** → Propagated via `pw.CloseWithError(err)`

Uses idiomatic Go error checking with `errors.Is()` for:
- `io.EOF`: normal end of file
- `fs.ErrClosed`: closed file descriptor  
- `io.ErrClosedPipe`: closed pipe

## Impact
The LSP server now shuts down gracefully without error logs when the client closes the connection. This is especially noticeable during:
- VSCode extension restarts (e.g., after upgrades)
- Manual server restarts via "Tally: Restart Server" command
- Workspace configuration changes that trigger restart

## Testing
- ✅ All Go LSP server tests pass: `GOEXPERIMENT=jsonv2 go test ./internal/lspserver/... -v`
- ✅ Server shuts down cleanly without error logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during connection shutdown to distinguish between normal termination and actual I/O failures, reducing spurious error reporting during disconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->