### PR TITLE
chore(vscode): downgrade minimum VSCode version to 1.106

### DIFF
--- a/_integrations/vscode-tally/bun.lock
+++ b/_integrations/vscode-tally/bun.lock
@@ -12,7 +12,7 @@
         "@types/bun": "1.3.10",
         "@types/node": "25.5.0",
         "@types/semver": "7.7.1",
-        "@types/vscode": "1.110.0",
+        "@types/vscode": "1.106.0",
         "@typescript/native-preview": "7.0.0-dev.20260317.1",
         "@vscode/test-electron": "2.5.2",
         "@vscode/vsce": "3.7.1",
@@ -234,7 +234,7 @@
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
-    "@types/vscode": ["@types/vscode@1.110.0", "", {}, "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA=="],
+    "@types/vscode": ["@types/vscode@1.106.0", "", {}, "sha512-88oUcEl9Wmlyt64pbvjLzyyFuFuPotdjwy+P+5ggg3DyTJSMWJD3ShX2ppya5mqrAYTKEhcaJBerdc5JTeb32w=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260317.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260317.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260317.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260317.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260317.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260317.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260317.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260317.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-HmYNuhDoN9OHfsSHuSRvYJobHAHDVubLvSGSrjfNL6C34fVlPkPDi+iA53LcN1pVX5J30kajcKC7Snm13xmuKA=="],
 

--- a/_integrations/vscode-tally/package.json
+++ b/_integrations/vscode-tally/package.json
@@ -44,7 +44,7 @@
     "@types/bun": "1.3.10",
     "@types/node": "25.5.0",
     "@types/semver": "7.7.1",
-    "@types/vscode": "1.110.0",
+    "@types/vscode": "1.106.0",
     "@typescript/native-preview": "7.0.0-dev.20260317.1",
     "@vscode/test-electron": "2.5.2",
     "@vscode/vsce": "3.7.1",
@@ -248,6 +248,6 @@
   ],
   "icon": "assets/logo.png",
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.106.0"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -73,7 +73,7 @@
     {
       "matchFileNames": ["_integrations/vscode-tally/package.json", "_integrations/vscode-tally/bun.lock"],
       "matchDepNames": ["@types/vscode"],
-      "automerge": false
+      "enabled": false
     },
     {
       "matchManagers": ["dockerfile"],


### PR DESCRIPTION
## Summary
- Downgrade `engines.vscode` from `^1.110.0` back to `^1.106.0` (accidentally bumped by Renovate), restoring compatibility with VSCode forks like AWS Kiro
- Downgrade `@types/vscode` from `1.110.0` to `1.106.0` to match the minimum engine version
- Disable Renovate upgrades for `@types/vscode` entirely (`enabled: false` instead of just `automerge: false`)

## Test plan
- [x] `bun install` succeeds with updated lockfile
- [ ] Extension loads in VSCode 1.106+
- [ ] Extension loads in AWS Kiro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code extension compatibility version constraints and TypeScript type dependencies.
  * Modified dependency management automation configuration for improved update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->