### PR TITLE
fix: default shell variant to Bash instead of POSIX

### DIFF
--- a/internal/facts/facts.go
+++ b/internal/facts/facts.go
@@ -281,6 +281,13 @@ func initialStageShell(
 		return newShellFacts(semantic.DefaultWindowsShell())
 	}
 
+	// Use the semantic model's ShellSetting when available — it already
+	// accounts for distro-aware variant refinement (e.g. VariantBash for
+	// most Linux distros, VariantPOSIX for Alpine/Debian/Ubuntu).
+	if semInfo != nil {
+		return newShellFactsWithVariant(semInfo.ShellSetting.Shell, semInfo.ShellSetting.Variant)
+	}
+
 	defaultShell := append([]string(nil), semantic.DefaultShell...)
 	return newShellFacts(defaultShell)
 }
@@ -305,12 +312,16 @@ func activeShellDirective(stage *instructions.Stage, shellDirectives []ShellDire
 }
 
 func newShellFacts(shellCmd []string) ShellFacts {
+	variant := shell.VariantFromShellCmd(shellCmd)
+	return newShellFactsWithVariant(shellCmd, variant)
+}
+
+func newShellFactsWithVariant(shellCmd []string, variant shell.Variant) ShellFacts {
 	cmd := append([]string(nil), shellCmd...)
 	var executable string
 	if len(cmd) > 0 {
 		executable = cmd[0]
 	}
-	variant := shell.VariantFromShellCmd(cmd)
 	return ShellFacts{
 		Command:              cmd,
 		Variant:              variant,

--- a/internal/integration/__snapshots__/TestLint_invalid-json-form-shell-test_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_invalid-json-form-shell-test_1.snap.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 0,
+    "info": 0,
+    "style": 0,
+    "total": 0,
+    "warnings": 0
+  }
+}

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -264,6 +264,12 @@ func lintCases(t *testing.T) []lintCase {
 			args:     append([]string{"--format", "json"}, mustSelectRules("tally/invalid-json-form")...),
 			wantExit: 1,
 		},
+		// Shell test expression [ -z "$VAR" ] should not be flagged.
+		{
+			name: "invalid-json-form-shell-test",
+			dir:  "invalid-json-form-shell-test",
+			args: append([]string{"--format", "json"}, mustSelectRules("tally/invalid-json-form")...),
+		},
 		// Cross-rule: invalid JSON triggers both tally/invalid-json-form and
 		// buildkit/JSONArgsRecommended (BuildKit falls back to shell-form).
 		{

--- a/internal/integration/testdata/invalid-json-form-shell-test/Dockerfile
+++ b/internal/integration/testdata/invalid-json-form-shell-test/Dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+ARG DEPENDENCIES
+RUN --mount=type=cache,target=/root/.cache/pip [ -z "$DEPENDENCIES" ] || { pip install --upgrade pip && pip install $(base64 -d <<< $DEPENDENCIES); }
+
+COPY ./ ./

--- a/internal/semantic/builder.go
+++ b/internal/semantic/builder.go
@@ -119,6 +119,16 @@ func (b *Builder) Build() *Model {
 			}
 		}
 
+		// Refine the default shell variant for Linux distros whose /bin/sh
+		// is a strict POSIX shell (dash or ash) rather than bash.
+		// The default is VariantBash (correct for most distros); narrow to
+		// VariantPOSIX only when the base image is a known dash/ash distro.
+		if info.ShellSetting.Source == ShellSourceDefault &&
+			info.ShellSetting.Variant == shell.VariantBash &&
+			isPOSIXShellDistro(stage.BaseName) {
+			info.ShellSetting.Variant = shell.VariantPOSIX
+		}
+
 		// Seed the environment used for undefined-var analysis.
 		var stageEnv *fromEnv
 		switch {

--- a/internal/semantic/builder_test.go
+++ b/internal/semantic/builder_test.go
@@ -157,7 +157,7 @@ func TestProcessShellCommandEmptyShellDoesNotPanic(t *testing.T) {
 		BaseImageOS: BaseImageOSUnknown,
 		ShellSetting: ShellSetting{
 			Shell:   DefaultShell,
-			Variant: shell.VariantPOSIX,
+			Variant: shell.VariantBash,
 			Source:  ShellSourceDefault,
 			Line:    -1,
 		},

--- a/internal/semantic/stage_info.go
+++ b/internal/semantic/stage_info.go
@@ -378,6 +378,27 @@ func isLinuxImageName(lower string) bool {
 	return false
 }
 
+// isPOSIXShellDistro reports whether the base image name belongs to a Linux
+// distro whose /bin/sh is a strict POSIX shell (dash or busybox ash) rather
+// than bash. This is only Debian/Ubuntu (dash), Alpine (ash), busybox, and
+// distroless/wolfi/chainguard (Alpine-derived, ash).
+//
+// On all other major Linux distros (RHEL, CentOS, Fedora, Amazon Linux, Arch,
+// openSUSE, Oracle Linux, Rocky, Alma, …) /bin/sh is a symlink to bash.
+func isPOSIXShellDistro(baseName string) bool {
+	lower := strings.ToLower(baseName)
+	_, repoPath, _ := parseImageRef(lower)
+	name := path.Base(repoPath)
+
+	switch name {
+	case "alpine", "debian", "ubuntu",
+		"busybox",
+		"distroless", "chainguard", "wolfi":
+		return true
+	}
+	return false
+}
+
 func inferStageOSHeuristically(stage *instructions.Stage) BaseImageOS {
 	if stage == nil {
 		return BaseImageOSUnknown
@@ -570,8 +591,15 @@ func newStageInfo(index int, stage *instructions.Stage, isLast bool) *StageInfo 
 		Index: index,
 		Stage: stage,
 		ShellSetting: ShellSetting{
-			Shell:   defaultShell,
-			Variant: shell.VariantFromShellCmd(defaultShell),
+			Shell: defaultShell,
+			// Docker defaults to /bin/sh -c, but on most Linux distros
+			// /bin/sh is a symlink to bash (RHEL, CentOS, Fedora, Amazon
+			// Linux, Arch, openSUSE, Oracle Linux, Rocky, Alma, …).
+			// Only Debian/Ubuntu (dash) and Alpine (ash) use a strict
+			// POSIX sh. Default to Bash; the builder refines to
+			// VariantPOSIX for known dash/ash distros after base-image
+			// detection.
+			Variant: shell.VariantBash,
 			Source:  ShellSourceDefault,
 			Line:    -1,
 		},


### PR DESCRIPTION
## Summary

- **Default shell variant → `VariantBash`** instead of `VariantPOSIX`. Docker defaults to `/bin/sh -c`, but on most Linux distros `/bin/sh` is a symlink to bash (RHEL, CentOS, Fedora, Amazon Linux, Arch, openSUSE, Rocky, Alma, Oracle Linux, …). Only Debian/Ubuntu (dash) and Alpine (ash) use a strict POSIX sh.
- **Distro-aware refinement**: added `isPOSIXShellDistro()` to narrow the variant back to `VariantPOSIX` for Alpine, Debian, Ubuntu, busybox, distroless, chainguard, and wolfi.
- **Facts layer alignment**: `initialStageShell` now delegates to the semantic model's `ShellSetting` (single source of truth) instead of re-deriving the variant from the shell path.
- **Integration test**: new fixture with `RUN --mount=... [ -z "$VAR" ] || { ... <<< ... }` on `public.ecr.aws/lambda/python:3.12` — verifies bash here-strings on non-Alpine/Debian images are not flagged by `tally/invalid-json-form`.

## Motivation

`tally/invalid-json-form` produced a false positive on:
```dockerfile
FROM public.ecr.aws/lambda/python:3.12
RUN --mount=type=cache,target=/root/.cache/pip [ -z "$DEPENDENCIES" ] || { pip install --upgrade pip && pip install $(base64 -d <<< $DEPENDENCIES); }
```

The `<<<` here-string is valid bash but not valid POSIX sh. With the old default of `VariantPOSIX`, the POSIX parser failed on `<<<`, and `posixLooksLikeJSON` incorrectly concluded the `[` was a JSON exec-form attempt.

The image's registry metadata has no `Shell` field set (most images don't), and `/bin/sh` on Amazon Linux 2023 is a symlink to bash — which can't be inferred from OCI metadata. The correct fix is to default to `VariantBash` since that matches reality for the majority of Linux distros.

## Test plan

- [x] Unit tests: `internal/semantic/`, `internal/shell/`, `internal/facts/`, `internal/rules/tally/` — all pass
- [x] Integration tests: all 200+ cases pass, including the new `invalid-json-form-shell-test` fixture (0 violations)
- [x] Existing Alpine/Debian-based fixtures (e.g. `TestShellVariantAtLineTracksTransitions` with `FROM alpine:3.18`) correctly get `VariantPOSIX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell variant detection based on base image distro (Alpine, Debian, Ubuntu, etc.) for more accurate linting results.
  * Fixed handling of shell test expressions in Dockerfiles to prevent incorrect linting flags.

* **Tests**
  * Added integration test cases to validate shell variant detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->