### PR TITLE
ci: add Windows smoke test and ShellCheck version assertion to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,7 @@ jobs:
           assert payload["version"] == expected_version, payload
           assert payload["platform"]["os"] == os.environ["EXPECTED_GOOS"], payload
           assert payload["platform"]["arch"] == os.environ["EXPECTED_GOARCH"], payload
+          assert payload.get("shellcheckVersion"), f"shellcheckVersion missing or empty: {payload}"
           PY
       - name: Build macOS binary
         if: matrix.runner_os == 'macOS'
@@ -244,6 +245,32 @@ jobs:
           export GOARCH="${{ matrix.goarch }}"
           LDFLAGS="-s -w -X github.com/wharflab/tally/internal/version.version=${CLEAN_VERSION} -X github.com/wharflab/tally/internal/version.commit=${GITHUB_SHA}"
           go build -tags "${BUILD_TAGS}" -trimpath -ldflags "${LDFLAGS}" -o "${DIST_DIR}/${{ matrix.binary_name }}" .
+      - name: Smoke test Windows binary
+        if: matrix.runner_os == 'Windows'
+        shell: pwsh
+        env:
+          EXPECTED_VERSION: ${{ env.RELEASE_VERSION }}
+          EXPECTED_GOOS: ${{ matrix.goos }}
+          EXPECTED_GOARCH: ${{ matrix.goarch }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $binary = "dist/tally_${{ matrix.goos }}_${{ matrix.goarch }}_${{ matrix.variant }}/${{ matrix.binary_name }}"
+          $versionJson = & $binary version --json | Out-String
+          Write-Host $versionJson
+          $payload = $versionJson | ConvertFrom-Json
+          $expectedVersion = $env:EXPECTED_VERSION -replace '^v', ''
+          if ($payload.version -ne $expectedVersion) {
+            throw "version mismatch: expected=$expectedVersion actual=$($payload.version)"
+          }
+          if ($payload.platform.os -ne $env:EXPECTED_GOOS) {
+            throw "os mismatch: expected=$($env:EXPECTED_GOOS) actual=$($payload.platform.os)"
+          }
+          if ($payload.platform.arch -ne $env:EXPECTED_GOARCH) {
+            throw "arch mismatch: expected=$($env:EXPECTED_GOARCH) actual=$($payload.platform.arch)"
+          }
+          if (-not $payload.shellcheckVersion) {
+            throw "shellcheckVersion missing or empty: $versionJson"
+          }
       - name: Import macOS Code Signing Certificate
         if: matrix.goos == 'darwin'
         uses: apple-actions/import-codesign-certs@v6


### PR DESCRIPTION
## Summary

- Add a PowerShell smoke test for Windows release builds that runs `tally version --json` and validates `version`, `platform.os`, `platform.arch`, and `shellcheckVersion` fields
- Add `shellcheckVersion` assertion to the existing Linux smoke test to catch builds where the embedded ShellCheck WASM module is missing or broken

## Test plan

- [ ] Verify the release workflow dry-run passes on a PR (Linux + Windows smoke tests both execute)
- [ ] Confirm `shellcheckVersion` is present in `version --json` output on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow validation with improved binary verification checks across Linux, macOS, and Windows platforms to ensure release quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->