### PR TITLE
fix: skip WorkdirRelativePath for variable/ARG paths

### DIFF
--- a/internal/rules/buildkit/workdir_relative_path.go
+++ b/internal/rules/buildkit/workdir_relative_path.go
@@ -70,7 +70,8 @@ func findRelativeWorkdirViolations(
 				continue
 			}
 
-			if !hasWorkdir[stageIdx] && !system.IsAbs(workdir.Path, platformOS) {
+			if !hasWorkdir[stageIdx] && !system.IsAbs(workdir.Path, platformOS) &&
+				!strings.HasPrefix(workdir.Path, "$") {
 				loc := rules.NewLocationFromRanges(file, workdir.Location())
 				v := rules.NewViolation(
 					loc,
@@ -211,7 +212,8 @@ func (h *workdirRelPathHandler) refineStageViolations(stageIdx int, baseDir stri
 			continue
 		}
 
-		if !workdirSet && !system.IsAbs(workdir.Path, platformOS) {
+		if !workdirSet && !system.IsAbs(workdir.Path, platformOS) &&
+			!strings.HasPrefix(workdir.Path, "$") {
 			resolvedPath, err := system.NormalizeWorkdir(baseDir, workdir.Path, platformOS)
 			if err != nil {
 				break // can't resolve — skip the fix

--- a/internal/rules/buildkit/workdir_relative_path_test.go
+++ b/internal/rules/buildkit/workdir_relative_path_test.go
@@ -109,6 +109,43 @@ func TestWorkdirRelativePathRule_Check_MultipleRelativeBeforeAbsolute(t *testing
 	}
 }
 
+func TestWorkdirRelativePathRule_Check_VariablePath(t *testing.T) {
+	t.Parallel()
+	r := NewWorkdirRelativePathRule()
+
+	tests := []struct {
+		name           string
+		path           string
+		wantViolations int
+	}{
+		{"bare variable", "${FUNCTION_DIR}", 0},
+		{"variable with suffix", "${SOME_FOO}/the/suffix", 0},
+		{"dollar without braces", "$APP_DIR", 0},
+		{"relative literal", "app", 1},
+		{"absolute with variable", "/app/${SUBDIR}", 0}, // absolute path
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := rules.LintInput{
+				File: "Dockerfile",
+				Stages: []instructions.Stage{
+					{
+						Commands: []instructions.Command{
+							&instructions.WorkdirCommand{Path: tt.path},
+						},
+					},
+				},
+			}
+			violations := r.Check(input)
+			if len(violations) != tt.wantViolations {
+				t.Errorf("path %q: got %d violations, want %d", tt.path, len(violations), tt.wantViolations)
+			}
+		})
+	}
+}
+
 func TestWorkdirRelativePathRule_Check_MultipleStages(t *testing.T) {
 	t.Parallel()
 	r := NewWorkdirRelativePathRule()


### PR DESCRIPTION
## Summary

- Fix false positive in `buildkit/WorkdirRelativePath` when `WORKDIR` uses a build-arg or variable reference (e.g. `WORKDIR ${FUNCTION_DIR}`, `WORKDIR $APP_DIR/suffix`)
- Since the resolved value is unknown at lint time, we cannot determine whether the path is absolute or relative — skip the violation
- The `$` prefix check works for both Linux and Windows containers since variable substitution is handled by the Dockerfile parser (BuildKit), not the container shell

## Test plan

- [x] Added unit tests covering bare variable (`${FUNCTION_DIR}`), variable with suffix (`${SOME_FOO}/the/suffix`), `$APP_DIR`, relative literal (still flags), and absolute with variable (no false positive)
- [x] Existing tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed WORKDIR validation to properly recognize and exclude paths containing variable expansions from relative path violation detection.

* **Tests**
  * Added test coverage for variable expansion handling in WORKDIR paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->