### PR TITLE
feat: add tally/gpu/no-hardcoded-visible-devices rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ tally integrates rules from multiple sources:
 | Source | Rules | Description |
 |--------|-------|-------------|
 | **[BuildKit](https://docs.docker.com/reference/build-checks/)** | 22/22 rules | Docker's official Dockerfile checks (captured + reimplemented) |
-| **tally** | 35 rules | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
+| **tally** | 36 rules | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
 | **[Hadolint](https://github.com/hadolint/hadolint)** | 37 rules | Hadolint-compatible Dockerfile rules (expanding) |
 <!-- END RULES_TABLE -->
 

--- a/RULES.md
+++ b/RULES.md
@@ -15,7 +15,7 @@ tally supports rules from multiple sources, each with its own namespace prefix.
 <!-- BEGIN RULES_SUMMARY -->
 | Namespace | Implemented | Covered by BuildKit | Total |
 |-----------|-------------|---------------------|-------|
-| tally | 35 | - | 35 |
+| tally | 36 | - | 36 |
 | buildkit | 17 + 5 captured | - | 22 |
 | hadolint | 27 | 10 | 66 |
 <!-- END RULES_SUMMARY -->
@@ -52,6 +52,7 @@ See the [tally rules documentation](docs/rules/tally/) for detailed descriptions
 | [`tally/powershell/prefer-shell-instruction`](docs/rules/tally/powershell/prefer-shell-instruction.md) 🔧 | Prefers a PowerShell `SHELL` instruction over repeated `pwsh` or `powershell -Command` wrappers in `RUN` | Style | Style | Enabled (experimental) |
 | [`tally/gpu/no-buildtime-gpu-queries`](docs/rules/tally/gpu/no-buildtime-gpu-queries.md) | GPU hardware queries in RUN will fail at build time | Error | Correctness | Enabled |
 | [`tally/gpu/no-container-runtime-in-image`](docs/rules/tally/gpu/no-container-runtime-in-image.md) | NVIDIA container runtime packages belong on the host, not inside the image | Warning | Correctness | Enabled |
+| [`tally/gpu/no-hardcoded-visible-devices`](docs/rules/tally/gpu/no-hardcoded-visible-devices.md) 🔧 | GPU visibility is deployment policy; hardcoding it in the image reduces portability | Warning | Correctness | Enabled |
 | [`tally/gpu/no-redundant-cuda-install`](docs/rules/tally/gpu/no-redundant-cuda-install.md) | CUDA packages are already provided by the nvidia/cuda base image | Warning | Correctness | Enabled |
 | [`tally/windows/no-run-mounts`](docs/rules/tally/windows/no-run-mounts.md) | `RUN --mount` flags are not supported on Windows containers and will fail at runtime | Error | Correctness | Enabled |
 | [`tally/prefer-run-heredoc`](docs/rules/tally/prefer-run-heredoc.md) 🔧 | Suggests using heredoc syntax for multi-command RUN instructions | Style | Style | Off (experimental) |

--- a/docs/rules/tally/gpu/no-hardcoded-visible-devices.md
+++ b/docs/rules/tally/gpu/no-hardcoded-visible-devices.md
@@ -1,0 +1,115 @@
+# tally/gpu/no-hardcoded-visible-devices
+
+GPU visibility is deployment policy; hardcoding it in the image reduces portability.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning |
+| Category | Correctness |
+| Default | Enabled |
+| Auto-fix | Partial |
+
+## Description
+
+Detects `ENV` instructions that hardcode GPU device visibility variables (`NVIDIA_VISIBLE_DEVICES`,
+`CUDA_VISIBLE_DEVICES`) inside the image. GPU visibility is deployment policy that should be set at
+runtime via `docker run --gpus`, `NVIDIA_VISIBLE_DEVICES` in the orchestrator, or similar mechanisms
+-- not baked into the container image.
+
+## Why this matters
+
+- **Portability** -- images with hardcoded device indices or UUIDs cannot run on hosts with different GPU topologies
+  without rebuilding
+- **Orchestrator conflict** -- Kubernetes device plugins, Slurm, and other schedulers set GPU visibility externally;
+  image-level settings can conflict with or override orchestrator intent
+- **Redundancy** -- official `nvidia/cuda` base images already set `NVIDIA_VISIBLE_DEVICES=all` via image labels;
+  re-declaring it in the Dockerfile is pure noise
+
+## What is flagged
+
+| Pattern | Flagged? | Fix safety |
+|---------|----------|------------|
+| `ENV NVIDIA_VISIBLE_DEVICES=all` on `nvidia/cuda:*` base | Yes (redundant) | `FixSafe` -- safe to delete |
+| `ENV NVIDIA_VISIBLE_DEVICES=0` or `=0,1` (device indices) | Yes | `FixSuggestion` |
+| `ENV NVIDIA_VISIBLE_DEVICES=GPU-<uuid>` or `MIG-<uuid>` | Yes | `FixSuggestion` |
+| `ENV CUDA_VISIBLE_DEVICES=<non-empty>` | Yes | `FixSuggestion` |
+| `ENV NVIDIA_VISIBLE_DEVICES=all` on non-CUDA base | No -- intentional for custom GPU images | -- |
+| `ENV NVIDIA_VISIBLE_DEVICES=none` / `void` / empty | No -- intentional disable signal | -- |
+| `ENV NVIDIA_VISIBLE_DEVICES=${VAR}` (variable reference) | No -- parameterized, not hardcoded | -- |
+| `ENV CUDA_VISIBLE_DEVICES=none` / `NoDevFiles` / empty | No -- intentional disable | -- |
+
+## Examples
+
+### Violation
+
+```dockerfile
+# Redundant: nvidia/cuda already sets NVIDIA_VISIBLE_DEVICES=all
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=all
+```
+
+```dockerfile
+# Hardcoded device indices make the image non-portable
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=0,1
+```
+
+```dockerfile
+# CUDA_VISIBLE_DEVICES bakes deployment policy into the image
+FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=0
+```
+
+```dockerfile
+# GPU UUIDs are host-specific
+FROM ubuntu:22.04
+ENV NVIDIA_VISIBLE_DEVICES=GPU-aaaa-bbbb-cccc-dddd-eeee-ffffffffffff
+```
+
+### No violation
+
+```dockerfile
+# NVIDIA_VISIBLE_DEVICES=all on a non-CUDA base is intentional
+FROM ubuntu:22.04
+ENV NVIDIA_VISIBLE_DEVICES=all
+```
+
+```dockerfile
+# Disable signals are intentional
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=none
+```
+
+```dockerfile
+# Variable references are parameterized, not hardcoded
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ARG GPU_DEVICES=all
+ENV NVIDIA_VISIBLE_DEVICES=${GPU_DEVICES}
+```
+
+## Auto-fix behavior
+
+The rule offers two fix safety levels:
+
+- **`FixSafe`** (applied with `--fix`): removes the redundant `NVIDIA_VISIBLE_DEVICES=all` on `nvidia/cuda` base
+  images. This is 100% behavior-preserving because the base image already sets this value.
+- **`FixSuggestion`** (applied with `--fix --fix-unsafe`): removes hardcoded device indices, UUIDs, or
+  `CUDA_VISIBLE_DEVICES` values. This improves portability but changes deployment semantics -- the user must
+  ensure GPU visibility is provided at runtime.
+
+For multi-key `ENV` instructions, only the flagged key is removed; other keys are preserved.
+
+## Configuration
+
+This rule has no rule-specific options.
+
+```toml
+[rules.tally."gpu/no-hardcoded-visible-devices"]
+severity = "warning"
+```
+
+## References
+
+- [NVIDIA Container Toolkit: Environment Variables](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html)
+- [CUDA Environment Variables](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars)
+- [GPU Container Rules design notes](../../../../design-docs/32-gpu-container-rules.md)

--- a/docs/rules/tally/index.md
+++ b/docs/rules/tally/index.md
@@ -25,6 +25,7 @@ Custom rules implemented by tally that go beyond BuildKit's checks.
 | [prefer-package-cache-mounts](./prefer-package-cache-mounts.md) | Suggests cache mounts for package install/build commands and removes cache cleanup | Info | Performance | Off (experimental) |
 | [powershell/prefer-shell-instruction](./powershell/prefer-shell-instruction.md) | Prefer a `SHELL` instruction instead of repeating `pwsh` or `powershell -Command` in `RUN` | Style | Style | Enabled (experimental) |
 | [gpu/no-container-runtime-in-image](./gpu/no-container-runtime-in-image.md) | NVIDIA container runtime packages belong on the host, not inside the image | Warning | Correctness | Enabled |
+| [gpu/no-hardcoded-visible-devices](./gpu/no-hardcoded-visible-devices.md) | GPU visibility is deployment policy; hardcoding it in the image reduces portability | Warning | Correctness | Enabled |
 | [gpu/no-redundant-cuda-install](./gpu/no-redundant-cuda-install.md) | CUDA packages are already provided by the nvidia/cuda base image | Warning | Correctness | Enabled |
 | [windows/no-run-mounts](./windows/no-run-mounts.md) | `RUN --mount` flags are not supported on Windows containers | Error | Correctness | Enabled |
 | [prefer-run-heredoc](./prefer-run-heredoc.md) | Suggests using heredoc syntax for multi-command RUN | Style | Style | Off (experimental) |

--- a/internal/integration/__snapshots__/TestFix_gpu-visible-devices-all-non-cuda-no-fire_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_gpu-visible-devices-all-non-cuda-no-fire_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:22.04
+ENV NVIDIA_VISIBLE_DEVICES=all
+RUN echo hello

--- a/internal/integration/__snapshots__/TestFix_gpu-visible-devices-hardcoded-index_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_gpu-visible-devices-hardcoded-index_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+RUN echo hello

--- a/internal/integration/__snapshots__/TestFix_gpu-visible-devices-multi-key-partial_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_gpu-visible-devices-multi-key-partial_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV CUDA_HOME=/usr/local/cuda
+RUN echo hello

--- a/internal/integration/__snapshots__/TestFix_gpu-visible-devices-redundant-all_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_gpu-visible-devices-redundant-all_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+RUN echo hello

--- a/internal/integration/__snapshots__/TestLint_gpu-no-hardcoded-visible-devices_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_gpu-no-hardcoded-visible-devices_1.snap.json
@@ -1,0 +1,222 @@
+{
+  "files": [
+    {
+      "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+      "violations": [
+        {
+          "detail": "The nvidia/cuda base image already sets NVIDIA_VISIBLE_DEVICES=all. This ENV instruction is redundant and can be safely removed.",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/gpu/no-hardcoded-visible-devices/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 5
+            },
+            "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 5
+            }
+          },
+          "message": "redundant NVIDIA_VISIBLE_DEVICES=all on nvidia/cuda base image",
+          "rule": "tally/gpu/no-hardcoded-visible-devices",
+          "severity": "warning",
+          "sourceCode": "ENV NVIDIA_VISIBLE_DEVICES=all",
+          "suggestedFix": {
+            "description": "Remove redundant NVIDIA_VISIBLE_DEVICES=all (already set by nvidia/cuda base image)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 6
+                  },
+                  "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 5
+                  }
+                },
+                "newText": ""
+              }
+            ],
+            "isPreferred": true,
+            "priority": 8
+          }
+        },
+        {
+          "detail": "GPU device visibility is deployment policy. Hardcoding device indices makes the image non-portable across hosts with different GPU topologies. Set GPU visibility at runtime via docker run --gpus or orchestrator configuration.",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/gpu/no-hardcoded-visible-devices/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 9
+            },
+            "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 9
+            }
+          },
+          "message": "hardcoded GPU device index in NVIDIA_VISIBLE_DEVICES=0,1",
+          "rule": "tally/gpu/no-hardcoded-visible-devices",
+          "severity": "warning",
+          "sourceCode": "ENV NVIDIA_VISIBLE_DEVICES=0,1",
+          "suggestedFix": {
+            "description": "Remove hardcoded NVIDIA_VISIBLE_DEVICES (set GPU visibility at runtime instead)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 10
+                  },
+                  "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 9
+                  }
+                },
+                "newText": ""
+              }
+            ],
+            "isPreferred": true,
+            "priority": 8,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "GPU device visibility is deployment policy. Hardcoding device indices makes the image non-portable across hosts with different GPU topologies. Set GPU visibility at runtime via docker run --gpus or orchestrator configuration.",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/gpu/no-hardcoded-visible-devices/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 13
+            },
+            "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 13
+            }
+          },
+          "message": "hardcoded GPU device index in CUDA_VISIBLE_DEVICES=0",
+          "rule": "tally/gpu/no-hardcoded-visible-devices",
+          "severity": "warning",
+          "sourceCode": "ENV CUDA_VISIBLE_DEVICES=0",
+          "suggestedFix": {
+            "description": "Remove hardcoded CUDA_VISIBLE_DEVICES (set GPU visibility at runtime instead)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 14
+                  },
+                  "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 13
+                  }
+                },
+                "newText": ""
+              }
+            ],
+            "isPreferred": true,
+            "priority": 8,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "GPU UUIDs are host-specific hardware identifiers. Hardcoding them makes the image non-portable. Set GPU visibility at runtime.",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/gpu/no-hardcoded-visible-devices/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 17
+            },
+            "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 17
+            }
+          },
+          "message": "hardcoded GPU UUID in NVIDIA_VISIBLE_DEVICES=GPU-aaaa-bbbb-cccc-dddd-eeee-ffffffff...",
+          "rule": "tally/gpu/no-hardcoded-visible-devices",
+          "severity": "warning",
+          "sourceCode": "ENV NVIDIA_VISIBLE_DEVICES=GPU-aaaa-bbbb-cccc-dddd-eeee-ffffffffffff",
+          "suggestedFix": {
+            "description": "Remove hardcoded NVIDIA_VISIBLE_DEVICES (set GPU visibility at runtime instead)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 18
+                  },
+                  "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 17
+                  }
+                },
+                "newText": ""
+              }
+            ],
+            "isPreferred": true,
+            "priority": 8,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "The nvidia/cuda base image already sets NVIDIA_VISIBLE_DEVICES=all. This ENV instruction is redundant and can be safely removed.",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/gpu/no-hardcoded-visible-devices/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 34
+            },
+            "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 34
+            }
+          },
+          "message": "redundant NVIDIA_VISIBLE_DEVICES=all on nvidia/cuda base image",
+          "rule": "tally/gpu/no-hardcoded-visible-devices",
+          "severity": "warning",
+          "sourceCode": "ENV NVIDIA_VISIBLE_DEVICES=all CUDA_HOME=/usr/local/cuda",
+          "suggestedFix": {
+            "description": "Remove redundant NVIDIA_VISIBLE_DEVICES=all (already set by nvidia/cuda base image)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 35
+                  },
+                  "file": "testdata/gpu-no-hardcoded-visible-devices/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 34
+                  }
+                },
+                "newText": "ENV CUDA_HOME=/usr/local/cuda\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 8
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 5,
+    "warnings": 5
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "files_scanned": 1,
-  "rules_enabled": 75,
+  "rules_enabled": 76,
   "summary": {
     "errors": 0,
     "files": 0,

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1463,5 +1463,42 @@ severity = "warning"
 			},
 			wantApplied: 1,
 		},
+
+		// GPU: no-hardcoded-visible-devices FixSafe (redundant all on nvidia/cuda)
+		{
+			name:  "gpu-visible-devices-redundant-all",
+			input: "FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04\nENV NVIDIA_VISIBLE_DEVICES=all\nRUN echo hello\n",
+			args: append(
+				[]string{"--fix"},
+				mustSelectRules("tally/gpu/no-hardcoded-visible-devices")...),
+			wantApplied: 1,
+		},
+		// GPU: no-hardcoded-visible-devices FixSuggestion (hardcoded index, requires --fix-unsafe)
+		{
+			name:  "gpu-visible-devices-hardcoded-index",
+			input: "FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04\nENV NVIDIA_VISIBLE_DEVICES=0\nRUN echo hello\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/gpu/no-hardcoded-visible-devices")...),
+			wantApplied: 1,
+		},
+		// GPU: no-hardcoded-visible-devices FixSafe multi-key partial removal
+		{
+			name:  "gpu-visible-devices-multi-key-partial",
+			input: "FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04\nENV NVIDIA_VISIBLE_DEVICES=all CUDA_HOME=/usr/local/cuda\nRUN echo hello\n",
+			args: append(
+				[]string{"--fix"},
+				mustSelectRules("tally/gpu/no-hardcoded-visible-devices")...),
+			wantApplied: 1,
+		},
+		// GPU: no-hardcoded-visible-devices no-fire (all on non-CUDA base)
+		{
+			name:  "gpu-visible-devices-all-non-cuda-no-fire",
+			input: "FROM ubuntu:22.04\nENV NVIDIA_VISIBLE_DEVICES=all\nRUN echo hello\n",
+			args: append(
+				[]string{"--fix"},
+				mustSelectRules("tally/gpu/no-hardcoded-visible-devices")...),
+			wantApplied: 0,
+		},
 	}
 }

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -281,6 +281,14 @@ func lintCases(t *testing.T) []lintCase {
 			wantExit: 1,
 		},
 
+		// GPU: Hardcoded GPU visible devices in ENV
+		{
+			name:     "gpu-no-hardcoded-visible-devices",
+			dir:      "gpu-no-hardcoded-visible-devices",
+			args:     append([]string{"--format", "json"}, mustSelectRules("tally/gpu/no-hardcoded-visible-devices")...),
+			wantExit: 1,
+		},
+
 		// Shell-form RUN in scratch stage
 		{
 			name:     "shell-run-in-scratch",

--- a/internal/integration/testdata/gpu-no-hardcoded-visible-devices/Dockerfile
+++ b/internal/integration/testdata/gpu-no-hardcoded-visible-devices/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Redundant NVIDIA_VISIBLE_DEVICES=all on nvidia/cuda base — violation (FixSafe)
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS redundant
+ENV NVIDIA_VISIBLE_DEVICES=all
+
+# Stage 2: Hardcoded device index — violation (FixSuggestion)
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 AS hardcoded-index
+ENV NVIDIA_VISIBLE_DEVICES=0,1
+
+# Stage 3: Hardcoded CUDA_VISIBLE_DEVICES — violation (FixSuggestion)
+FROM ubuntu:22.04 AS cuda-vis
+ENV CUDA_VISIBLE_DEVICES=0
+
+# Stage 4: Hardcoded GPU UUID — violation (FixSuggestion)
+FROM ubuntu:22.04 AS gpu-uuid
+ENV NVIDIA_VISIBLE_DEVICES=GPU-aaaa-bbbb-cccc-dddd-eeee-ffffffffffff
+
+# Stage 5: NVIDIA_VISIBLE_DEVICES=all on non-CUDA base — NO violation (intentional)
+FROM ubuntu:22.04 AS custom-gpu
+ENV NVIDIA_VISIBLE_DEVICES=all
+
+# Stage 6: Disable signal — NO violation
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS disabled
+ENV NVIDIA_VISIBLE_DEVICES=none
+
+# Stage 7: Variable reference — NO violation
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS parameterized
+ARG GPU_DEVICES=all
+ENV NVIDIA_VISIBLE_DEVICES=${GPU_DEVICES}
+
+# Stage 8: Multi-key ENV with flagged key — violation (FixSafe, partial removal)
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS multi-key
+ENV NVIDIA_VISIBLE_DEVICES=all CUDA_HOME=/usr/local/cuda

--- a/internal/rules/env_edit.go
+++ b/internal/rules/env_edit.go
@@ -1,0 +1,54 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+)
+
+// BuildEnvKeyRemovalEdit constructs a TextEdit to remove specific keys from one ENV instruction.
+// When all keys are removed, the entire instruction line is deleted. When some keys remain,
+// the instruction is reconstructed without the removed keys.
+func BuildEnvKeyRemovalEdit(file string, env *instructions.EnvCommand, keysToRemove []string) *TextEdit {
+	envLoc := env.Location()
+	if len(envLoc) == 0 {
+		return nil
+	}
+
+	removeSet := make(map[string]bool, len(keysToRemove))
+	for _, k := range keysToRemove {
+		removeSet[k] = true
+	}
+
+	startLine := envLoc[0].Start.Line
+	startCol := envLoc[0].Start.Character
+
+	// Count remaining variables after removal.
+	parts := make([]string, 0, len(env.Env))
+	for _, kv := range env.Env {
+		if removeSet[kv.Key] {
+			continue
+		}
+		parts = append(parts, kv.String())
+	}
+
+	if len(parts) == 0 {
+		// Remove the entire instruction including its trailing newline.
+		endLine := envLoc[len(envLoc)-1].End.Line
+		return &TextEdit{
+			Location: NewRangeLocation(file, startLine, startCol, endLine+1, 0),
+			NewText:  "",
+		}
+	}
+
+	// Multi-variable ENV: replace the entire instruction line(s) with the
+	// reconstructed key list plus a trailing newline. We use endLine+1, col 0
+	// (same strategy as the full-deletion path) because BuildKit's End.Character
+	// is often 0 for single-line instructions, which would create a zero-width range.
+	endLine := envLoc[len(envLoc)-1].End.Line
+
+	return &TextEdit{
+		Location: NewRangeLocation(file, startLine, startCol, endLine+1, 0),
+		NewText:  "ENV " + strings.Join(parts, " ") + "\n",
+	}
+}

--- a/internal/rules/tally/gpu/__snapshots__/TestNoHardcodedVisibleDevicesRule_Metadata_1.snap.json
+++ b/internal/rules/tally/gpu/__snapshots__/TestNoHardcodedVisibleDevicesRule_Metadata_1.snap.json
@@ -1,0 +1,10 @@
+{
+ "Category": "correctness",
+ "Code": "tally/gpu/no-hardcoded-visible-devices",
+ "DefaultSeverity": "warning",
+ "Description": "GPU visibility is deployment policy; hardcoding it in the image reduces portability",
+ "DocURL": "https://wharflab.github.io/tally/rules/tally/gpu/no-hardcoded-visible-devices/",
+ "FixPriority": 8,
+ "IsExperimental": false,
+ "Name": "No hardcoded GPU visible devices"
+}

--- a/internal/rules/tally/gpu/no_hardcoded_visible_devices.go
+++ b/internal/rules/tally/gpu/no_hardcoded_visible_devices.go
@@ -1,0 +1,325 @@
+package gpu
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+)
+
+// NoHardcodedVisibleDevicesRuleCode is the full rule code.
+const NoHardcodedVisibleDevicesRuleCode = rules.TallyRulePrefix + "gpu/no-hardcoded-visible-devices"
+
+// visibleDevicesClass classifies an ENV value to determine violation and fix type.
+type visibleDevicesClass int
+
+const (
+	// classNone means no violation (none, void, empty, variable reference).
+	classNone visibleDevicesClass = iota
+	// classExplicitAll means NVIDIA_VISIBLE_DEVICES=all on a non-CUDA base — intentional, no violation.
+	classExplicitAll
+	// classRedundantAll means NVIDIA_VISIBLE_DEVICES=all on an nvidia/cuda base — redundant, FixSafe.
+	classRedundantAll
+	// classHardcodedIndex means a device index list like "0" or "0,1" — FixSuggestion.
+	classHardcodedIndex
+	// classHardcodedUUID means a GPU/MIG UUID — FixSuggestion.
+	classHardcodedUUID
+	// classHardcodedOther means any other non-empty hardcoded value — FixSuggestion.
+	classHardcodedOther
+)
+
+// NoHardcodedVisibleDevicesRule flags ENV instructions that hardcode GPU device
+// visibility (NVIDIA_VISIBLE_DEVICES, CUDA_VISIBLE_DEVICES). GPU visibility is
+// deployment policy that should be set at runtime, not baked into the image.
+type NoHardcodedVisibleDevicesRule struct{}
+
+// NewNoHardcodedVisibleDevicesRule creates a new rule instance.
+func NewNoHardcodedVisibleDevicesRule() *NoHardcodedVisibleDevicesRule {
+	return &NoHardcodedVisibleDevicesRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *NoHardcodedVisibleDevicesRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            NoHardcodedVisibleDevicesRuleCode,
+		Name:            "No hardcoded GPU visible devices",
+		Description:     "GPU visibility is deployment policy; hardcoding it in the image reduces portability",
+		DocURL:          rules.TallyDocURL(NoHardcodedVisibleDevicesRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "correctness",
+		FixPriority:     8,
+	}
+}
+
+// Check runs the rule against the given input.
+func (r *NoHardcodedVisibleDevicesRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	sem, _ := input.Semantic.(*semantic.Model) //nolint:errcheck // nil-safe assertion
+
+	fileFacts, ok := input.Facts.(*facts.FileFacts)
+	if ok && fileFacts != nil {
+		return r.checkWithFacts(input, fileFacts, sem, meta)
+	}
+
+	// Fallback: iterate stages directly when facts are unavailable.
+	return r.checkFallback(input, sem, meta)
+}
+
+func (r *NoHardcodedVisibleDevicesRule) checkWithFacts(
+	input rules.LintInput,
+	fileFacts *facts.FileFacts,
+	sem *semantic.Model,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	var violations []rules.Violation
+
+	for _, stageFacts := range fileFacts.Stages() {
+		isCUDABase := stageIsCUDABase(sem, stageFacts.Index)
+
+		for _, key := range visibleDevicesKeys {
+			binding, ok := stageFacts.EffectiveEnv.Bindings[key]
+			if !ok || binding.Command == nil {
+				continue
+			}
+
+			class := classifyValue(key, binding.Value, isCUDABase)
+			if class == classNone || class == classExplicitAll {
+				continue
+			}
+
+			if v, ok := r.buildViolation(input.File, stageFacts.Index, binding, class, meta); ok {
+				violations = append(violations, v)
+			}
+		}
+	}
+	return violations
+}
+
+func (r *NoHardcodedVisibleDevicesRule) checkFallback(
+	input rules.LintInput,
+	sem *semantic.Model,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	var violations []rules.Violation
+
+	for stageIdx, stage := range input.Stages {
+		isCUDABase := stageIsCUDABase(sem, stageIdx)
+
+		for _, cmd := range stage.Commands {
+			env, ok := cmd.(*instructions.EnvCommand)
+			if !ok {
+				continue
+			}
+			for _, kv := range env.Env {
+				if !isVisibleDevicesKey(kv.Key) {
+					continue
+				}
+				value := facts.Unquote(kv.Value)
+				class := classifyValue(kv.Key, value, isCUDABase)
+				if class == classNone || class == classExplicitAll {
+					continue
+				}
+
+				binding := facts.EnvBinding{Key: kv.Key, Value: value, Command: env}
+				if v, ok := r.buildViolation(input.File, stageIdx, binding, class, meta); ok {
+					violations = append(violations, v)
+				}
+			}
+		}
+	}
+	return violations
+}
+
+func (r *NoHardcodedVisibleDevicesRule) buildViolation(
+	file string,
+	stageIdx int,
+	binding facts.EnvBinding,
+	class visibleDevicesClass,
+	meta rules.RuleMetadata,
+) (rules.Violation, bool) {
+	loc := rules.NewLocationFromRanges(file, binding.Command.Location())
+	if loc.IsFileLevel() {
+		return rules.Violation{}, false
+	}
+
+	message, detail := violationText(binding.Key, binding.Value, class)
+	v := rules.NewViolation(loc, meta.Code, message, meta.DefaultSeverity).
+		WithDocURL(meta.DocURL).
+		WithDetail(detail)
+	v.StageIndex = stageIdx
+
+	if fix := r.buildFix(file, binding, class, meta); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+
+	return v, true
+}
+
+func (r *NoHardcodedVisibleDevicesRule) buildFix(
+	file string,
+	binding facts.EnvBinding,
+	class visibleDevicesClass,
+	meta rules.RuleMetadata,
+) *rules.SuggestedFix {
+	edit := buildEnvKeyRemovalEdit(file, binding.Command, []string{binding.Key})
+	if edit == nil {
+		return nil
+	}
+
+	if class == classRedundantAll {
+		return &rules.SuggestedFix{
+			Description: "Remove redundant NVIDIA_VISIBLE_DEVICES=all (already set by nvidia/cuda base image)",
+			Edits:       []rules.TextEdit{*edit},
+			Safety:      rules.FixSafe,
+			Priority:    meta.FixPriority,
+			IsPreferred: true,
+		}
+	}
+
+	desc := "Remove hardcoded " + binding.Key + " (set GPU visibility at runtime instead)"
+	return &rules.SuggestedFix{
+		Description: desc,
+		Edits:       []rules.TextEdit{*edit},
+		Safety:      rules.FixSuggestion,
+		Priority:    meta.FixPriority,
+		IsPreferred: true,
+	}
+}
+
+// visibleDevicesKeys is the ordered list of ENV keys this rule inspects.
+var visibleDevicesKeys = []string{
+	"NVIDIA_VISIBLE_DEVICES",
+	"CUDA_VISIBLE_DEVICES",
+}
+
+func isVisibleDevicesKey(key string) bool {
+	return slices.Contains(visibleDevicesKeys, key)
+}
+
+// classifyValue determines the violation class for a visible-devices ENV value.
+func classifyValue(key, value string, isCUDABase bool) visibleDevicesClass {
+	trimmed := strings.TrimSpace(value)
+	lower := strings.ToLower(trimmed)
+
+	// Skip empty, none, void, and variable references.
+	switch {
+	case trimmed == "":
+		return classNone
+	case lower == "none" || lower == "void":
+		return classNone
+	case strings.Contains(trimmed, "$"):
+		return classNone // ARG/variable reference, not hardcoded
+	}
+
+	if key == "NVIDIA_VISIBLE_DEVICES" {
+		return classifyNvidiaVisibleDevices(trimmed, lower, isCUDABase)
+	}
+	return classifyCudaVisibleDevices(trimmed, lower)
+}
+
+func classifyNvidiaVisibleDevices(trimmed, lower string, isCUDABase bool) visibleDevicesClass {
+	if lower == "all" {
+		if isCUDABase {
+			return classRedundantAll
+		}
+		return classExplicitAll
+	}
+
+	if isGPUOrMIGUUID(trimmed) {
+		return classHardcodedUUID
+	}
+	if isDeviceIndexList(trimmed) {
+		return classHardcodedIndex
+	}
+	return classHardcodedOther
+}
+
+func classifyCudaVisibleDevices(trimmed, lower string) visibleDevicesClass {
+	// CUDA_VISIBLE_DEVICES uses "NoDevFiles" as a disable value in some CUDA versions.
+	if lower == "nodevfiles" {
+		return classNone
+	}
+
+	if isGPUOrMIGUUID(trimmed) {
+		return classHardcodedUUID
+	}
+	if isDeviceIndexList(trimmed) {
+		return classHardcodedIndex
+	}
+	return classHardcodedOther
+}
+
+// isDeviceIndexList matches patterns like "0", "1", "0,1", "0, 1, 2".
+func isDeviceIndexList(value string) bool {
+	hasDigit := false
+	for _, ch := range value {
+		switch {
+		case ch >= '0' && ch <= '9':
+			hasDigit = true
+		case ch == ',' || ch == ' ':
+			// allowed separators
+		default:
+			return false
+		}
+	}
+	return hasDigit
+}
+
+// isGPUOrMIGUUID matches GPU-<uuid> or MIG-<guid> prefixes.
+func isGPUOrMIGUUID(value string) bool {
+	upper := strings.ToUpper(value)
+	return strings.HasPrefix(upper, "GPU-") || strings.HasPrefix(upper, "MIG-")
+}
+
+func stageIsCUDABase(sem *semantic.Model, stageIdx int) bool {
+	if sem == nil {
+		return false
+	}
+	return stageUsesNVIDIACUDABase(sem.StageInfo(stageIdx))
+}
+
+func violationText(key, value string, class visibleDevicesClass) (message, detail string) {
+	switch class { //nolint:exhaustive // classNone and classExplicitAll never reach here
+	case classRedundantAll:
+		message = "redundant " + key + "=all on nvidia/cuda base image"
+		detail = "The nvidia/cuda base image already sets " + key + "=all. " +
+			"This ENV instruction is redundant and can be safely removed."
+
+	case classHardcodedIndex:
+		message = "hardcoded GPU device index in " + key + "=" + value
+		detail = "GPU device visibility is deployment policy. Hardcoding device indices " +
+			"makes the image non-portable across hosts with different GPU topologies. " +
+			"Set GPU visibility at runtime via docker run --gpus or orchestrator configuration."
+
+	case classHardcodedUUID:
+		message = "hardcoded GPU UUID in " + key + "=" + truncateValue(value, 40)
+		detail = "GPU UUIDs are host-specific hardware identifiers. Hardcoding them " +
+			"makes the image non-portable. Set GPU visibility at runtime."
+
+	default: // classHardcodedOther
+		message = "hardcoded " + key + "=" + value + " bakes deployment policy into the image"
+		detail = "GPU device visibility should be set at runtime, not inside the image. " +
+			"This allows the same image to run on different GPU configurations without rebuilding."
+	}
+	return message, detail
+}
+
+func truncateValue(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// buildEnvKeyRemovalEdit delegates to the shared rules.BuildEnvKeyRemovalEdit helper.
+func buildEnvKeyRemovalEdit(file string, env *instructions.EnvCommand, keysToRemove []string) *rules.TextEdit {
+	return rules.BuildEnvKeyRemovalEdit(file, env, keysToRemove)
+}
+
+func init() {
+	rules.Register(NewNoHardcodedVisibleDevicesRule())
+}

--- a/internal/rules/tally/gpu/no_hardcoded_visible_devices_test.go
+++ b/internal/rules/tally/gpu/no_hardcoded_visible_devices_test.go
@@ -1,0 +1,442 @@
+package gpu
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestNoHardcodedVisibleDevicesRule_Metadata(t *testing.T) {
+	t.Parallel()
+	snaps.MatchStandaloneJSON(t, NewNoHardcodedVisibleDevicesRule().Metadata())
+}
+
+func TestNoHardcodedVisibleDevicesRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewNoHardcodedVisibleDevicesRule(), []testutil.RuleTestCase{
+		// ── NVIDIA_VISIBLE_DEVICES violations ──
+
+		{
+			Name: "redundant all on nvidia/cuda base",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=all
+`,
+			WantViolations: 1,
+			WantCodes:      []string{NoHardcodedVisibleDevicesRuleCode},
+			WantMessages:   []string{"redundant NVIDIA_VISIBLE_DEVICES=all"},
+		},
+		{
+			Name: "redundant all on docker.io/nvidia/cuda base",
+			Content: `FROM docker.io/nvidia/cuda:12.2.0-devel-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=all
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"redundant"},
+		},
+		{
+			Name: "hardcoded single device index",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=0
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"hardcoded GPU device index"},
+		},
+		{
+			Name: "hardcoded multi device index",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=0,1,2
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"hardcoded GPU device index"},
+		},
+		{
+			Name: "hardcoded GPU UUID",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=GPU-aaaabbbb-cccc-dddd-eeee-ffffffffffff
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"hardcoded GPU UUID"},
+		},
+		{
+			Name: "hardcoded MIG UUID",
+			Content: `FROM ubuntu:22.04
+ENV NVIDIA_VISIBLE_DEVICES=MIG-aaaabbbb-cccc-dddd-eeee-ffffffffffff
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"hardcoded GPU UUID"},
+		},
+		{
+			Name: "device index on non-CUDA base",
+			Content: `FROM ubuntu:22.04
+ENV NVIDIA_VISIBLE_DEVICES=0
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"hardcoded GPU device index"},
+		},
+
+		// ── NVIDIA_VISIBLE_DEVICES no-fire cases ──
+
+		{
+			Name: "all on non-CUDA base is intentional",
+			Content: `FROM ubuntu:22.04
+ENV NVIDIA_VISIBLE_DEVICES=all
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "all on nvcr.io NVIDIA base is not flagged",
+			Content: `FROM nvcr.io/nvidia/pytorch:24.01-py3
+ENV NVIDIA_VISIBLE_DEVICES=all
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "none is intentional disable",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=none
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "void is intentional disable",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=void
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "empty value is not flagged",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "variable reference with dollar-brace",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ARG GPU_DEVICES=all
+ENV NVIDIA_VISIBLE_DEVICES=${GPU_DEVICES}
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "variable reference with dollar",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ARG DEVICES=0
+ENV NVIDIA_VISIBLE_DEVICES=$DEVICES
+`,
+			WantViolations: 0,
+		},
+
+		// ── CUDA_VISIBLE_DEVICES violations ──
+
+		{
+			Name: "CUDA_VISIBLE_DEVICES hardcoded index",
+			Content: `FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=0
+`,
+			WantViolations: 1,
+			WantCodes:      []string{NoHardcodedVisibleDevicesRuleCode},
+			WantMessages:   []string{"hardcoded GPU device index in CUDA_VISIBLE_DEVICES=0"},
+		},
+		{
+			Name: "CUDA_VISIBLE_DEVICES multi index",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV CUDA_VISIBLE_DEVICES=0,1
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"CUDA_VISIBLE_DEVICES=0,1"},
+		},
+		{
+			Name: "CUDA_VISIBLE_DEVICES GPU UUID",
+			Content: `FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=GPU-aaaabbbb-cccc-dddd-eeee-ffffffffffff
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"hardcoded GPU UUID"},
+		},
+		{
+			Name: "CUDA_VISIBLE_DEVICES arbitrary string",
+			Content: `FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=device0
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"CUDA_VISIBLE_DEVICES=device0"},
+		},
+
+		// ── CUDA_VISIBLE_DEVICES no-fire cases ──
+
+		{
+			Name: "CUDA_VISIBLE_DEVICES empty",
+			Content: `FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "CUDA_VISIBLE_DEVICES none",
+			Content: `FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=none
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "CUDA_VISIBLE_DEVICES NoDevFiles",
+			Content: `FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=NoDevFiles
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "CUDA_VISIBLE_DEVICES variable reference",
+			Content: `FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=$DEVICES
+`,
+			WantViolations: 0,
+		},
+
+		// ── Multi-key ENV ──
+
+		{
+			Name: "multi-key ENV with one flagged key",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=all CUDA_HOME=/usr/local/cuda
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"redundant NVIDIA_VISIBLE_DEVICES=all"},
+		},
+
+		// ── Multi-stage ──
+
+		{
+			Name: "multi-stage fires only in offending stages",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS base
+ENV NVIDIA_VISIBLE_DEVICES=all
+
+FROM ubuntu:22.04 AS app
+ENV CUDA_VISIBLE_DEVICES=0
+`,
+			WantViolations: 2,
+		},
+		{
+			Name: "stage reference base treats all as intentional",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS base
+RUN echo hello
+
+FROM base AS app
+ENV NVIDIA_VISIBLE_DEVICES=all
+`,
+			// FROM base — base image is a stage ref, stageUsesNVIDIACUDABase returns false,
+			// so NVIDIA_VISIBLE_DEVICES=all is classExplicitAll (no violation).
+			WantViolations: 0,
+		},
+
+		// ── Edge cases ──
+
+		{
+			Name: "no ENV instructions",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+RUN echo hello
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "quoted value is unquoted before classification",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES="all"
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"redundant"},
+		},
+		{
+			Name: "case-insensitive none",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=None
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "both variables in same stage",
+			Content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV CUDA_VISIBLE_DEVICES=0
+`,
+			WantViolations: 2,
+		},
+	})
+}
+
+func TestNoHardcodedVisibleDevicesRule_FixSafety(t *testing.T) {
+	t.Parallel()
+
+	rule := NewNoHardcodedVisibleDevicesRule()
+
+	tests := []struct {
+		name       string
+		content    string
+		wantSafety rules.FixSafety
+		wantFix    bool
+	}{
+		{
+			name: "FixSafe for redundant all on nvidia/cuda",
+			content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=all
+`,
+			wantSafety: rules.FixSafe,
+			wantFix:    true,
+		},
+		{
+			name: "FixSuggestion for device index",
+			content: `FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+ENV NVIDIA_VISIBLE_DEVICES=0
+`,
+			wantSafety: rules.FixSuggestion,
+			wantFix:    true,
+		},
+		{
+			name: "FixSuggestion for CUDA_VISIBLE_DEVICES",
+			content: `FROM ubuntu:22.04
+ENV CUDA_VISIBLE_DEVICES=0,1
+`,
+			wantSafety: rules.FixSuggestion,
+			wantFix:    true,
+		},
+		{
+			name: "FixSuggestion for GPU UUID",
+			content: `FROM ubuntu:22.04
+ENV NVIDIA_VISIBLE_DEVICES=GPU-aaaa-bbbb-cccc-dddd
+`,
+			wantSafety: rules.FixSuggestion,
+			wantFix:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := testutil.MakeLintInput(t, "Dockerfile", tt.content)
+			violations := rule.Check(input)
+			if len(violations) != 1 {
+				t.Fatalf("expected 1 violation, got %d", len(violations))
+			}
+			v := violations[0]
+			if tt.wantFix && v.SuggestedFix == nil {
+				t.Fatal("expected SuggestedFix, got nil")
+			}
+			if v.SuggestedFix != nil && v.SuggestedFix.Safety != tt.wantSafety {
+				t.Errorf("SuggestedFix.Safety = %v, want %v", v.SuggestedFix.Safety, tt.wantSafety)
+			}
+		})
+	}
+}
+
+// ── Classification helper tests ──
+
+func TestClassifyValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		key        string
+		value      string
+		isCUDABase bool
+		want       visibleDevicesClass
+	}{
+		{"empty", "NVIDIA_VISIBLE_DEVICES", "", false, classNone},
+		{"none", "NVIDIA_VISIBLE_DEVICES", "none", false, classNone},
+		{"None-mixed", "NVIDIA_VISIBLE_DEVICES", "None", false, classNone},
+		{"void", "NVIDIA_VISIBLE_DEVICES", "void", false, classNone},
+		{"variable-brace", "NVIDIA_VISIBLE_DEVICES", "${GPU}", false, classNone},
+		{"variable-dollar", "NVIDIA_VISIBLE_DEVICES", "$DEVICES", false, classNone},
+
+		{"all-on-cuda", "NVIDIA_VISIBLE_DEVICES", "all", true, classRedundantAll},
+		{"all-on-non-cuda", "NVIDIA_VISIBLE_DEVICES", "all", false, classExplicitAll},
+
+		{"single-index", "NVIDIA_VISIBLE_DEVICES", "0", false, classHardcodedIndex},
+		{"multi-index", "NVIDIA_VISIBLE_DEVICES", "0,1,2", false, classHardcodedIndex},
+		{"spaced-index", "NVIDIA_VISIBLE_DEVICES", "0, 1", false, classHardcodedIndex},
+
+		{"gpu-uuid", "NVIDIA_VISIBLE_DEVICES", "GPU-aaaa-bbbb", false, classHardcodedUUID},
+		{"mig-uuid", "NVIDIA_VISIBLE_DEVICES", "MIG-aaaa-bbbb", false, classHardcodedUUID},
+		{"gpu-uuid-lower", "NVIDIA_VISIBLE_DEVICES", "gpu-aaaa-bbbb", false, classHardcodedUUID},
+
+		{"cuda-vis-none", "CUDA_VISIBLE_DEVICES", "none", false, classNone},
+		{"cuda-vis-nodevfiles", "CUDA_VISIBLE_DEVICES", "NoDevFiles", false, classNone},
+		{"cuda-vis-index", "CUDA_VISIBLE_DEVICES", "0", false, classHardcodedIndex},
+		{"cuda-vis-uuid", "CUDA_VISIBLE_DEVICES", "GPU-uuid", false, classHardcodedUUID},
+		{"cuda-vis-other", "CUDA_VISIBLE_DEVICES", "device0", false, classHardcodedOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyValue(tt.key, tt.value, tt.isCUDABase)
+			if got != tt.want {
+				t.Errorf("classifyValue(%q, %q, %v) = %d, want %d", tt.key, tt.value, tt.isCUDABase, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDeviceIndexList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"0", true},
+		{"1", true},
+		{"0,1", true},
+		{"0,1,2,3", true},
+		{"0, 1, 2", true},
+		{"", false},
+		{"all", false},
+		{"GPU-abc", false},
+		{"none", false},
+		{",", false},
+		{"0a", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+			got := isDeviceIndexList(tt.value)
+			if got != tt.want {
+				t.Errorf("isDeviceIndexList(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGPUOrMIGUUID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"GPU-aaaa-bbbb-cccc", true},
+		{"MIG-aaaa-bbbb-cccc", true},
+		{"gpu-lower-case", true},
+		{"mig-lower-case", true},
+		{"0", false},
+		{"all", false},
+		{"none", false},
+		{"GPUAAAA", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+			got := isGPUOrMIGUUID(tt.value)
+			if got != tt.want {
+				t.Errorf("isGPUOrMIGUUID(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -1035,48 +1035,9 @@ func consumeEnvRemovalEdits(file string, cleaners map[cleanupKind]bool, entries 
 	return edits, remaining
 }
 
-// buildEnvKeyRemovalEdit constructs a TextEdit to remove specific keys from one ENV instruction.
-// All keys removed → delete entire line. Some remaining → reconstruct with fmt.Sprintf("%s=%q", ...).
+// buildEnvKeyRemovalEdit delegates to the shared rules.BuildEnvKeyRemovalEdit helper.
 func buildEnvKeyRemovalEdit(file string, env *instructions.EnvCommand, keysToRemove []string) *rules.TextEdit {
-	envLoc := env.Location()
-	if len(envLoc) == 0 {
-		return nil
-	}
-
-	removeSet := make(map[string]bool, len(keysToRemove))
-	for _, k := range keysToRemove {
-		removeSet[k] = true
-	}
-
-	startLine := envLoc[0].Start.Line
-	startCol := envLoc[0].Start.Character
-
-	// Count remaining variables after removal.
-	parts := make([]string, 0, len(env.Env))
-	for _, kv := range env.Env {
-		if removeSet[kv.Key] {
-			continue
-		}
-		parts = append(parts, kv.String())
-	}
-
-	if len(parts) == 0 {
-		// Remove the entire instruction including its trailing newline.
-		endLine := envLoc[len(envLoc)-1].End.Line
-		return &rules.TextEdit{
-			Location: rules.NewRangeLocation(file, startLine, startCol, endLine+1, 0),
-			NewText:  "",
-		}
-	}
-
-	// Multi-variable ENV: reconstruct without the removed keys.
-	endLine := envLoc[len(envLoc)-1].End.Line
-	endCol := envLoc[len(envLoc)-1].End.Character
-
-	return &rules.TextEdit{
-		Location: rules.NewRangeLocation(file, startLine, startCol, endLine, endCol),
-		NewText:  "ENV " + strings.Join(parts, " "),
-	}
+	return rules.BuildEnvKeyRemovalEdit(file, env, keysToRemove)
 }
 
 // resolveCachePathOverrides updates overrides if the ENV instruction sets any cache-location variables.


### PR DESCRIPTION
## Summary

- Add `tally/gpu/no-hardcoded-visible-devices` rule that detects `ENV` instructions hardcoding GPU device visibility (`NVIDIA_VISIBLE_DEVICES`, `CUDA_VISIBLE_DEVICES`) inside the image
- Auto-fix with two safety levels:
  - **FixSafe**: removes redundant `NVIDIA_VISIBLE_DEVICES=all` on `nvidia/cuda:*` bases (100% behavior-preserving since the base image already sets this)
  - **FixSuggestion**: removes hardcoded device indices, GPU UUIDs, and `CUDA_VISIBLE_DEVICES` values (improves portability, requires `--fix-unsafe`)
- Intentionally does **not** flag `NVIDIA_VISIBLE_DEVICES=all` on non-CUDA bases (intentional for custom GPU images), `none`/`void`/empty (disable signals), or `$VAR` references (parameterized)
- Extract shared `BuildEnvKeyRemovalEdit` helper into `internal/rules/env_edit.go` to eliminate duplication with `prefer-package-cache-mounts`, also fixing a zero-width edit range bug in the multi-key ENV partial removal path

## Test plan

- [ ] Unit tests: 30+ cases covering all classification branches, fix safety levels, multi-stage, multi-key ENV, edge cases (quoted values, stage refs, case sensitivity)
- [ ] Integration lint test with 8-stage Dockerfile fixture (4 violations, 4 no-fire cases)
- [ ] Integration fix tests: FixSafe deletion, FixSuggestion deletion (with `--fix-unsafe`), multi-key partial removal, no-fire verification
- [ ] `go test ./...`, `make lint`, `make cpd` all pass
- [ ] Snapshot updates: metadata, lint, fix, total-rules-enabled (75 → 76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new linting rule to detect hardcoded GPU visibility settings in Docker images, helping ensure containers remain portable across different deployment environments.

* **Tests**
  * Added comprehensive integration and unit tests for the new GPU rule.

* **Documentation**
  * Updated rule documentation to include the new GPU portability check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->