### PR TITLE
feat(rules): add tally/php/no-xdebug-in-final-image rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ tally integrates rules from multiple sources:
 | Source | Rules | Description |
 |--------|-------|-------------|
 | **[BuildKit](https://docs.docker.com/reference/build-checks/)** | 22/22 rules | Docker's official Dockerfile checks (captured + reimplemented) |
-| **tally** | 53 rules | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
+| **tally** | 54 rules | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
 | **[Hadolint](https://github.com/hadolint/hadolint)** | 37 rules | Hadolint-compatible Dockerfile rules (expanding) |
 <!-- END RULES_TABLE -->
 

--- a/RULES.md
+++ b/RULES.md
@@ -15,7 +15,7 @@ tally supports rules from multiple sources, each with its own namespace prefix.
 <!-- BEGIN RULES_SUMMARY -->
 | Namespace | Implemented | Covered by BuildKit | Total |
 |-----------|-------------|---------------------|-------|
-| tally | 53 | - | 53 |
+| tally | 54 | - | 54 |
 | buildkit | 17 + 5 captured | - | 22 |
 | hadolint | 27 | 10 | 66 |
 <!-- END RULES_SUMMARY -->
@@ -62,6 +62,7 @@ See the [tally rules documentation](docs/rules/tally/) for detailed descriptions
 | [`tally/prefer-copy-heredoc`](docs/rules/tally/prefer-copy-heredoc.md) 🔧 | Suggests using COPY heredoc for file creation instead of RUN echo/cat/printf | Info | Performance | Enabled |
 | [`tally/prefer-package-cache-mounts`](docs/rules/tally/prefer-package-cache-mounts.md) 🔧 | Suggests BuildKit cache mounts for package install/build commands and removes cache cleanup commands | Info | Performance | Enabled |
 | [`tally/php/composer-no-dev-in-production`](docs/rules/tally/php/composer-no-dev-in-production.md) 🔧 | Production Composer install commands should include `--no-dev` | Warning | Security | Enabled |
+| [`tally/php/no-xdebug-in-final-image`](docs/rules/tally/php/no-xdebug-in-final-image.md) 🔧 | Final image installs or enables Xdebug, a development-only tool | Warning | Best Practices | Enabled |
 | [`tally/powershell/prefer-shell-instruction`](docs/rules/tally/powershell/prefer-shell-instruction.md) 🔧 | Prefers a PowerShell `SHELL` instruction over repeated `pwsh` or `powershell -Command` wrappers in `RUN` | Style | Style | Enabled (experimental) |
 | [`tally/gpu/no-buildtime-gpu-queries`](docs/rules/tally/gpu/no-buildtime-gpu-queries.md) | GPU hardware queries in RUN will fail at build time | Error | Correctness | Enabled |
 | [`tally/gpu/no-container-runtime-in-image`](docs/rules/tally/gpu/no-container-runtime-in-image.md) | NVIDIA container runtime packages belong on the host, not inside the image | Warning | Correctness | Enabled |

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ tally lint --fix Dockerfile
 | Source | Rules | Description |
 |--------|-------|-------------|
 | [BuildKit](https://docs.docker.com/reference/build-checks/) | 22/22 | Docker's official Dockerfile checks |
-| tally | 53 | Custom rules including secret detection |
+| tally | 54 | Custom rules including secret detection |
 | [Hadolint](https://github.com/hadolint/hadolint) | 37 | Hadolint-compatible rules |
 
 [View all rules →](rules/index.md)

--- a/docs/rules/tally/index.md
+++ b/docs/rules/tally/index.md
@@ -36,6 +36,7 @@ Custom rules implemented by tally that go beyond BuildKit's checks.
 | [prefer-copy-heredoc](./prefer-copy-heredoc.md) | Suggests using COPY heredoc for file creation | Info | Performance | Enabled |
 | [prefer-package-cache-mounts](./prefer-package-cache-mounts.md) | Suggests cache mounts for package install/build commands and removes cache cleanup | Info | Performance | Enabled |
 | [php/composer-no-dev-in-production](./php/composer-no-dev-in-production.md) | Production Composer install commands should include --no-dev | Warning | Security | Enabled |
+| [php/no-xdebug-in-final-image](./php/no-xdebug-in-final-image.md) | Final image installs or enables Xdebug, a development-only tool | Warning | Best Practices | Enabled |
 | [powershell/prefer-shell-instruction](./powershell/prefer-shell-instruction.md) | Prefer a `SHELL` instruction instead of repeating `pwsh` or `powershell -Command` in `RUN` | Style | Style | Enabled (experimental) |
 | [gpu/no-container-runtime-in-image](./gpu/no-container-runtime-in-image.md) | NVIDIA container runtime packages belong on the host, not inside the image | Warning | Correctness | Enabled |
 | [gpu/no-hardcoded-visible-devices](./gpu/no-hardcoded-visible-devices.md) | GPU visibility is deployment policy; hardcoding it in the image reduces portability | Warning | Correctness | Enabled |

--- a/docs/rules/tally/php/no-xdebug-in-final-image.md
+++ b/docs/rules/tally/php/no-xdebug-in-final-image.md
@@ -1,0 +1,68 @@
+# tally/php/no-xdebug-in-final-image
+
+Final image installs or enables Xdebug, a development-only tool.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning |
+| Category | Best Practices |
+| Default | Enabled |
+| Auto-fix | Yes (comment-out as suggestion, delete as unsafe) |
+
+## Description
+
+Flags Xdebug installations in the final image stage. Xdebug is a PHP debugging and profiling tool designed for development workflows. Shipping it in
+production images degrades performance, increases image size, and widens the attack surface.
+
+The rule detects:
+
+- `docker-php-ext-install xdebug`
+- `docker-php-ext-enable xdebug`
+- `pecl install xdebug` (including versioned forms like `xdebug-3.4.0`)
+- Package manager installs containing xdebug (`apt-get install php-xdebug`, `apk add php-pecl-xdebug`, etc.)
+- Observable scripts (COPY heredoc, build context) that install Xdebug
+
+Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug` are skipped. Only the final stage is checked — intermediate builder
+stages are expected to have development tooling.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM php:8.4-fpm AS app
+WORKDIR /app
+COPY . .
+RUN docker-php-ext-install gd intl
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+```
+
+### After
+
+Move Xdebug into a dedicated development stage:
+
+```dockerfile
+FROM php:8.4-fpm AS app
+WORKDIR /app
+COPY . .
+RUN docker-php-ext-install gd intl
+
+FROM app AS dev
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+```
+
+## Fix behavior
+
+When the entire RUN instruction only installs or enables Xdebug, two alternative fixes are offered:
+
+1. **Comment out** (suggestion, preferred): Prefixes each line with `#`.
+2. **Delete** (unsafe): Removes the instruction entirely.
+
+When Xdebug is mixed with other extensions in the same command (e.g., `docker-php-ext-install gd xdebug intl`), no auto-fix is offered — the rule
+reports the violation for manual resolution.
+
+## References
+
+- [Docker guide for PHP: develop](https://docs.docker.com/guides/php/develop/)
+- [Laravel Sail: Xdebug](https://laravel.com/docs/12.x/sail)
+- [PHP OPcache manual](https://www.php.net/manual/en/book.opcache.php)

--- a/internal/integration/__snapshots__/TestFix_php-no-xdebug-in-final-image-comment-out_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_php-no-xdebug-in-final-image-comment-out_1.snap.Dockerfile
@@ -1,0 +1,5 @@
+FROM php:8.4-cli AS builder
+RUN docker-php-ext-install xdebug
+
+FROM php:8.4-fpm AS app
+# RUN pecl install xdebug

--- a/internal/integration/__snapshots__/TestLint_php-no-xdebug-in-final-image_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_php-no-xdebug-in-final-image_1.snap.json
@@ -1,0 +1,124 @@
+{
+  "files": [
+    {
+      "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+      "violations": [
+        {
+          "detail": "Xdebug is a development and debugging tool that should not ship in production images. Move the Xdebug installation into a dedicated dev or debug build stage.",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/php/no-xdebug-in-final-image/",
+          "location": {
+            "end": {
+              "column": 8,
+              "line": 11
+            },
+            "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+            "start": {
+              "column": 4,
+              "line": 11
+            }
+          },
+          "message": "Final image installs or enables Xdebug, a development-only tool",
+          "rule": "tally/php/no-xdebug-in-final-image",
+          "severity": "warning",
+          "sourceCode": "RUN pecl install xdebug",
+          "suggestedFix": {
+            "description": "Comment out Xdebug installation",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 23,
+                    "line": 11
+                  },
+                  "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 11
+                  }
+                },
+                "newText": "# RUN pecl install xdebug"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          },
+          "suggestedFixes": [
+            {
+              "description": "Comment out Xdebug installation",
+              "edits": [
+                {
+                  "location": {
+                    "end": {
+                      "column": 23,
+                      "line": 11
+                    },
+                    "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+                    "start": {
+                      "column": 0,
+                      "line": 11
+                    }
+                  },
+                  "newText": "# RUN pecl install xdebug"
+                }
+              ],
+              "isPreferred": true,
+              "priority": 88,
+              "safety": 1
+            },
+            {
+              "description": "Delete Xdebug installation",
+              "edits": [
+                {
+                  "location": {
+                    "end": {
+                      "column": 0,
+                      "line": 12
+                    },
+                    "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+                    "start": {
+                      "column": 0,
+                      "line": 11
+                    }
+                  },
+                  "newText": ""
+                }
+              ],
+              "priority": 88,
+              "safety": 2
+            }
+          ]
+        },
+        {
+          "detail": "Xdebug is a development and debugging tool that should not ship in production images. Move the Xdebug installation into a dedicated dev or debug build stage.",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/php/no-xdebug-in-final-image/",
+          "location": {
+            "end": {
+              "column": 11,
+              "line": 12
+            },
+            "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+            "start": {
+              "column": 4,
+              "line": 12
+            }
+          },
+          "message": "Final image installs or enables Xdebug, a development-only tool",
+          "rule": "tally/php/no-xdebug-in-final-image",
+          "severity": "warning",
+          "sourceCode": "RUN apt-get install -y php-xdebug"
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 2,
+    "warnings": 2
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_php-no-xdebug-in-final-image_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_php-no-xdebug-in-final-image_1.snap.json
@@ -106,7 +106,74 @@
           "message": "Final image installs or enables Xdebug, a development-only tool",
           "rule": "tally/php/no-xdebug-in-final-image",
           "severity": "warning",
-          "sourceCode": "RUN apt-get install -y php-xdebug"
+          "sourceCode": "RUN apt-get install -y php-xdebug",
+          "suggestedFix": {
+            "description": "Comment out Xdebug installation",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 33,
+                    "line": 12
+                  },
+                  "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 12
+                  }
+                },
+                "newText": "# RUN apt-get install -y php-xdebug"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          },
+          "suggestedFixes": [
+            {
+              "description": "Comment out Xdebug installation",
+              "edits": [
+                {
+                  "location": {
+                    "end": {
+                      "column": 33,
+                      "line": 12
+                    },
+                    "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+                    "start": {
+                      "column": 0,
+                      "line": 12
+                    }
+                  },
+                  "newText": "# RUN apt-get install -y php-xdebug"
+                }
+              ],
+              "isPreferred": true,
+              "priority": 88,
+              "safety": 1
+            },
+            {
+              "description": "Delete Xdebug installation",
+              "edits": [
+                {
+                  "location": {
+                    "end": {
+                      "column": 0,
+                      "line": 13
+                    },
+                    "file": "testdata/php-no-xdebug-in-final-image/Dockerfile",
+                    "start": {
+                      "column": 0,
+                      "line": 12
+                    }
+                  },
+                  "newText": ""
+                }
+              ],
+              "priority": 88,
+              "safety": 2
+            }
+          ]
         }
       ]
     }

--- a/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "files_scanned": 1,
-  "rules_enabled": 94,
+  "rules_enabled": 95,
   "summary": {
     "errors": 0,
     "files": 0,

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1373,6 +1373,20 @@ severity = "style"
 severity = "warning"
 `,
 		},
+		// PHP: no-xdebug-in-final-image comments out a standalone xdebug
+		// installation. The pecl install is the only command in the RUN, so the
+		// preferred comment-out fix (FixSuggestion, priority 88) applies. The
+		// builder stage is non-final so no fix there.
+		{
+			name: "php-no-xdebug-in-final-image-comment-out",
+			input: "FROM php:8.4-cli AS builder\n" +
+				"RUN docker-php-ext-install xdebug\n\n" +
+				"FROM php:8.4-fpm AS app\n" +
+				"RUN pecl install xdebug\n",
+			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules("tally/php/no-xdebug-in-final-image")...),
+			wantApplied: 1,
+		},
 		// Full composition: two secret mounts (insertion) + two cache mounts
 		// (insertion) + cleanup removal (npm cache clean, --no-cache-dir)
 		// on the same RUN in a single --fix pass.

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -254,6 +254,12 @@ func lintCases(t *testing.T) []lintCase {
 			args:     append([]string{"--format", "json"}, mustSelectRules("tally/php/composer-no-dev-in-production")...),
 			wantExit: 1,
 		},
+		{
+			name:     "php-no-xdebug-in-final-image",
+			dir:      "php-no-xdebug-in-final-image",
+			args:     append([]string{"--format", "json"}, mustSelectRules("tally/php/no-xdebug-in-final-image")...),
+			wantExit: 1,
+		},
 
 		// Windows: RUN --mount not supported
 		{

--- a/internal/integration/testdata/php-no-xdebug-in-final-image/Dockerfile
+++ b/internal/integration/testdata/php-no-xdebug-in-final-image/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:8.4-cli AS builder
+WORKDIR /ext
+RUN docker-php-ext-install xdebug
+
+FROM php:8.4-cli AS dev
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+
+FROM php:8.4-fpm AS app
+WORKDIR /app
+RUN docker-php-ext-install gd intl
+RUN pecl install xdebug
+RUN apt-get install -y php-xdebug

--- a/internal/rules/tally/php/composer_no_dev_in_production.go
+++ b/internal/rules/tally/php/composer_no_dev_in_production.go
@@ -111,7 +111,7 @@ func (r *ComposerNoDevInProductionRule) checkRun(
 		}
 
 		v := rules.NewViolation(
-			composerCommandLocation(file, run, cmd, runStartLine),
+			phpCommandLocation(file, run, cmd, runStartLine),
 			meta.Code,
 			meta.Description,
 			meta.DefaultSeverity,

--- a/internal/rules/tally/php/helpers.go
+++ b/internal/rules/tally/php/helpers.go
@@ -4,7 +4,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
 	"github.com/wharflab/tally/internal/facts"
@@ -14,7 +13,10 @@ import (
 	"github.com/wharflab/tally/internal/sourcemap"
 )
 
-const subcommandInstall = "install"
+const (
+	subcommandInstall = "install"
+	subcommandAdd     = "add" //nolint:customlint // apk subcommand, not Dockerfile ADD instruction
+)
 
 var nonProductionStageTokens = []string{"dev", "development", "test", "testing", "ci", "debug"}
 
@@ -138,7 +140,7 @@ func commandReferencesXdebug(cmd shell.CommandInfo) bool {
 	case "apt-get", "apt":
 		return cmd.Subcommand == subcommandInstall && argsContainXdebugSubstring(cmd.Args)
 	case "apk":
-		return cmd.Subcommand == command.Add && argsContainXdebugSubstring(cmd.Args)
+		return cmd.Subcommand == subcommandAdd && argsContainXdebugSubstring(cmd.Args)
 	case "dnf", "yum":
 		return cmd.Subcommand == subcommandInstall && argsContainXdebugSubstring(cmd.Args)
 	default:

--- a/internal/rules/tally/php/helpers.go
+++ b/internal/rules/tally/php/helpers.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
 	"github.com/wharflab/tally/internal/facts"
@@ -12,6 +13,8 @@ import (
 	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/sourcemap"
 )
+
+const subcommandInstall = "install"
 
 var nonProductionStageTokens = []string{"dev", "development", "test", "testing", "ci", "debug"}
 
@@ -59,7 +62,7 @@ func composerTruthy(value string) bool {
 }
 
 func composerInstallHasNoDev(cmd shell.CommandInfo) bool {
-	return cmd.Subcommand == "install" && cmd.HasFlag("--no-dev")
+	return cmd.Subcommand == subcommandInstall && cmd.HasFlag("--no-dev")
 }
 
 func findComposerCommands(
@@ -82,7 +85,7 @@ func findComposerCommands(
 	return filtered, runStartLine
 }
 
-func composerCommandLocation(
+func phpCommandLocation(
 	file string,
 	run *instructions.RunCommand,
 	cmd shell.CommandInfo,
@@ -93,4 +96,80 @@ func composerCommandLocation(
 	}
 	cmdLine := runStartLine + cmd.Line
 	return rules.NewRangeLocation(file, cmdLine, cmd.StartCol, cmdLine, cmd.EndCol)
+}
+
+// xdebugCommandNames are the command names that can install or enable Xdebug.
+var xdebugCommandNames = []string{
+	"docker-php-ext-install",
+	"docker-php-ext-enable",
+	"pecl",
+	"apt-get", "apt",
+	"apk",
+	"dnf", "yum",
+}
+
+// findXdebugCommands returns commands that install or enable Xdebug in a RUN instruction.
+func findXdebugCommands(
+	run *instructions.RunCommand,
+	shellVariant shell.Variant,
+	sm *sourcemap.SourceMap,
+) ([]shell.CommandInfo, int) {
+	cmds, runStartLine := runcheck.FindCommands(run, shellVariant, sm, xdebugCommandNames...)
+	if len(cmds) == 0 {
+		return nil, 0
+	}
+
+	filtered := make([]shell.CommandInfo, 0, len(cmds))
+	for _, cmd := range cmds {
+		if commandReferencesXdebug(cmd) {
+			filtered = append(filtered, cmd)
+		}
+	}
+	return filtered, runStartLine
+}
+
+// commandReferencesXdebug checks whether a parsed command installs or enables Xdebug.
+func commandReferencesXdebug(cmd shell.CommandInfo) bool {
+	switch cmd.Name {
+	case "docker-php-ext-install", "docker-php-ext-enable":
+		return argsContainXdebug(cmd.Args)
+	case "pecl":
+		return cmd.Subcommand == subcommandInstall && argsContainXdebug(cmd.Args)
+	case "apt-get", "apt":
+		return cmd.Subcommand == subcommandInstall && argsContainXdebugSubstring(cmd.Args)
+	case "apk":
+		return cmd.Subcommand == command.Add && argsContainXdebugSubstring(cmd.Args)
+	case "dnf", "yum":
+		return cmd.Subcommand == subcommandInstall && argsContainXdebugSubstring(cmd.Args)
+	default:
+		return false
+	}
+}
+
+// argsContainXdebug checks if any non-flag arg is "xdebug" or starts with "xdebug-" (versioned pecl).
+func argsContainXdebug(args []string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		lower := strings.ToLower(arg)
+		if lower == "xdebug" || strings.HasPrefix(lower, "xdebug-") {
+			return true
+		}
+	}
+	return false
+}
+
+// argsContainXdebugSubstring checks if any non-flag arg contains "xdebug" as a substring.
+// Used for package-manager installs where package names vary (php-xdebug, php8.3-xdebug, etc.).
+func argsContainXdebugSubstring(args []string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if strings.Contains(strings.ToLower(arg), "xdebug") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/rules/tally/php/helpers_test.go
+++ b/internal/rules/tally/php/helpers_test.go
@@ -182,63 +182,6 @@ func TestArgsContainXdebugSubstring(t *testing.T) {
 	}
 }
 
-func TestLooksLikeShellScript(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		path string
-		want bool
-	}{
-		{name: "sh extension", path: "/usr/local/bin/setup.sh", want: true},
-		{name: "bash extension", path: "/opt/install.bash", want: true},
-		{name: "install in name", path: "/usr/local/bin/install-extensions", want: true},
-		{name: "setup in name", path: "/app/setup", want: true},
-		{name: "init in name", path: "/docker-entrypoint-init", want: true},
-		{name: "entrypoint in name", path: "/usr/local/bin/docker-entrypoint", want: true},
-		{name: "start in name", path: "/app/start-server", want: true},
-		{name: "php file", path: "/app/index.php", want: false},
-		{name: "config file", path: "/etc/php/conf.d/xdebug.ini", want: false},
-		{name: "random binary", path: "/usr/bin/composer", want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := looksLikeShellScript(tt.path); got != tt.want {
-				t.Errorf("looksLikeShellScript(%q) = %v, want %v", tt.path, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestContentLooksLikeShellScript(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		content string
-		want    bool
-	}{
-		{name: "bin sh shebang", content: "#!/bin/sh\ndocker-php-ext-install xdebug\n", want: true},
-		{name: "bin bash shebang", content: "#!/bin/bash\nset -e\npecl install xdebug\n", want: true},
-		{name: "env sh shebang", content: "#!/usr/bin/env sh\necho hello\n", want: true},
-		{name: "env bash shebang", content: "#!/usr/bin/env bash\necho hello\n", want: true},
-		{name: "no shebang", content: "docker-php-ext-install xdebug\n", want: false},
-		{name: "php shebang", content: "#!/usr/bin/php\n<?php echo 1;\n", want: false},
-		{name: "empty", content: "", want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := contentLooksLikeShellScript(tt.content); got != tt.want {
-				t.Errorf("contentLooksLikeShellScript() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestComposerTruthy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/php/helpers_test.go
+++ b/internal/rules/tally/php/helpers_test.go
@@ -195,6 +195,8 @@ func TestLooksLikeShellScript(t *testing.T) {
 		{name: "install in name", path: "/usr/local/bin/install-extensions", want: true},
 		{name: "setup in name", path: "/app/setup", want: true},
 		{name: "init in name", path: "/docker-entrypoint-init", want: true},
+		{name: "entrypoint in name", path: "/usr/local/bin/docker-entrypoint", want: true},
+		{name: "start in name", path: "/app/start-server", want: true},
 		{name: "php file", path: "/app/index.php", want: false},
 		{name: "config file", path: "/etc/php/conf.d/xdebug.ini", want: false},
 		{name: "random binary", path: "/usr/bin/composer", want: false},
@@ -205,6 +207,33 @@ func TestLooksLikeShellScript(t *testing.T) {
 			t.Parallel()
 			if got := looksLikeShellScript(tt.path); got != tt.want {
 				t.Errorf("looksLikeShellScript(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentLooksLikeShellScript(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "bin sh shebang", content: "#!/bin/sh\ndocker-php-ext-install xdebug\n", want: true},
+		{name: "bin bash shebang", content: "#!/bin/bash\nset -e\npecl install xdebug\n", want: true},
+		{name: "env sh shebang", content: "#!/usr/bin/env sh\necho hello\n", want: true},
+		{name: "env bash shebang", content: "#!/usr/bin/env bash\necho hello\n", want: true},
+		{name: "no shebang", content: "docker-php-ext-install xdebug\n", want: false},
+		{name: "php shebang", content: "#!/usr/bin/php\n<?php echo 1;\n", want: false},
+		{name: "empty", content: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := contentLooksLikeShellScript(tt.content); got != tt.want {
+				t.Errorf("contentLooksLikeShellScript() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/rules/tally/php/helpers_test.go
+++ b/internal/rules/tally/php/helpers_test.go
@@ -1,6 +1,10 @@
 package php
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/shell"
+)
 
 func TestStageLooksLikeDev(t *testing.T) {
 	t.Parallel()
@@ -23,6 +27,184 @@ func TestStageLooksLikeDev(t *testing.T) {
 			t.Parallel()
 			if got := stageLooksLikeDev(tt.stage); got != tt.want {
 				t.Errorf("stageLooksLikeDev(%q) = %v, want %v", tt.stage, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandReferencesXdebug(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  shell.CommandInfo
+		want bool
+	}{
+		{
+			name: "docker-php-ext-install xdebug",
+			cmd:  shell.CommandInfo{Name: "docker-php-ext-install", Subcommand: "xdebug", Args: []string{"xdebug"}},
+			want: true,
+		},
+		{
+			name: "docker-php-ext-enable xdebug",
+			cmd:  shell.CommandInfo{Name: "docker-php-ext-enable", Subcommand: "xdebug", Args: []string{"xdebug"}},
+			want: true,
+		},
+		{
+			name: "docker-php-ext-install xdebug not first arg",
+			cmd:  shell.CommandInfo{Name: "docker-php-ext-install", Subcommand: "gd", Args: []string{"gd", "xdebug"}},
+			want: true,
+		},
+		{
+			name: "pecl install xdebug",
+			cmd:  shell.CommandInfo{Name: "pecl", Subcommand: "install", Args: []string{"install", "xdebug"}},
+			want: true,
+		},
+		{
+			name: "pecl install versioned xdebug",
+			cmd:  shell.CommandInfo{Name: "pecl", Subcommand: "install", Args: []string{"install", "xdebug-3.4.0"}},
+			want: true,
+		},
+		{
+			name: "pecl uninstall xdebug ignored",
+			cmd:  shell.CommandInfo{Name: "pecl", Subcommand: "uninstall", Args: []string{"uninstall", "xdebug"}},
+			want: false,
+		},
+		{
+			name: "apt-get install php-xdebug",
+			cmd:  shell.CommandInfo{Name: "apt-get", Subcommand: "install", Args: []string{"install", "-y", "php-xdebug"}},
+			want: true,
+		},
+		{
+			name: "apt-get install versioned php8.3-xdebug",
+			cmd:  shell.CommandInfo{Name: "apt-get", Subcommand: "install", Args: []string{"install", "php8.3-xdebug"}},
+			want: true,
+		},
+		{
+			name: "apk add php-pecl-xdebug",
+			cmd:  shell.CommandInfo{Name: "apk", Subcommand: "add", Args: []string{"add", "--no-cache", "php83-pecl-xdebug"}},
+			want: true,
+		},
+		{
+			name: "dnf install php-pecl-xdebug",
+			cmd:  shell.CommandInfo{Name: "dnf", Subcommand: "install", Args: []string{"install", "php-pecl-xdebug"}},
+			want: true,
+		},
+		{
+			name: "yum install php-pecl-xdebug",
+			cmd:  shell.CommandInfo{Name: "yum", Subcommand: "install", Args: []string{"install", "php-pecl-xdebug"}},
+			want: true,
+		},
+		{
+			name: "docker-php-ext-install gd only",
+			cmd:  shell.CommandInfo{Name: "docker-php-ext-install", Subcommand: "gd", Args: []string{"gd"}},
+			want: false,
+		},
+		{
+			name: "pecl install redis",
+			cmd:  shell.CommandInfo{Name: "pecl", Subcommand: "install", Args: []string{"install", "redis"}},
+			want: false,
+		},
+		{
+			name: "apt-get update",
+			cmd:  shell.CommandInfo{Name: "apt-get", Subcommand: "update", Args: []string{"update"}},
+			want: false,
+		},
+		{
+			name: "unrelated command",
+			cmd:  shell.CommandInfo{Name: "echo", Subcommand: "hello", Args: []string{"hello"}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := commandReferencesXdebug(tt.cmd); got != tt.want {
+				t.Errorf("commandReferencesXdebug(%v) = %v, want %v", tt.cmd.Name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestArgsContainXdebug(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "exact match", args: []string{"xdebug"}, want: true},
+		{name: "versioned", args: []string{"xdebug-3.4.0"}, want: true},
+		{name: "among others", args: []string{"gd", "xdebug", "intl"}, want: true},
+		{name: "skip flags", args: []string{"-j$(nproc)", "xdebug"}, want: true},
+		{name: "case insensitive", args: []string{"Xdebug"}, want: true},
+		{name: "no match", args: []string{"gd", "intl"}, want: false},
+		{name: "empty", args: nil, want: false},
+		{name: "flags only", args: []string{"--enable-debug"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := argsContainXdebug(tt.args); got != tt.want {
+				t.Errorf("argsContainXdebug(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestArgsContainXdebugSubstring(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "php-xdebug", args: []string{"php-xdebug"}, want: true},
+		{name: "php8.3-xdebug", args: []string{"php8.3-xdebug"}, want: true},
+		{name: "php-pecl-xdebug", args: []string{"php-pecl-xdebug"}, want: true},
+		{name: "php83-pecl-xdebug", args: []string{"php83-pecl-xdebug"}, want: true},
+		{name: "skip flags", args: []string{"-y", "php-xdebug"}, want: true},
+		{name: "no xdebug", args: []string{"php-gd", "php-intl"}, want: false},
+		{name: "empty", args: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := argsContainXdebugSubstring(tt.args); got != tt.want {
+				t.Errorf("argsContainXdebugSubstring(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeShellScript(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "sh extension", path: "/usr/local/bin/setup.sh", want: true},
+		{name: "bash extension", path: "/opt/install.bash", want: true},
+		{name: "install in name", path: "/usr/local/bin/install-extensions", want: true},
+		{name: "setup in name", path: "/app/setup", want: true},
+		{name: "init in name", path: "/docker-entrypoint-init", want: true},
+		{name: "php file", path: "/app/index.php", want: false},
+		{name: "config file", path: "/etc/php/conf.d/xdebug.ini", want: false},
+		{name: "random binary", path: "/usr/bin/composer", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := looksLikeShellScript(tt.path); got != tt.want {
+				t.Errorf("looksLikeShellScript(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
 	}

--- a/internal/rules/tally/php/no_xdebug_in_final_image.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image.go
@@ -1,0 +1,289 @@
+package php
+
+import (
+	"bytes"
+	"path"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+// NoXdebugInFinalImageRuleCode is the full rule code.
+const NoXdebugInFinalImageRuleCode = rules.TallyRulePrefix + "php/no-xdebug-in-final-image"
+
+// NoXdebugInFinalImageRule flags Xdebug installations in the final image stage.
+type NoXdebugInFinalImageRule struct{}
+
+// NewNoXdebugInFinalImageRule creates the rule.
+func NewNoXdebugInFinalImageRule() *NoXdebugInFinalImageRule {
+	return &NoXdebugInFinalImageRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *NoXdebugInFinalImageRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            NoXdebugInFinalImageRuleCode,
+		Name:            "Xdebug should not be installed in the final image",
+		Description:     "Final image installs or enables Xdebug, a development-only tool",
+		DocURL:          rules.TallyDocURL(NoXdebugInFinalImageRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "best-practices",
+		FixPriority:     88, //nolint:mnd // stable priority contract, consistent with companion PHP rules
+	}
+}
+
+// Check runs the rule.
+func (r *NoXdebugInFinalImageRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	sm := input.SourceMap()
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stageLooksLikeDev(stage.Name) {
+			continue
+		}
+
+		stageFacts := input.Facts.Stage(stageIdx)
+		if stageFacts == nil || !stageFacts.IsLast {
+			continue
+		}
+		if stageFacts.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+
+		violations = append(violations, r.checkRunCommands(stageFacts, input.File, input.Source, meta, sm)...)
+		violations = append(violations, r.checkObservableFiles(stageFacts, input.File, meta)...)
+	}
+
+	return violations
+}
+
+func (r *NoXdebugInFinalImageRule) checkRunCommands(
+	stageFacts *facts.StageFacts,
+	file string,
+	source []byte,
+	meta rules.RuleMetadata,
+	sm *sourcemap.SourceMap,
+) []rules.Violation {
+	var violations []rules.Violation
+
+	for _, runFacts := range stageFacts.Runs {
+		if runFacts == nil {
+			continue
+		}
+
+		shellVariant, ok := factsRunShellVariant(runFacts)
+		if !ok {
+			continue
+		}
+
+		xdebugCmds, runStartLine := findXdebugCommands(runFacts.Run, shellVariant, sm)
+		if len(xdebugCmds) == 0 {
+			continue
+		}
+
+		allXdebug := allCommandsOnlyXdebug(runFacts.CommandInfos)
+
+		for _, cmd := range xdebugCmds {
+			v := rules.NewViolation(
+				phpCommandLocation(file, runFacts.Run, cmd, runStartLine),
+				meta.Code,
+				meta.Description,
+				meta.DefaultSeverity,
+			).WithDocURL(meta.DocURL).WithDetail(
+				"Xdebug is a development and debugging tool that should not ship in production images. " +
+					"Move the Xdebug installation into a dedicated dev or debug build stage.",
+			)
+
+			if allXdebug {
+				v = v.WithSuggestedFixes(buildXdebugFixes(file, source, runFacts.Run, meta.FixPriority, sm))
+			}
+
+			violations = append(violations, v)
+		}
+	}
+
+	return violations
+}
+
+func (r *NoXdebugInFinalImageRule) checkObservableFiles(
+	stageFacts *facts.StageFacts,
+	file string,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	var violations []rules.Violation
+
+	for _, observed := range stageFacts.ObservableFiles {
+		if observed == nil || observed.Source == facts.ObservableFileSourceRun {
+			continue
+		}
+		if !looksLikeShellScript(observed.Path) {
+			continue
+		}
+
+		content, ok := observed.Content()
+		if !ok || content == "" {
+			continue
+		}
+
+		cmds := shell.FindCommands(content, shell.VariantBash, xdebugCommandNames...)
+		for _, cmd := range cmds {
+			if !commandReferencesXdebug(cmd) {
+				continue
+			}
+
+			v := rules.NewViolation(
+				rules.NewLineLocation(file, observed.Line),
+				meta.Code,
+				"Observable script installs Xdebug in the final image",
+				meta.DefaultSeverity,
+			).WithDocURL(meta.DocURL).WithDetail(
+				"The script at " + observed.Path + " installs Xdebug. " +
+					"Move the Xdebug installation into a dedicated dev or debug build stage.",
+			)
+			violations = append(violations, v)
+		}
+	}
+
+	return violations
+}
+
+// allCommandsOnlyXdebug reports whether every command in a RUN instruction
+// exclusively does Xdebug work (no other extensions or packages), meaning the
+// entire instruction can be safely commented out or deleted.
+func allCommandsOnlyXdebug(cmds []shell.CommandInfo) bool {
+	if len(cmds) == 0 {
+		return false
+	}
+	for _, cmd := range cmds {
+		if !commandOnlyDoesXdebug(cmd) {
+			return false
+		}
+	}
+	return true
+}
+
+// commandOnlyDoesXdebug checks whether a command installs/enables Xdebug
+// exclusively, with no other extensions or packages.
+func commandOnlyDoesXdebug(cmd shell.CommandInfo) bool {
+	switch cmd.Name {
+	case "docker-php-ext-install", "docker-php-ext-enable":
+		return allNonFlagArgsAreXdebug(cmd.Args)
+	case "pecl":
+		if cmd.Subcommand != subcommandInstall {
+			return false
+		}
+		return allNonFlagArgsAreXdebug(argsAfterSubcommand(cmd.Args, subcommandInstall))
+	case "apt-get", "apt", "apk", "dnf", "yum":
+		return false // package managers always have mixed installs
+	default:
+		return false
+	}
+}
+
+func allNonFlagArgsAreXdebug(args []string) bool {
+	found := false
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		lower := strings.ToLower(arg)
+		if lower != "xdebug" && !strings.HasPrefix(lower, "xdebug-") {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+func argsAfterSubcommand(args []string, subcmd string) []string {
+	for i, arg := range args {
+		if arg == subcmd {
+			return args[i+1:]
+		}
+	}
+	return args
+}
+
+// buildXdebugFixes returns comment-out and delete fix alternatives for a RUN
+// instruction that only installs/enables Xdebug.
+func buildXdebugFixes(
+	file string,
+	source []byte,
+	run *instructions.RunCommand,
+	priority int,
+	sm *sourcemap.SourceMap,
+) []*rules.SuggestedFix {
+	locs := run.Location()
+	if len(locs) == 0 || sm == nil {
+		return nil
+	}
+
+	startLine := locs[0].Start.Line // 1-based
+	endLine := sm.ResolveEndLine(
+		locs[len(locs)-1].End.Line,
+	) // 1-based, resolve continuations
+
+	// Build the commented-out text: prefix each source line with "# ".
+	var commented strings.Builder
+	for l := startLine; l <= endLine; l++ {
+		line := sm.Line(l - 1)
+		commented.WriteString("# ")
+		commented.WriteString(line)
+		if l < endLine {
+			commented.WriteByte('\n')
+		}
+	}
+
+	lastLineText := sm.Line(endLine - 1)
+	editLoc := rules.NewRangeLocation(file, startLine, 0, endLine, len(lastLineText))
+
+	totalLines := bytes.Count(source, []byte("\n")) + 1
+	deleteLoc := rules.DeleteLineLocation(file, startLine, len(lastLineText), totalLines)
+	if startLine < endLine {
+		// Multi-line: delete from start of first line to start of line after last.
+		if endLine < totalLines {
+			deleteLoc = rules.NewRangeLocation(file, startLine, 0, endLine+1, 0)
+		} else {
+			deleteLoc = rules.NewRangeLocation(file, startLine, 0, endLine, len(lastLineText))
+		}
+	}
+
+	return []*rules.SuggestedFix{
+		{
+			Description: "Comment out Xdebug installation",
+			Safety:      rules.FixSuggestion,
+			Priority:    priority,
+			IsPreferred: true,
+			Edits:       []rules.TextEdit{{Location: editLoc, NewText: commented.String()}},
+		},
+		{
+			Description: "Delete Xdebug installation",
+			Safety:      rules.FixUnsafe,
+			Priority:    priority,
+			Edits:       []rules.TextEdit{{Location: deleteLoc, NewText: ""}},
+		},
+	}
+}
+
+// looksLikeShellScript checks if a file path looks like a shell script.
+func looksLikeShellScript(filePath string) bool {
+	switch path.Ext(filePath) {
+	case ".sh", ".bash":
+		return true
+	}
+	base := strings.ToLower(path.Base(filePath))
+	return strings.Contains(base, "install") ||
+		strings.Contains(base, "setup") ||
+		strings.Contains(base, "init")
+}
+
+func init() {
+	rules.Register(NewNoXdebugInFinalImageRule())
+}

--- a/internal/rules/tally/php/no_xdebug_in_final_image.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image.go
@@ -123,12 +123,15 @@ func (r *NoXdebugInFinalImageRule) checkObservableFiles(
 		if observed == nil || observed.Source == facts.ObservableFileSourceRun {
 			continue
 		}
-		if !looksLikeShellScript(observed.Path) {
-			continue
-		}
 
 		content, ok := observed.Content()
 		if !ok || content == "" {
+			continue
+		}
+
+		// Check filename first; fall back to shebang for extensionless scripts
+		// like /usr/local/bin/docker-entrypoint.
+		if !looksLikeShellScript(observed.Path) && !contentLooksLikeShellScript(content) {
 			continue
 		}
 
@@ -308,9 +311,19 @@ func looksLikeShellScript(filePath string) bool {
 		return true
 	}
 	base := strings.ToLower(path.Base(filePath))
-	return strings.Contains(base, "install") ||
+	return strings.Contains(base, "entrypoint") || //nolint:customlint // filename pattern, not Dockerfile instruction
+		strings.Contains(base, "install") ||
 		strings.Contains(base, "setup") ||
-		strings.Contains(base, "init")
+		strings.Contains(base, "init") ||
+		strings.Contains(base, "start")
+}
+
+// contentLooksLikeShellScript checks if file content starts with a shell shebang.
+func contentLooksLikeShellScript(content string) bool {
+	return strings.HasPrefix(content, "#!/bin/sh") ||
+		strings.HasPrefix(content, "#!/bin/bash") ||
+		strings.HasPrefix(content, "#!/usr/bin/env sh") ||
+		strings.HasPrefix(content, "#!/usr/bin/env bash")
 }
 
 func init() {

--- a/internal/rules/tally/php/no_xdebug_in_final_image.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image.go
@@ -180,8 +180,21 @@ func commandOnlyDoesXdebug(cmd shell.CommandInfo) bool {
 			return false
 		}
 		return allNonFlagArgsAreXdebug(argsAfterSubcommand(cmd.Args, subcommandInstall))
-	case "apt-get", "apt", "apk", "dnf", "yum":
-		return false // package managers always have mixed installs
+	case "apt-get", "apt":
+		if cmd.Subcommand != subcommandInstall {
+			return false
+		}
+		return allNonFlagArgsAreXdebugSubstring(argsAfterSubcommand(cmd.Args, subcommandInstall))
+	case "apk":
+		if cmd.Subcommand != subcommandAdd {
+			return false
+		}
+		return allNonFlagArgsAreXdebugSubstring(argsAfterSubcommand(cmd.Args, subcommandAdd))
+	case "dnf", "yum":
+		if cmd.Subcommand != subcommandInstall {
+			return false
+		}
+		return allNonFlagArgsAreXdebugSubstring(argsAfterSubcommand(cmd.Args, subcommandInstall))
 	default:
 		return false
 	}
@@ -195,6 +208,22 @@ func allNonFlagArgsAreXdebug(args []string) bool {
 		}
 		lower := strings.ToLower(arg)
 		if lower != "xdebug" && !strings.HasPrefix(lower, "xdebug-") {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+// allNonFlagArgsAreXdebugSubstring is like allNonFlagArgsAreXdebug but uses
+// substring matching for package-manager packages (e.g., "php-xdebug").
+func allNonFlagArgsAreXdebugSubstring(args []string) bool {
+	found := false
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(arg), "xdebug") {
 			return false
 		}
 		found = true

--- a/internal/rules/tally/php/no_xdebug_in_final_image_test.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image_test.go
@@ -178,6 +178,30 @@ RUN docker-php-ext-install xdebug
 `,
 			WantViolations: 1,
 		},
+		// --- Observable file (COPY heredoc) ---
+		{
+			Name: "COPY heredoc script installing xdebug triggers violation",
+			Content: `FROM php:8.4-fpm AS app
+COPY <<EOF /usr/local/bin/setup.sh
+#!/bin/bash
+pecl install xdebug
+docker-php-ext-enable xdebug
+EOF
+RUN chmod +x /usr/local/bin/setup.sh && /usr/local/bin/setup.sh
+`,
+			WantViolations: 2,
+		},
+		{
+			Name: "COPY heredoc script without xdebug no violation",
+			Content: `FROM php:8.4-fpm AS app
+COPY <<EOF /usr/local/bin/setup.sh
+#!/bin/bash
+docker-php-ext-install gd intl
+EOF
+RUN chmod +x /usr/local/bin/setup.sh && /usr/local/bin/setup.sh
+`,
+			WantViolations: 0,
+		},
 	})
 }
 

--- a/internal/rules/tally/php/no_xdebug_in_final_image_test.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image_test.go
@@ -231,6 +231,42 @@ func TestNoXdebugInFinalImageRule_SuggestedFix_MultiLine(t *testing.T) {
 	}
 }
 
+func TestNoXdebugInFinalImageRule_SuggestedFix_AptGetSinglePackage(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN apt-get install -y php-xdebug\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix for standalone apt-get xdebug install")
+	}
+	if fix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", fix.Safety)
+	}
+	if fix.Edits[0].NewText != "# RUN apt-get install -y php-xdebug" {
+		t.Errorf("NewText = %q, want commented-out line", fix.Edits[0].NewText)
+	}
+}
+
+func TestNoXdebugInFinalImageRule_NoFixWhenMixedPackages(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN apt-get install -y php-gd php-xdebug php-intl\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Error("expected no SuggestedFix when xdebug is mixed with other packages")
+	}
+}
+
 func TestNoXdebugInFinalImageRule_NoFixWhenMixed(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/php/no_xdebug_in_final_image_test.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image_test.go
@@ -1,0 +1,286 @@
+package php
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestNoXdebugInFinalImageRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewNoXdebugInFinalImageRule().Metadata()
+	if meta.Code != NoXdebugInFinalImageRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, NoXdebugInFinalImageRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityWarning {
+		t.Errorf("DefaultSeverity = %v, want Warning", meta.DefaultSeverity)
+	}
+	if meta.Category != "best-practices" {
+		t.Errorf("Category = %q, want %q", meta.Category, "best-practices")
+	}
+	if meta.FixPriority != 88 { //nolint:mnd // stable priority contract
+		t.Errorf("FixPriority = %d, want 88", meta.FixPriority)
+	}
+}
+
+func TestNoXdebugInFinalImageRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewNoXdebugInFinalImageRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "docker-php-ext-install xdebug triggers violation",
+			Content: `FROM php:8.4-cli
+RUN docker-php-ext-install xdebug
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "docker-php-ext-enable xdebug triggers violation",
+			Content: `FROM php:8.4-cli
+RUN docker-php-ext-enable xdebug
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "pecl install xdebug triggers violation",
+			Content: `FROM php:8.4-cli
+RUN pecl install xdebug
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "versioned pecl install triggers violation",
+			Content: `FROM php:8.4-cli
+RUN pecl install xdebug-3.4.0
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "xdebug among other extensions triggers violation",
+			Content: `FROM php:8.4-cli
+RUN docker-php-ext-install gd xdebug intl
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "apt-get install php-xdebug triggers violation",
+			Content: `FROM php:8.4-cli
+RUN apt-get install -y php-xdebug
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "apt-get versioned php8.3-xdebug triggers violation",
+			Content: `FROM php:8.4-cli
+RUN apt-get install -y php8.3-xdebug
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "apk add php-pecl-xdebug triggers violation",
+			Content: `FROM php:8.4-cli
+RUN apk add --no-cache php83-pecl-xdebug
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "chained install and enable reports both",
+			Content: `FROM php:8.4-cli
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+`,
+			WantViolations: 2,
+		},
+		{
+			Name: "exec form pecl install xdebug triggers violation",
+			Content: `FROM php:8.4-cli
+RUN ["pecl", "install", "xdebug"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "multi-line continuation triggers violation",
+			Content: `FROM php:8.4-cli
+RUN pecl install \
+    xdebug
+`,
+			WantViolations: 1,
+		},
+		// --- No violations ---
+		{
+			Name: "xdebug in builder stage no violation",
+			Content: `FROM php:8.4-cli AS builder
+RUN docker-php-ext-install xdebug
+
+FROM php:8.4-cli
+RUN echo done
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "xdebug in dev-named stage no violation",
+			Content: `FROM php:8.4-cli AS dev
+RUN docker-php-ext-install xdebug
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "xdebug in debug-named stage no violation",
+			Content: `FROM php:8.4-cli AS runtime.debug
+RUN pecl install xdebug
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "xdebug in test-named stage no violation",
+			Content: `FROM php:8.4-cli AS test
+RUN docker-php-ext-install xdebug
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "multi-stage only final violates",
+			Content: `FROM php:8.4-cli AS builder
+RUN docker-php-ext-install xdebug
+
+FROM php:8.4-cli AS app
+RUN docker-php-ext-install xdebug
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "no xdebug clean image",
+			Content: `FROM php:8.4-cli
+RUN docker-php-ext-install gd intl
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "windows stage skipped",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN docker-php-ext-install xdebug
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "pecl install unrelated package no violation",
+			Content: `FROM php:8.4-cli
+RUN pecl install redis
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-dev word in stage name still reports",
+			Content: `FROM php:8.4-cli AS device
+RUN docker-php-ext-install xdebug
+`,
+			WantViolations: 1,
+		},
+	})
+}
+
+func TestNoXdebugInFinalImageRule_SuggestedFix_SingleLine(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN docker-php-ext-install xdebug\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if fix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", fix.Safety)
+	}
+	if !fix.IsPreferred {
+		t.Error("expected IsPreferred = true")
+	}
+	if fix.Priority != 88 { //nolint:mnd // stable priority contract
+		t.Errorf("Priority = %d, want 88", fix.Priority)
+	}
+	if len(fix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	}
+	if fix.Edits[0].NewText != "# RUN docker-php-ext-install xdebug" {
+		t.Errorf("NewText = %q, want commented-out line", fix.Edits[0].NewText)
+	}
+}
+
+func TestNoXdebugInFinalImageRule_SuggestedFix_MultiLine(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN pecl install \\\n    xdebug\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if fix.Edits[0].NewText != "# RUN pecl install \\\n#     xdebug" {
+		t.Errorf("NewText = %q, want commented-out multi-line", fix.Edits[0].NewText)
+	}
+}
+
+func TestNoXdebugInFinalImageRule_NoFixWhenMixed(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN docker-php-ext-install gd xdebug intl\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Error("expected no SuggestedFix when xdebug is mixed with other extensions")
+	}
+}
+
+func TestNoXdebugInFinalImageRule_ExecFormHasNoFix(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN [\"pecl\", \"install\", \"xdebug\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	// Exec form may not get a fix since runStartLine can be 0 and source mapping
+	// behaves differently.
+}
+
+func TestNoXdebugInFinalImageRule_DeleteFix(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN docker-php-ext-install xdebug\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	fixes := violations[0].SuggestedFixes
+	if len(fixes) < 2 {
+		t.Fatalf("expected at least 2 alternative fixes, got %d", len(fixes))
+	}
+
+	deleteFix := fixes[1]
+	if deleteFix.Safety != rules.FixUnsafe {
+		t.Errorf("delete fix Safety = %v, want FixUnsafe", deleteFix.Safety)
+	}
+	if len(deleteFix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(deleteFix.Edits))
+	}
+	if deleteFix.Edits[0].NewText != "" {
+		t.Errorf("NewText = %q, want empty (deletion)", deleteFix.Edits[0].NewText)
+	}
+}

--- a/internal/rules/tally/php/no_xdebug_in_final_image_test.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image_test.go
@@ -320,3 +320,60 @@ func TestNoXdebugInFinalImageRule_DeleteFix(t *testing.T) {
 		t.Errorf("NewText = %q, want empty (deletion)", deleteFix.Edits[0].NewText)
 	}
 }
+
+func TestLooksLikeShellScript(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "sh extension", path: "/usr/local/bin/setup.sh", want: true},
+		{name: "bash extension", path: "/opt/install.bash", want: true},
+		{name: "install in name", path: "/usr/local/bin/install-extensions", want: true},
+		{name: "setup in name", path: "/app/setup", want: true},
+		{name: "init in name", path: "/docker-entrypoint-init", want: true},
+		{name: "entrypoint in name", path: "/usr/local/bin/docker-entrypoint", want: true},
+		{name: "start in name", path: "/app/start-server", want: true},
+		{name: "php file", path: "/app/index.php", want: false},
+		{name: "config file", path: "/etc/php/conf.d/xdebug.ini", want: false},
+		{name: "random binary", path: "/usr/bin/composer", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := looksLikeShellScript(tt.path); got != tt.want {
+				t.Errorf("looksLikeShellScript(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentLooksLikeShellScript(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "bin sh shebang", content: "#!/bin/sh\ndocker-php-ext-install xdebug\n", want: true},
+		{name: "bin bash shebang", content: "#!/bin/bash\nset -e\npecl install xdebug\n", want: true},
+		{name: "env sh shebang", content: "#!/usr/bin/env sh\necho hello\n", want: true},
+		{name: "env bash shebang", content: "#!/usr/bin/env bash\necho hello\n", want: true},
+		{name: "no shebang", content: "docker-php-ext-install xdebug\n", want: false},
+		{name: "php shebang", content: "#!/usr/bin/php\n<?php echo 1;\n", want: false},
+		{name: "empty", content: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := contentLooksLikeShellScript(tt.content); got != tt.want {
+				t.Errorf("contentLooksLikeShellScript() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `tally/php/no-xdebug-in-final-image` rule that detects Xdebug installations in the final Docker image stage
- Detects `docker-php-ext-install`, `docker-php-ext-enable`, `pecl install`, and package-manager installs (`apt-get`, `apk`, `dnf`, `yum`) containing "xdebug"
- Also scans observable scripts (COPY heredoc, build context) for Xdebug installs
- Fix offers comment-out (FixSuggestion) and delete (FixUnsafe) for RUN instructions that exclusively do xdebug work; detection-only when mixed with other extensions
- Skips dev/test/debug/ci-named stages, non-final stages, and Windows stages

Implements batch 1 rule #5 from design-docs/35-php-container-rules.md. Corpus signal: 26 of 29 Xdebug-using Dockerfiles left it in the final image path.

## Test plan

- [x] Unit tests: 20+ cases covering all detection patterns, stage filtering, fix generation
- [x] Helper tests: `commandReferencesXdebug`, `argsContainXdebug`, `argsContainXdebugSubstring`, `looksLikeShellScript`
- [x] Integration lint test with multi-stage fixture (builder, dev, final stages)
- [x] Integration fix test verifying comment-out on standalone xdebug RUN
- [x] Coverage: 85.6% (exceeds 85% target)
- [x] `go test ./...` passes
- [x] `make lint` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `tally/php/no-xdebug-in-final-image` rule (Enabled, Warning, Best Practices) to detect Xdebug in final Docker images and offer safe auto-fix (comment-out) or an unsafe removal option when applicable.

* **Documentation**
  * Updated README/docs to reflect tally rules count (now 54) and added full rule documentation with examples and remediation guidance.

* **Tests**
  * Added unit/integration tests and snapshots covering detection, fix behavior, and rule enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->