### PR TITLE
feat(lsp): suppress-rule, show-documentation CodeActions and iterative fix-all

### DIFF
--- a/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallyConfigurable.kt
+++ b/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallyConfigurable.kt
@@ -6,10 +6,12 @@ import com.intellij.openapi.options.BoundSearchableConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.ui.dsl.builder.COLUMNS_LARGE
 import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.columns
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.toNullableProperty
 import javax.swing.JCheckBox
 
 internal class TallyConfigurable(
@@ -69,6 +71,11 @@ internal class TallyConfigurable(
                     checkBox("Fix all on save")
                         .bindSelected(settings.state::fixAllOnSave)
                 comment("Apply safe fixes when saving Dockerfiles.")
+            }
+            row("Fix all mode:") {
+                comboBox(listOf("all", "problems"))
+                    .bindItem(settings.state::fixAllMode.toNullableProperty())
+                comment("'all' re-lints iteratively; 'problems' applies fixes in a single pass.")
             }
         }
 

--- a/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettings.kt
+++ b/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettings.kt
@@ -7,6 +7,9 @@ internal data class TallyRuntimeSettings(
     val fixUnsafe: Boolean,
     val configurationOverride: String?,
     val workspaceTrusted: Boolean,
+    val suppressRuleEnabled: Boolean,
+    val showDocumentationEnabled: Boolean,
+    val fixAllMode: String,
 )
 
 internal object TallySettings {
@@ -29,6 +32,9 @@ internal object TallySettings {
             fixUnsafe = service.fixUnsafe,
             configurationOverride = service.configurationPath?.takeIf { it.isNotBlank() },
             workspaceTrusted = workspaceTrusted,
+            suppressRuleEnabled = true,
+            showDocumentationEnabled = true,
+            fixAllMode = service.fixAllMode ?: "all",
         )
     }
 
@@ -48,6 +54,9 @@ internal object TallySettings {
                     "configurationPreference" to "editorFirst",
                     "fixUnsafe" to settings.fixUnsafe,
                     "workspaceTrusted" to settings.workspaceTrusted,
+                    "suppressRuleEnabled" to settings.suppressRuleEnabled,
+                    "showDocumentationEnabled" to settings.showDocumentationEnabled,
+                    "fixAllMode" to settings.fixAllMode,
                 ),
             "workspaces" to emptyList<Map<String, Any?>>(),
         )

--- a/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettings.kt
+++ b/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettings.kt
@@ -32,8 +32,8 @@ internal object TallySettings {
             fixUnsafe = service.fixUnsafe,
             configurationOverride = service.configurationPath?.takeIf { it.isNotBlank() },
             workspaceTrusted = workspaceTrusted,
-            suppressRuleEnabled = true,
-            showDocumentationEnabled = true,
+            suppressRuleEnabled = service.suppressRuleEnabled,
+            showDocumentationEnabled = service.showDocumentationEnabled,
             fixAllMode = service.fixAllMode ?: "all",
         )
     }

--- a/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettingsService.kt
+++ b/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettingsService.kt
@@ -16,6 +16,8 @@ internal class TallySettingsService(
     val executablePath: String? get() = state.executablePath
     val fixUnsafe: Boolean get() = state.fixUnsafe
     val fixAllOnSave: Boolean get() = state.fixAllOnSave
+    val suppressRuleEnabled: Boolean get() = state.suppressRuleEnabled
+    val showDocumentationEnabled: Boolean get() = state.showDocumentationEnabled
     val fixAllMode: String? get() = state.fixAllMode
     val formatOnReformat: Boolean get() = state.formatOnReformat
     val configurationPath: String? get() = state.configurationPath

--- a/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettingsService.kt
+++ b/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettingsService.kt
@@ -16,6 +16,7 @@ internal class TallySettingsService(
     val executablePath: String? get() = state.executablePath
     val fixUnsafe: Boolean get() = state.fixUnsafe
     val fixAllOnSave: Boolean get() = state.fixAllOnSave
+    val fixAllMode: String? get() = state.fixAllMode
     val formatOnReformat: Boolean get() = state.formatOnReformat
     val configurationPath: String? get() = state.configurationPath
 

--- a/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettingsState.kt
+++ b/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettingsState.kt
@@ -7,6 +7,7 @@ internal class TallySettingsState : BaseState() {
     var executablePath by string()
     var fixUnsafe by property(false)
     var fixAllOnSave by property(false)
+    var fixAllMode by string("all")
     var formatOnReformat by property(true)
     var configurationPath by string()
 }

--- a/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettingsState.kt
+++ b/_integrations/intellij-tally/src/main/kotlin/io/github/wharflab/tally/intellij/lsp/TallySettingsState.kt
@@ -7,6 +7,8 @@ internal class TallySettingsState : BaseState() {
     var executablePath by string()
     var fixUnsafe by property(false)
     var fixAllOnSave by property(false)
+    var suppressRuleEnabled by property(true)
+    var showDocumentationEnabled by property(true)
     var fixAllMode by string("all")
     var formatOnReformat by property(true)
     var configurationPath by string()

--- a/_integrations/vscode-tally/package.json
+++ b/_integrations/vscode-tally/package.json
@@ -143,6 +143,29 @@
           "default": false,
           "description": "Allow manual 'Fix all' command to apply unsafe fixes."
         },
+        "tally.codeAction.suppressRule.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show 'Suppress rule' code actions that insert # tally ignore= directives."
+        },
+        "tally.codeAction.showDocumentation.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show 'Show documentation' code actions to open rule docs in a browser."
+        },
+        "tally.fixAll.mode": {
+          "type": "string",
+          "default": "all",
+          "enum": [
+            "all",
+            "problems"
+          ],
+          "enumDescriptions": [
+            "Iteratively re-lint and fix until no more auto-fixable issues remain (up to 10 passes).",
+            "Apply pre-computed fixes in a single pass (faster, but may miss cascading fixes)."
+          ],
+          "description": "Strategy for 'Fix all' and source.fixAll.tally code actions."
+        },
         "tally.trace.server": {
           "type": "string",
           "enum": [

--- a/_integrations/vscode-tally/src/config/vscodeConfig.ts
+++ b/_integrations/vscode-tally/src/config/vscodeConfig.ts
@@ -3,6 +3,8 @@ import * as vscode from "vscode";
 export type ImportStrategy = "fromEnvironment" | "useBundled";
 export type ConfigurationPreference = "editorFirst" | "filesystemFirst" | "editorOnly";
 
+export type FixAllMode = "all" | "problems";
+
 export interface TallySettings {
   enable: boolean;
   path: string[];
@@ -10,6 +12,9 @@ export interface TallySettings {
   configuration?: unknown;
   configurationPreference: ConfigurationPreference;
   fixUnsafe: boolean;
+  suppressRuleEnabled: boolean;
+  showDocumentationEnabled: boolean;
+  fixAllMode: FixAllMode;
 }
 
 export interface TallyLspSettings extends TallySettings {
@@ -28,6 +33,9 @@ const DEFAULTS: TallyLspSettings = {
   configuration: null,
   configurationPreference: "editorFirst",
   fixUnsafe: false,
+  suppressRuleEnabled: true,
+  showDocumentationEnabled: true,
+  fixAllMode: "all",
   workspaceTrusted: false,
 };
 
@@ -43,6 +51,15 @@ export function readEffectiveSettings(scope?: vscode.ConfigurationScope): TallyL
       DEFAULTS.configurationPreference,
     ),
     fixUnsafe: cfg.get("fixUnsafe", DEFAULTS.fixUnsafe),
+    suppressRuleEnabled: cfg.get(
+      "codeAction.suppressRule.enable",
+      DEFAULTS.suppressRuleEnabled,
+    ),
+    showDocumentationEnabled: cfg.get(
+      "codeAction.showDocumentation.enable",
+      DEFAULTS.showDocumentationEnabled,
+    ),
+    fixAllMode: cfg.get<FixAllMode>("fixAll.mode", DEFAULTS.fixAllMode),
     workspaceTrusted: vscode.workspace.isTrusted,
   };
 }

--- a/_integrations/vscode-tally/src/config/vscodeConfig.ts
+++ b/_integrations/vscode-tally/src/config/vscodeConfig.ts
@@ -51,10 +51,7 @@ export function readEffectiveSettings(scope?: vscode.ConfigurationScope): TallyL
       DEFAULTS.configurationPreference,
     ),
     fixUnsafe: cfg.get("fixUnsafe", DEFAULTS.fixUnsafe),
-    suppressRuleEnabled: cfg.get(
-      "codeAction.suppressRule.enable",
-      DEFAULTS.suppressRuleEnabled,
-    ),
+    suppressRuleEnabled: cfg.get("codeAction.suppressRule.enable", DEFAULTS.suppressRuleEnabled),
     showDocumentationEnabled: cfg.get(
       "codeAction.showDocumentation.enable",
       DEFAULTS.showDocumentationEnabled,

--- a/_integrations/vscode-tally/test/suite/index.js
+++ b/_integrations/vscode-tally/test/suite/index.js
@@ -136,15 +136,27 @@ async function runSmoke() {
 
   assert.strictEqual(formatted, expected, "formatted output mismatch");
 
-  // Verify command-based "fix all" path: revert to original content first so
-  // applyAllFixes runs on the same input as formatting (single pass, not a
-  // second pass on already-formatted content which may clean leftover spaces).
+  // Verify command-based "fix all" path: revert to original content first.
+  // With iterative fix-all mode ("all"), the server re-lints after each fix
+  // pass, which may clean up residual whitespace from first-pass conversions.
+  // The result may differ slightly from single-pass formatting.
   await vscode.commands.executeCommand("workbench.action.files.revert");
   await scheduler.wait(500);
   await vscode.commands.executeCommand("tally.applyAllFixes");
 
   const fixedViaCommand = normalizeNewlines(doc.getText());
-  assert.strictEqual(fixedViaCommand, expected, "fix-all command output mismatch");
+  const fixAllExpectedPath =
+    process.env.VSCODE_SMOKE_EXPECTED_FIXALL_SNAPSHOT ??
+    process.env.TALLY_EXPECTED_FIXALL_SNAPSHOT ??
+    path.join(
+      workspaceRoot,
+      "internal",
+      "lsptest",
+      "__snapshots__",
+      "TestLSP_ExecuteCommandApplyAllFixesRealWorld_1.snap.Dockerfile",
+    );
+  const fixAllExpected = normalizeNewlines(await fs.readFile(fixAllExpectedPath, "utf8"));
+  assert.strictEqual(fixedViaCommand, fixAllExpected, "fix-all command output mismatch");
 
   // Keep the workspace clean for future tests.
   await vscode.commands.executeCommand("workbench.action.files.revert");

--- a/internal/directive/format.go
+++ b/internal/directive/format.go
@@ -1,0 +1,66 @@
+package directive
+
+import "strings"
+
+// reasonSeparator is the separator between the rule list and the reason field.
+// Used by both the parser (regex) and the formatter (this file).
+const reasonSeparator = ";reason="
+
+// FormatNextLine produces a canonical next-line suppression directive comment:
+//
+//	# tally ignore=RULE1,RULE2[;reason=explanation]
+func FormatNextLine(rules []string, reason string) string {
+	return formatDirective("# tally ignore=", rules, reason)
+}
+
+// FormatGlobal produces a canonical global (file-level) suppression directive comment:
+//
+//	# tally global ignore=RULE1,RULE2[;reason=explanation]
+func FormatGlobal(rules []string, reason string) string {
+	return formatDirective("# tally global ignore=", rules, reason)
+}
+
+func formatDirective(prefix string, rules []string, reason string) string {
+	var b strings.Builder
+	b.WriteString(prefix)
+	b.WriteString(strings.Join(rules, ","))
+	if reason != "" {
+		b.WriteString(reasonSeparator)
+		b.WriteString(reason)
+	}
+	return b.String()
+}
+
+// AppendRuleEdit describes a text replacement to append a rule code to an
+// existing directive line. Start and End are 0-based character offsets within
+// the line; NewText is the replacement text for that range.
+type AppendRuleEdit struct {
+	Start   int
+	End     int
+	NewText string
+}
+
+// AppendRule computes the edit needed to append ruleCode to an existing
+// directive line (e.g. "# tally ignore=DL3008" → insert ",DL3027").
+//
+// The edit inserts before ";reason=" if present, otherwise at end of line,
+// trimming trailing whitespace before the insertion point.
+func AppendRule(lineText, ruleCode string) AppendRuleEdit {
+	// Find insertion point: before ;reason= if present, otherwise at end.
+	insertPos := len(lineText)
+	if idx := strings.Index(lineText, reasonSeparator); idx >= 0 {
+		insertPos = idx
+	}
+
+	// Trim trailing whitespace before insertion point.
+	trimmed := insertPos
+	for trimmed > 0 && lineText[trimmed-1] == ' ' {
+		trimmed--
+	}
+
+	return AppendRuleEdit{
+		Start:   trimmed,
+		End:     insertPos,
+		NewText: "," + ruleCode,
+	}
+}

--- a/internal/directive/format.go
+++ b/internal/directive/format.go
@@ -1,10 +1,17 @@
 package directive
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
-// reasonSeparator is the separator between the rule list and the reason field.
-// Used by both the parser (regex) and the formatter (this file).
+// reasonSeparator is the canonical separator between the rule list and the
+// reason field, used when formatting new directives.
 const reasonSeparator = ";reason="
+
+// reasonPattern matches the reason separator in existing directive text.
+// Mirrors the parser's regex: case-insensitive, optional whitespace around '='.
+var reasonPattern = regexp.MustCompile(`(?i);reason\s*=\s*`)
 
 // FormatNextLine produces a canonical next-line suppression directive comment:
 //
@@ -46,10 +53,11 @@ type AppendRuleEdit struct {
 // The edit inserts before ";reason=" if present, otherwise at end of line,
 // trimming trailing whitespace before the insertion point.
 func AppendRule(lineText, ruleCode string) AppendRuleEdit {
-	// Find insertion point: before ;reason= if present, otherwise at end.
+	// Find insertion point: before ;reason= (case-insensitive, flexible whitespace)
+	// if present, otherwise at end of line.
 	insertPos := len(lineText)
-	if idx := strings.Index(lineText, reasonSeparator); idx >= 0 {
-		insertPos = idx
+	if loc := reasonPattern.FindStringIndex(lineText); loc != nil {
+		insertPos = loc[0]
 	}
 
 	// Trim trailing whitespace before insertion point.

--- a/internal/directive/format.go
+++ b/internal/directive/format.go
@@ -54,7 +54,7 @@ func AppendRule(lineText, ruleCode string) AppendRuleEdit {
 
 	// Trim trailing whitespace before insertion point.
 	trimmed := insertPos
-	for trimmed > 0 && lineText[trimmed-1] == ' ' {
+	for trimmed > 0 && (lineText[trimmed-1] == ' ' || lineText[trimmed-1] == '\t') {
 		trimmed--
 	}
 

--- a/internal/directive/format_test.go
+++ b/internal/directive/format_test.go
@@ -1,0 +1,74 @@
+package directive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatNextLine(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "# tally ignore=DL3008", FormatNextLine([]string{"DL3008"}, ""))
+	assert.Equal(t, "# tally ignore=DL3008,DL3027", FormatNextLine([]string{"DL3008", "DL3027"}, ""))
+	assert.Equal(t, "# tally ignore=DL3008;reason=false positive",
+		FormatNextLine([]string{"DL3008"}, "false positive"))
+}
+
+func TestFormatGlobal(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "# tally global ignore=tally/max-lines", FormatGlobal([]string{"tally/max-lines"}, ""))
+	assert.Equal(t, "# tally global ignore=DL3008;reason=TODO",
+		FormatGlobal([]string{"DL3008"}, "TODO"))
+}
+
+func TestFormatNextLine_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// A formatted directive should be parseable by the tallyPattern regex.
+	text := FormatNextLine([]string{"DL3008", "tally/max-lines"}, "testing")
+	matches := tallyPattern.FindStringSubmatch(text)
+	assert.NotNil(t, matches, "formatted directive should match tallyPattern")
+	assert.Empty(t, matches[1], "should not have 'global' capture")
+	assert.Equal(t, "DL3008,tally/max-lines", matches[2])
+	assert.Equal(t, "testing", matches[3])
+}
+
+func TestFormatGlobal_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	text := FormatGlobal([]string{"DL3008"}, "")
+	matches := tallyPattern.FindStringSubmatch(text)
+	assert.NotNil(t, matches, "formatted global directive should match tallyPattern")
+	assert.Contains(t, matches[1], "global")
+	assert.Equal(t, "DL3008", matches[2])
+}
+
+func TestAppendRule(t *testing.T) {
+	t.Parallel()
+
+	t.Run("simple append", func(t *testing.T) {
+		t.Parallel()
+		edit := AppendRule("# tally ignore=DL3008", "DL3027")
+		assert.Equal(t, ",DL3027", edit.NewText)
+		assert.Equal(t, 21, edit.Start)
+		assert.Equal(t, 21, edit.End)
+	})
+
+	t.Run("before reason", func(t *testing.T) {
+		t.Parallel()
+		edit := AppendRule("# tally ignore=DL3008;reason=test", "DL3027")
+		assert.Equal(t, ",DL3027", edit.NewText)
+		assert.Equal(t, 21, edit.Start)
+		assert.Equal(t, 21, edit.End)
+	})
+
+	t.Run("trims trailing spaces before reason", func(t *testing.T) {
+		t.Parallel()
+		edit := AppendRule("# tally ignore=DL3008   ;reason=test", "DL3027")
+		assert.Equal(t, ",DL3027", edit.NewText)
+		assert.Equal(t, 21, edit.Start)
+		assert.Equal(t, 24, edit.End, "should replace the trailing spaces")
+	})
+}

--- a/internal/directive/format_test.go
+++ b/internal/directive/format_test.go
@@ -71,4 +71,12 @@ func TestAppendRule(t *testing.T) {
 		assert.Equal(t, 21, edit.Start)
 		assert.Equal(t, 24, edit.End, "should replace the trailing spaces")
 	})
+
+	t.Run("trims trailing tabs", func(t *testing.T) {
+		t.Parallel()
+		edit := AppendRule("# tally ignore=DL3008\t\t;reason=test", "DL3027")
+		assert.Equal(t, ",DL3027", edit.NewText)
+		assert.Equal(t, 21, edit.Start)
+		assert.Equal(t, 23, edit.End, "should replace the trailing tabs")
+	})
 }

--- a/internal/directive/format_test.go
+++ b/internal/directive/format_test.go
@@ -79,4 +79,20 @@ func TestAppendRule(t *testing.T) {
 		assert.Equal(t, 21, edit.Start)
 		assert.Equal(t, 23, edit.End, "should replace the trailing tabs")
 	})
+
+	t.Run("reason with spaces around equals", func(t *testing.T) {
+		t.Parallel()
+		edit := AppendRule("# tally ignore=DL3008;reason = false positive", "DL3027")
+		assert.Equal(t, ",DL3027", edit.NewText)
+		assert.Equal(t, 21, edit.Start)
+		assert.Equal(t, 21, edit.End, "should insert before ;reason with spaces")
+	})
+
+	t.Run("case-insensitive REASON", func(t *testing.T) {
+		t.Parallel()
+		edit := AppendRule("# tally ignore=DL3008;REASON=test", "DL3027")
+		assert.Equal(t, ",DL3027", edit.NewText)
+		assert.Equal(t, 21, edit.Start)
+		assert.Equal(t, 21, edit.End, "should recognize uppercase REASON")
+	})
 }

--- a/internal/directive/parser.go
+++ b/internal/directive/parser.go
@@ -94,6 +94,23 @@ func NewInstructionSpanIndexFromSource(source []byte, sm *sourcemap.SourceMap) *
 	return NewInstructionSpanIndexFromAST(res, sm)
 }
 
+// ContainingSpan returns the instruction span that contains the given 0-based line,
+// or false if no span contains it.
+func (idx *InstructionSpanIndex) ContainingSpan(line int) (InstructionSpan, bool) {
+	if idx == nil {
+		return InstructionSpan{}, false
+	}
+	for _, span := range idx.Spans {
+		if line >= span.StartLine && line <= span.EndLine {
+			return span, true
+		}
+		if span.StartLine > line {
+			break // spans are sorted; no later span can contain this line
+		}
+	}
+	return InstructionSpan{}, false
+}
+
 func (idx *InstructionSpanIndex) nextInstructionSpan(afterLine int) (InstructionSpan, bool) {
 	if idx == nil || len(idx.Spans) == 0 {
 		return InstructionSpan{}, false

--- a/internal/lspserver/async_test.go
+++ b/internal/lspserver/async_test.go
@@ -151,8 +151,8 @@ func TestLintContentWithConfig_RunsAsyncUndefinedVarResolution(t *testing.T) {
 
 	s := New()
 	uri := fileURI(filePath)
-	violations := s.lintContentWithConfig(context.Background(), uri, content, cfg, rawResult.ParseResult)
-	require.False(t, hasRule(violations, "buildkit/UndefinedVar"))
+	lr := s.lintContentWithConfig(context.Background(), uri, content, cfg, rawResult.ParseResult)
+	require.False(t, hasRule(lr.violations, "buildkit/UndefinedVar"))
 }
 
 func fileURI(path string) string {

--- a/internal/lspserver/codeactions.go
+++ b/internal/lspserver/codeactions.go
@@ -19,21 +19,24 @@ func (s *Server) codeActionsForDocument(
 ) []protocol.CodeAction {
 	includeQuickFix := true
 	includeFixAll := true
+	includeSuppress := true
 	if params.Context.Only != nil {
 		includeQuickFix = kindRequested(params.Context.Only, protocol.CodeActionKindQuickFix)
 		includeFixAll = kindRequested(params.Context.Only, fixAllCodeActionKind)
+		includeSuppress = kindRequested(params.Context.Only, suppressCodeActionKind)
 	}
 
-	if !includeQuickFix && !includeFixAll {
+	if !includeQuickFix && !includeFixAll && !includeSuppress {
 		return nil
 	}
 
 	// Use cached lint results from publishDiagnostics when the version matches.
 	violations, ok := s.lintCache.get(doc.URI, doc.Version)
 	if !ok {
-		violations = s.lintContent(ctx, doc.URI, []byte(doc.Content))
+		lr := s.lintContent(ctx, doc.URI, []byte(doc.Content))
+		violations = lr.violations
 		if s.documentVersionCurrent(doc.URI, doc.Version) {
-			s.lintCache.set(doc.URI, doc.Version, violations)
+			s.lintCache.set(doc.URI, doc.Version, lr.violations, lr.config, lr.parseResult)
 		}
 	}
 
@@ -52,7 +55,29 @@ func (s *Server) codeActionsForDocument(
 		}
 	}
 
+	// Suppress-rule actions: inject # tally ignore= directives.
+	if includeSuppress && s.suppressRuleEnabled(doc.URI) {
+		entry, cached := s.lintCache.getEntry(doc.URI, doc.Version)
+		if cached {
+			actions = append(actions, suppressRuleActions(violations, params, doc.Content, entry.parseResult, entry.config)...)
+		}
+	}
+
+	// Show documentation actions (no Kind filter — they have nil kind and appear
+	// in the full lightbulb menu regardless of the Only filter).
+	if s.showDocEnabled(doc.URI) && s.showDocumentSupported {
+		actions = append(actions, showDocActions(violations, params)...)
+	}
+
 	return actions
+}
+
+func (s *Server) suppressRuleEnabled(docURI string) bool {
+	return s.settingsForFile(uriToPath(docURI)).SuppressRuleEnabled
+}
+
+func (s *Server) showDocEnabled(docURI string) bool {
+	return s.settingsForFile(uriToPath(docURI)).ShowDocEnabled
 }
 
 // resolveFixEdits resolves async fix edits on-the-fly using the registered resolver.

--- a/internal/lspserver/diagnostics.go
+++ b/internal/lspserver/diagnostics.go
@@ -39,14 +39,19 @@ type diagnosticsTask struct {
 
 // lintResultCache caches lint results keyed by document URI + version
 // to avoid redundant linting between publishDiagnostics and codeAction requests.
+// In addition to violations, it stores the resolved config and parse result
+// so that code action providers (e.g. suppress-rule) can reuse the already-parsed
+// document without re-parsing.
 type lintResultCache struct {
 	mu      sync.Mutex
 	entries map[string]lintCacheEntry
 }
 
 type lintCacheEntry struct {
-	version    int32
-	violations []rules.Violation
+	version     int32
+	violations  []rules.Violation
+	config      *config.Config
+	parseResult *dockerfile.ParseResult
 }
 
 func newLintResultCache() *lintResultCache {
@@ -63,10 +68,33 @@ func (c *lintResultCache) get(uri string, version int32) ([]rules.Violation, boo
 	return entry.violations, true
 }
 
-func (c *lintResultCache) set(uri string, version int32, violations []rules.Violation) {
+// getEntry returns the full cache entry for the given URI and version.
+// Returns a zero entry and false if not cached or version doesn't match.
+func (c *lintResultCache) getEntry(uri string, version int32) (lintCacheEntry, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[uri] = lintCacheEntry{version: version, violations: violations}
+	entry, ok := c.entries[uri]
+	if !ok || entry.version != version {
+		return lintCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (c *lintResultCache) set(
+	uri string,
+	version int32,
+	violations []rules.Violation,
+	cfg *config.Config,
+	parseResult *dockerfile.ParseResult,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[uri] = lintCacheEntry{
+		version:     version,
+		violations:  violations,
+		config:      cfg,
+		parseResult: parseResult,
+	}
 }
 
 func (c *lintResultCache) delete(uri string) {
@@ -158,10 +186,10 @@ func (s *Server) cancelPendingDiagnostics(docURI string) {
 }
 
 func (s *Server) publishDiagnosticsForDocument(ctx context.Context, docURI string, version int32, content []byte) {
-	violations := s.lintContent(ctx, docURI, content)
+	lr := s.lintContent(ctx, docURI, content)
 	if s.documentVersionCurrent(docURI, version) {
-		s.lintCache.set(docURI, version, violations)
-		s.notifyDiagnostics(ctx, docURI, version, violations)
+		s.lintCache.set(docURI, version, lr.violations, lr.config, lr.parseResult)
+		s.notifyDiagnostics(ctx, docURI, version, lr.violations)
 	}
 }
 
@@ -216,14 +244,14 @@ func (s *Server) handleDiagnostic(ctx context.Context, params *protocol.Document
 			}, nil
 		}
 
-		violations := s.lintContent(ctx, uri, []byte(doc.Content))
+		lr := s.lintContent(ctx, uri, []byte(doc.Content))
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
 		if s.documentVersionCurrent(uri, doc.Version) {
-			s.lintCache.set(uri, doc.Version, violations)
+			s.lintCache.set(uri, doc.Version, lr.violations, lr.config, lr.parseResult)
 		}
-		diagnostics := convertDiagnostics(violations)
+		diagnostics := convertDiagnostics(lr.violations)
 
 		return &protocol.DocumentDiagnosticResponse{
 			FullDocumentDiagnosticReport: &protocol.RelatedFullDocumentDiagnosticReport{
@@ -279,11 +307,11 @@ func (s *Server) pullDiagnosticsFromDisk(ctx context.Context, docURI, filePath s
 		return nil, err
 	}
 
-	violations := s.lintContent(ctx, docURI, content)
+	lr := s.lintContent(ctx, docURI, content)
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	diagnostics := convertDiagnostics(violations)
+	diagnostics := convertDiagnostics(lr.violations)
 
 	return &protocol.DocumentDiagnosticResponse{
 		FullDocumentDiagnosticReport: &protocol.RelatedFullDocumentDiagnosticReport{
@@ -332,8 +360,16 @@ func (s *Server) resolveConfig(filePath string) *config.Config {
 	return cfg
 }
 
+// lintResult holds the full output of a lint pass: violations plus the resolved
+// config and parse result that produced them.
+type lintResult struct {
+	violations  []rules.Violation
+	config      *config.Config
+	parseResult *dockerfile.ParseResult
+}
+
 // lintContent runs the shared lint pipeline and applies LSP-specific processors.
-func (s *Server) lintContent(ctx context.Context, docURI string, content []byte) []rules.Violation {
+func (s *Server) lintContent(ctx context.Context, docURI string, content []byte) lintResult {
 	filePath := uriToPath(docURI)
 	cfg := s.resolveConfig(filePath)
 	return s.lintContentWithConfig(ctx, docURI, content, cfg, nil)
@@ -345,7 +381,7 @@ func (s *Server) lintContentWithConfig(
 	content []byte,
 	cfg *config.Config,
 	parseResult *dockerfile.ParseResult,
-) []rules.Violation {
+) lintResult {
 	filePath := uriToPath(docURI)
 	input := linter.Input{
 		FilePath:    filePath,
@@ -357,7 +393,7 @@ func (s *Server) lintContentWithConfig(
 	result, err := linter.LintFile(input)
 	if err != nil {
 		log.Printf("lsp: lint error for %s: %v", input.FilePath, err)
-		return nil
+		return lintResult{}
 	}
 
 	violations := result.Violations
@@ -372,7 +408,11 @@ func (s *Server) lintContentWithConfig(
 		result.Config,
 		map[string][]byte{input.FilePath: content},
 	)
-	return chain.Process(violations, procCtx)
+	return lintResult{
+		violations:  chain.Process(violations, procCtx),
+		config:      result.Config,
+		parseResult: result.ParseResult,
+	}
 }
 
 // convertDiagnostics converts tally violations to LSP diagnostics.

--- a/internal/lspserver/execute_command.go
+++ b/internal/lspserver/execute_command.go
@@ -17,7 +17,13 @@ func (s *Server) handleExecuteCommand(ctx context.Context, params *protocol.Exec
 	if params == nil {
 		return nil, nil //nolint:nilnil // LSP: null result is valid
 	}
-	if params.Command != applyAllFixesCommand {
+
+	switch params.Command {
+	case openRuleDocCommand:
+		return s.handleOpenRuleDoc(params.Arguments) //nolint:contextcheck // detached goroutine for showDocument
+	case applyAllFixesCommand:
+		// handled below
+	default:
 		return nil, jsonrpc2.NewError(int64(protocol.ErrorCodeInvalidParams), "unknown command: "+params.Command)
 	}
 
@@ -36,7 +42,8 @@ func (s *Server) handleExecuteCommand(ctx context.Context, params *protocol.Exec
 		safety = fix.FixUnsafe
 	}
 
-	edits := s.computeFixEdits(ctx, uri, content, safety)
+	mode := s.settingsForFile(uriToPath(uri)).FixAllMode
+	edits := s.computeFixEdits(ctx, uri, content, safety, mode)
 	if len(edits) == 0 {
 		return nil, nil //nolint:nilnil // no changes
 	}

--- a/internal/lspserver/fixall.go
+++ b/internal/lspserver/fixall.go
@@ -96,8 +96,8 @@ func (s *Server) computeFixEdits(
 	filePath := uriToPath(docURI)
 	cfg := s.resolveConfig(filePath)
 	fixModes := fix.BuildFixModes(cfg)
-	fixed := computeFixedContent(ctx, filePath, content, cfg, fixModes, safety)
-	if fixed == nil || bytes.Equal(fixed, content) {
+	fixed, err := computeFixedContent(ctx, filePath, content, cfg, fixModes, safety)
+	if err != nil || fixed == nil || bytes.Equal(fixed, content) {
 		return nil
 	}
 	return minimalTextEdit(content, fixed)
@@ -118,9 +118,12 @@ func (s *Server) computeFixEditsIterative(ctx context.Context, docURI string, co
 		if ctx.Err() != nil {
 			return nil
 		}
-		next := computeFixedContent(ctx, filePath, current, cfg, fixModes, safety)
+		next, err := computeFixedContent(ctx, filePath, current, cfg, fixModes, safety)
+		if err != nil {
+			return nil // don't return partially-fixed content on error
+		}
 		if next == nil || bytes.Equal(next, current) {
-			break
+			break // converged
 		}
 		current = next
 	}
@@ -132,7 +135,10 @@ func (s *Server) computeFixEditsIterative(ctx context.Context, docURI string, co
 
 // computeFixedContent runs a single lint+fix pass and returns the modified content.
 // Config and fixModes are pre-resolved by the caller so they aren't recomputed
-// on each iteration. Returns nil if there's nothing to fix or an error occurs.
+// on each iteration.
+//
+// Returns (nil, nil) when there is nothing to fix (convergence).
+// Returns (nil, err) when linting or fixing fails.
 func computeFixedContent(
 	ctx context.Context,
 	filePath string,
@@ -140,7 +146,7 @@ func computeFixedContent(
 	cfg *config.Config,
 	fixModes map[string]fix.FixMode,
 	safety fix.FixSafety,
-) []byte {
+) ([]byte, error) {
 	input := linter.Input{
 		FilePath: filePath,
 		Content:  content,
@@ -149,7 +155,7 @@ func computeFixedContent(
 
 	result, err := linter.LintFile(input)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	chain := linter.LSPProcessors()
@@ -169,13 +175,13 @@ func computeFixedContent(
 	}
 	fixResult, err := fixer.Apply(ctx, violations, map[string][]byte{filePath: content})
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	change := fixResult.Changes[fileKey]
 	if change == nil || !change.HasChanges() || bytes.Equal(change.ModifiedContent, content) {
-		return nil
+		return nil, nil
 	}
 
-	return change.ModifiedContent
+	return change.ModifiedContent, nil
 }

--- a/internal/lspserver/fixall.go
+++ b/internal/lspserver/fixall.go
@@ -77,7 +77,52 @@ func fixModeAllowsSafeFix(ruleCode string, fixModes map[string]fix.FixMode) bool
 	}
 }
 
-func (s *Server) computeFixEdits(ctx context.Context, docURI string, content []byte, safety fix.FixSafety) []*protocol.TextEdit {
+const maxFixIterations = 10
+
+// computeFixEdits computes text edits to fix all auto-fixable violations.
+// In "all" mode (fixAllModeAll), it iteratively re-lints and re-fixes until
+// convergence or maxFixIterations. In "problems" mode (fixAllModeProblems),
+// it applies a single pass (current behavior).
+func (s *Server) computeFixEdits(
+	ctx context.Context,
+	docURI string,
+	content []byte,
+	safety fix.FixSafety,
+	mode string,
+) []*protocol.TextEdit {
+	if mode == fixAllModeAll {
+		return s.computeFixEditsIterative(ctx, docURI, content, safety)
+	}
+	fixed := s.computeFixedContent(ctx, docURI, content, safety)
+	if fixed == nil || bytes.Equal(fixed, content) {
+		return nil
+	}
+	return minimalTextEdit(content, fixed)
+}
+
+// computeFixEditsIterative runs lint+fix in a loop until the content stabilizes
+// or maxFixIterations is reached. Returns minimal text edits from original to final.
+func (s *Server) computeFixEditsIterative(ctx context.Context, docURI string, content []byte, safety fix.FixSafety) []*protocol.TextEdit {
+	current := content
+	for range maxFixIterations {
+		if ctx.Err() != nil {
+			return nil
+		}
+		next := s.computeFixedContent(ctx, docURI, current, safety)
+		if next == nil || bytes.Equal(next, current) {
+			break
+		}
+		current = next
+	}
+	if bytes.Equal(current, content) {
+		return nil
+	}
+	return minimalTextEdit(content, current)
+}
+
+// computeFixedContent runs a single lint+fix pass and returns the modified content.
+// Returns nil if there's nothing to fix or an error occurs.
+func (s *Server) computeFixedContent(ctx context.Context, docURI string, content []byte, safety fix.FixSafety) []byte {
 	input := s.lintInput(docURI, content)
 
 	result, err := linter.LintFile(input)
@@ -111,5 +156,5 @@ func (s *Server) computeFixEdits(ctx context.Context, docURI string, content []b
 		return nil
 	}
 
-	return minimalTextEdit(content, change.ModifiedContent)
+	return change.ModifiedContent
 }

--- a/internal/lspserver/fixall.go
+++ b/internal/lspserver/fixall.go
@@ -93,7 +93,10 @@ func (s *Server) computeFixEdits(
 	if mode == fixAllModeAll {
 		return s.computeFixEditsIterative(ctx, docURI, content, safety)
 	}
-	fixed := s.computeFixedContent(ctx, docURI, content, safety)
+	filePath := uriToPath(docURI)
+	cfg := s.resolveConfig(filePath)
+	fixModes := fix.BuildFixModes(cfg)
+	fixed := computeFixedContent(ctx, filePath, content, cfg, fixModes, safety)
 	if fixed == nil || bytes.Equal(fixed, content) {
 		return nil
 	}
@@ -102,13 +105,20 @@ func (s *Server) computeFixEdits(
 
 // computeFixEditsIterative runs lint+fix in a loop until the content stabilizes
 // or maxFixIterations is reached. Returns minimal text edits from original to final.
+//
+// Config and fix modes are resolved once before the loop — they don't change
+// between iterations (only the content does).
 func (s *Server) computeFixEditsIterative(ctx context.Context, docURI string, content []byte, safety fix.FixSafety) []*protocol.TextEdit {
+	filePath := uriToPath(docURI)
+	cfg := s.resolveConfig(filePath)
+	fixModes := fix.BuildFixModes(cfg)
+
 	current := content
 	for range maxFixIterations {
 		if ctx.Err() != nil {
 			return nil
 		}
-		next := s.computeFixedContent(ctx, docURI, current, safety)
+		next := computeFixedContent(ctx, filePath, current, cfg, fixModes, safety)
 		if next == nil || bytes.Equal(next, current) {
 			break
 		}
@@ -121,9 +131,21 @@ func (s *Server) computeFixEditsIterative(ctx context.Context, docURI string, co
 }
 
 // computeFixedContent runs a single lint+fix pass and returns the modified content.
-// Returns nil if there's nothing to fix or an error occurs.
-func (s *Server) computeFixedContent(ctx context.Context, docURI string, content []byte, safety fix.FixSafety) []byte {
-	input := s.lintInput(docURI, content)
+// Config and fixModes are pre-resolved by the caller so they aren't recomputed
+// on each iteration. Returns nil if there's nothing to fix or an error occurs.
+func computeFixedContent(
+	ctx context.Context,
+	filePath string,
+	content []byte,
+	cfg *config.Config,
+	fixModes map[string]fix.FixMode,
+	safety fix.FixSafety,
+) []byte {
+	input := linter.Input{
+		FilePath: filePath,
+		Content:  content,
+		Config:   cfg,
+	}
 
 	result, err := linter.LintFile(input)
 	if err != nil {
@@ -132,21 +154,20 @@ func (s *Server) computeFixedContent(ctx context.Context, docURI string, content
 
 	chain := linter.LSPProcessors()
 	procCtx := processor.NewContext(
-		map[string]*config.Config{input.FilePath: result.Config},
+		map[string]*config.Config{filePath: result.Config},
 		result.Config,
-		map[string][]byte{input.FilePath: content},
+		map[string][]byte{filePath: content},
 	)
 	violations := chain.Process(result.Violations, procCtx)
 
-	fixModes := fix.BuildFixModes(result.Config)
-	fileKey := filepath.Clean(input.FilePath)
+	fileKey := filepath.Clean(filePath)
 	fixer := &fix.Fixer{
 		SafetyThreshold: safety,
 		FixModes: map[string]map[string]fix.FixMode{
 			fileKey: fixModes,
 		},
 	}
-	fixResult, err := fixer.Apply(ctx, violations, map[string][]byte{input.FilePath: content})
+	fixResult, err := fixer.Apply(ctx, violations, map[string][]byte{filePath: content})
 	if err != nil {
 		return nil
 	}

--- a/internal/lspserver/opendoc.go
+++ b/internal/lspserver/opendoc.go
@@ -1,0 +1,95 @@
+package lspserver
+
+import (
+	"context"
+	"log"
+	"time"
+
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
+
+	"github.com/wharflab/tally/internal/rules"
+)
+
+const openRuleDocCommand = "tally.openRuleDoc"
+
+// showDocActions generates "Show documentation for {ruleCode}" CodeActions
+// for violations that have a non-empty DocURL.
+// Each action is command-based: it triggers tally.openRuleDoc which sends
+// window/showDocument to the client to open the URL in a browser.
+func showDocActions(violations []rules.Violation, params *protocol.CodeActionParams) []protocol.CodeAction {
+	seen := make(map[string]struct{})
+	var actions []protocol.CodeAction
+
+	for _, v := range violations {
+		if v.DocURL == "" {
+			continue
+		}
+
+		vRange := violationRange(v)
+		if !rangesOverlap(vRange, params.Range) {
+			continue
+		}
+
+		if _, ok := seen[v.RuleCode]; ok {
+			continue
+		}
+		seen[v.RuleCode] = struct{}{}
+
+		args := []any{map[string]any{"url": v.DocURL}}
+		actions = append(actions, protocol.CodeAction{
+			Title: "Show documentation for " + v.RuleCode,
+			// Kind intentionally nil: appears in full lightbulb but not in
+			// quickfix-only filtered requests (matching ESLint's pattern).
+			Command: &protocol.Command{
+				Title:     "Show documentation for " + v.RuleCode,
+				Command:   openRuleDocCommand,
+				Arguments: &args,
+			},
+		})
+	}
+
+	return actions
+}
+
+// handleOpenRuleDoc handles the tally.openRuleDoc command.
+// It sends a window/showDocument request to the client to open the rule
+// documentation URL in the system browser.
+func (s *Server) handleOpenRuleDoc(args *[]any) (any, error) {
+	docURL := parseOpenRuleDocArgs(args)
+	if docURL == "" {
+		return nil, nil //nolint:nilnil // LSP: no URL, no action
+	}
+
+	// Send window/showDocument asynchronously. If the client doesn't respond
+	// in time or doesn't support it, we log and move on.
+	conn := s.conn
+	go func() {
+		reqCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		if err := lspCall(reqCtx, conn, string(protocol.MethodWindowShowDocument),
+			&protocol.ShowDocumentParams{
+				Uri:      protocol.URI(docURL),
+				External: ptrTo(true),
+			}); err != nil {
+			log.Printf("lsp: window/showDocument failed: %v", err)
+		}
+	}()
+
+	return nil, nil //nolint:nilnil // LSP: command produces no direct result
+}
+
+func parseOpenRuleDocArgs(args *[]any) string {
+	if args == nil || len(*args) == 0 {
+		return ""
+	}
+	m, ok := (*args)[0].(map[string]any)
+	if !ok {
+		return ""
+	}
+	url, ok := m["url"].(string)
+	if !ok {
+		return ""
+	}
+	return url
+}

--- a/internal/lspserver/opendoc_test.go
+++ b/internal/lspserver/opendoc_test.go
@@ -1,0 +1,121 @@
+package lspserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
+	"github.com/wharflab/tally/internal/rules"
+)
+
+func TestShowDocActions_WithDocURL(t *testing.T) {
+	t.Parallel()
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 3, 0, 3, 10),
+		"tally/max-lines",
+		"file too long",
+		rules.SeverityWarning,
+	)
+	v.DocURL = "https://wharflab.github.io/tally/rules/tally/max-lines/"
+
+	params := makeCodeActionParams("file:///test/Dockerfile", fullRange(), &protocol.CodeActionContext{})
+	actions := showDocActions([]rules.Violation{v}, params)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, "Show documentation for tally/max-lines", actions[0].Title)
+	assert.Nil(t, actions[0].Kind, "show-doc actions should have nil Kind")
+	require.NotNil(t, actions[0].Command)
+	assert.Equal(t, openRuleDocCommand, actions[0].Command.Command)
+	require.NotNil(t, actions[0].Command.Arguments)
+	args, ok := (*actions[0].Command.Arguments)[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "https://wharflab.github.io/tally/rules/tally/max-lines/", args["url"])
+}
+
+func TestShowDocActions_NoDocURL(t *testing.T) {
+	t.Parallel()
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 3, 0, 3, 10),
+		"tally/test-rule",
+		"msg",
+		rules.SeverityWarning,
+	)
+	// No DocURL set.
+
+	params := makeCodeActionParams("file:///test/Dockerfile", fullRange(), &protocol.CodeActionContext{})
+	actions := showDocActions([]rules.Violation{v}, params)
+
+	assert.Empty(t, actions)
+}
+
+func TestShowDocActions_Dedup(t *testing.T) {
+	t.Parallel()
+
+	loc1 := rules.NewRangeLocation("Dockerfile", 3, 0, 3, 10)
+	loc2 := rules.NewRangeLocation("Dockerfile", 5, 0, 5, 10)
+
+	v1 := rules.NewViolation(loc1, "tally/max-lines", "msg1", rules.SeverityWarning)
+	v1.DocURL = "https://example.com/doc"
+	v2 := rules.NewViolation(loc2, "tally/max-lines", "msg2", rules.SeverityWarning)
+	v2.DocURL = "https://example.com/doc"
+
+	params := makeCodeActionParams("file:///test/Dockerfile", fullRange(), &protocol.CodeActionContext{})
+	actions := showDocActions([]rules.Violation{v1, v2}, params)
+
+	require.Len(t, actions, 1, "should deduplicate by ruleCode")
+}
+
+func TestShowDocActions_OutOfRange(t *testing.T) {
+	t.Parallel()
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 50, 0, 50, 10),
+		"tally/max-lines",
+		"msg",
+		rules.SeverityWarning,
+	)
+	v.DocURL = "https://example.com/doc"
+
+	// Request range is lines 0-5 only.
+	params := makeCodeActionParams("file:///test/Dockerfile",
+		protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 5, Character: 0},
+		},
+		&protocol.CodeActionContext{},
+	)
+	actions := showDocActions([]rules.Violation{v}, params)
+
+	assert.Empty(t, actions, "should not emit action for violations outside the requested range")
+}
+
+func TestParseOpenRuleDocArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		args := []any{map[string]any{"url": "https://example.com"}}
+		assert.Equal(t, "https://example.com", parseOpenRuleDocArgs(&args))
+	})
+
+	t.Run("nil args", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, parseOpenRuleDocArgs(nil))
+	})
+
+	t.Run("empty args", func(t *testing.T) {
+		t.Parallel()
+		args := []any{}
+		assert.Empty(t, parseOpenRuleDocArgs(&args))
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		t.Parallel()
+		args := []any{"not a map"}
+		assert.Empty(t, parseOpenRuleDocArgs(&args))
+	})
+}

--- a/internal/lspserver/server.go
+++ b/internal/lspserver/server.go
@@ -57,6 +57,7 @@ type Server struct {
 	pushDiagnostics            bool
 	supportsDiagnosticRefresh  bool
 	supportsDiagnosticPullMode bool
+	showDocumentSupported      bool
 
 	requestCancelMu          sync.Mutex
 	requestQueuedIDs         map[string]struct{}
@@ -399,11 +400,26 @@ func lspNotify(ctx context.Context, conn *jsonrpc2.Connection, method string, pa
 	return conn.Notify(ctx, method, stdjson.RawMessage(raw))
 }
 
+// lspCall pre-marshals params with json/v2 and sends a call via conn.Call.
+// The response is awaited but the result is discarded.
+func lspCall(ctx context.Context, conn *jsonrpc2.Connection, method string, params any) error {
+	raw, err := jsonv2.Marshal(params)
+	if err != nil {
+		return err
+	}
+	return conn.Call(ctx, method, stdjson.RawMessage(raw)).Await(ctx, nil)
+}
+
 // handleInitialize responds to the initialize request with server capabilities.
 func (s *Server) handleInitialize(params *protocol.InitializeParams) (any, error) {
 	log.Printf("lsp: initialize from %s", clientInfoString(params))
 
 	s.configureDiagnosticsMode(params)
+	if params.Capabilities != nil &&
+		params.Capabilities.Window != nil &&
+		params.Capabilities.Window.ShowDocument != nil {
+		s.showDocumentSupported = params.Capabilities.Window.ShowDocument.Support
+	}
 	if params.InitializationOptions != nil {
 		if next, ok := parseClientSettings(*params.InitializationOptions); ok {
 			s.settingsMu.Lock()
@@ -429,6 +445,7 @@ func (s *Server) handleInitialize(params *protocol.InitializeParams) (any, error
 				CodeActionOptions: &protocol.CodeActionOptions{
 					CodeActionKinds: new([]protocol.CodeActionKind{
 						protocol.CodeActionKindQuickFix,
+						suppressCodeActionKind,
 						"source.fixAll.tally",
 					}),
 				},
@@ -454,6 +471,7 @@ func (s *Server) handleInitialize(params *protocol.InitializeParams) (any, error
 			ExecuteCommandProvider: &protocol.ExecuteCommandOptions{
 				Commands: []string{
 					applyAllFixesCommand,
+					openRuleDocCommand,
 				},
 			},
 		},

--- a/internal/lspserver/settings.go
+++ b/internal/lspserver/settings.go
@@ -30,6 +30,9 @@ type folderSettings struct {
 	ConfigurationPreference config.ConfigurationPreference
 	ConfigurationOverrides  map[string]any
 	WorkspaceTrusted        bool
+	SuppressRuleEnabled     bool
+	ShowDocEnabled          bool
+	FixAllMode              string // "all" (iterative) or "problems" (single-pass)
 }
 
 func applyDefaultPreference(pref config.ConfigurationPreference) config.ConfigurationPreference {
@@ -39,11 +42,19 @@ func applyDefaultPreference(pref config.ConfigurationPreference) config.Configur
 	return pref
 }
 
+const (
+	fixAllModeAll      = "all"
+	fixAllModeProblems = "problems"
+)
+
 func defaultClientSettings() clientSettings {
 	return clientSettings{
 		Global: folderSettings{
 			ConfigurationPreference: config.ConfigurationPreferenceEditorFirst,
 			WorkspaceTrusted:        false,
+			SuppressRuleEnabled:     true,
+			ShowDocEnabled:          true,
+			FixAllMode:              fixAllModeAll,
 		},
 	}
 }
@@ -138,6 +149,9 @@ type folderSettingsWire struct {
 	ConfigurationPreference config.ConfigurationPreference `json:"configurationPreference"`
 	Configuration           any                            `json:"configuration"`
 	WorkspaceTrusted        bool                           `json:"workspaceTrusted"`
+	SuppressRuleEnabled     *bool                          `json:"suppressRuleEnabled"`
+	ShowDocEnabled          *bool                          `json:"showDocumentationEnabled"`
+	FixAllMode              string                         `json:"fixAllMode"`
 }
 
 func parseClientSettings(settings any) (clientSettings, bool) {
@@ -163,6 +177,9 @@ func parseClientSettings(settings any) (clientSettings, bool) {
 			ConfigurationPreference: applyDefaultPreference(wire.Global.ConfigurationPreference),
 			ConfigurationOverrides:  toOverridesMap(wire.Global.Configuration),
 			WorkspaceTrusted:        wire.Global.WorkspaceTrusted,
+			SuppressRuleEnabled:     boolPtrTrue(wire.Global.SuppressRuleEnabled),
+			ShowDocEnabled:          boolPtrTrue(wire.Global.ShowDocEnabled),
+			FixAllMode:              fixAllModeOrDefault(wire.Global.FixAllMode),
 		},
 	}
 
@@ -173,6 +190,9 @@ func parseClientSettings(settings any) (clientSettings, bool) {
 				ConfigurationPreference: applyDefaultPreference(ws.Settings.ConfigurationPreference),
 				ConfigurationOverrides:  toOverridesMap(ws.Settings.Configuration),
 				WorkspaceTrusted:        ws.Settings.WorkspaceTrusted,
+				SuppressRuleEnabled:     boolPtrTrue(ws.Settings.SuppressRuleEnabled),
+				ShowDocEnabled:          boolPtrTrue(ws.Settings.ShowDocEnabled),
+				FixAllMode:              fixAllModeOrDefault(ws.Settings.FixAllMode),
 			},
 		})
 	}
@@ -183,6 +203,23 @@ func parseClientSettings(settings any) (clientSettings, bool) {
 	})
 
 	return out, true
+}
+
+// boolPtrTrue returns the value pointed to by p, or true if p is nil.
+func boolPtrTrue(p *bool) bool {
+	if p == nil {
+		return true
+	}
+	return *p
+}
+
+func fixAllModeOrDefault(mode string) string {
+	switch mode {
+	case fixAllModeAll, fixAllModeProblems:
+		return mode
+	default:
+		return fixAllModeAll
+	}
 }
 
 func toOverridesMap(v any) map[string]any {

--- a/internal/lspserver/settings_test.go
+++ b/internal/lspserver/settings_test.go
@@ -44,3 +44,53 @@ func TestHandleInitialize_ConsumesInitializationOptions(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, s.settings.Global.WorkspaceTrusted)
 }
+
+func TestParseClientSettings_NewFields_Defaults(t *testing.T) {
+	t.Parallel()
+
+	// When the new fields are omitted, they should default to sensible values.
+	settings, ok := parseClientSettings(map[string]any{
+		"tally": map[string]any{
+			"version": 1,
+			"global":  map[string]any{},
+		},
+	})
+	require.True(t, ok)
+	require.True(t, settings.Global.SuppressRuleEnabled, "SuppressRuleEnabled should default to true")
+	require.True(t, settings.Global.ShowDocEnabled, "ShowDocEnabled should default to true")
+	require.Equal(t, fixAllModeAll, settings.Global.FixAllMode, "FixAllMode should default to 'all'")
+}
+
+func TestParseClientSettings_NewFields_Explicit(t *testing.T) {
+	t.Parallel()
+
+	settings, ok := parseClientSettings(map[string]any{
+		"tally": map[string]any{
+			"version": 1,
+			"global": map[string]any{
+				"suppressRuleEnabled":      false,
+				"showDocumentationEnabled": false,
+				"fixAllMode":               "problems",
+			},
+		},
+	})
+	require.True(t, ok)
+	require.False(t, settings.Global.SuppressRuleEnabled)
+	require.False(t, settings.Global.ShowDocEnabled)
+	require.Equal(t, fixAllModeProblems, settings.Global.FixAllMode)
+}
+
+func TestParseClientSettings_FixAllMode_InvalidDefaultsToAll(t *testing.T) {
+	t.Parallel()
+
+	settings, ok := parseClientSettings(map[string]any{
+		"tally": map[string]any{
+			"version": 1,
+			"global": map[string]any{
+				"fixAllMode": "invalid-value",
+			},
+		},
+	})
+	require.True(t, ok)
+	require.Equal(t, fixAllModeAll, settings.Global.FixAllMode, "unknown fixAllMode should default to 'all'")
+}

--- a/internal/lspserver/suppress.go
+++ b/internal/lspserver/suppress.go
@@ -34,10 +34,10 @@ func suppressRuleActions(
 	spanIndex := directive.NewInstructionSpanIndexFromAST(parseResult.AST, sm)
 	dirResult := directive.Parse(sm, nil, spanIndex)
 
-	// The first instruction's start line (0-based) marks where parser directives
-	// end. Derived from the already-parsed AST — no string-based parser directive
-	// detection needed.
-	firstInstLine0 := firstInstructionLine(parseResult)
+	// The floor line is the first line after parser directives (# syntax=, # escape=).
+	// Comments between parser directives and the first instruction are NOT parser
+	// directives — findCommentBlockStart should be free to walk through them.
+	parserDirFloor0 := parserDirectiveFloor(parseResult)
 
 	requireReason := cfg != nil && cfg.InlineDirectives.RequireReason
 	lines := strings.Split(content, "\n")
@@ -65,7 +65,7 @@ func suppressRuleActions(
 		uri := params.TextDocument.Uri
 
 		// Next-line suppress action
-		if edit := suppressLineEdit(v, lines, dirResult, spanIndex, firstInstLine0, requireReason); edit != nil {
+		if edit := suppressLineEdit(v, lines, dirResult, spanIndex, parserDirFloor0, requireReason); edit != nil {
 			suppressLineData := any(map[string]any{"type": "suppress-line", "ruleCode": v.RuleCode})
 			actions = append(actions, protocol.CodeAction{
 				Title: fmt.Sprintf("Suppress %s for this line", v.RuleCode),
@@ -83,7 +83,7 @@ func suppressRuleActions(
 		// rule on different lines should produce only one "for this file" action).
 		if _, fileSeen := seenFile[v.RuleCode]; !fileSeen {
 			seenFile[v.RuleCode] = struct{}{}
-			if edit := suppressFileEdit(v.RuleCode, lines, dirResult, firstInstLine0, requireReason); edit != nil {
+			if edit := suppressFileEdit(v.RuleCode, lines, dirResult, parserDirFloor0, requireReason); edit != nil {
 				suppressFileData := any(map[string]any{"type": "suppress-file", "ruleCode": v.RuleCode})
 				actions = append(actions, protocol.CodeAction{
 					Title: fmt.Sprintf("Suppress %s for this file", v.RuleCode),
@@ -102,19 +102,32 @@ func suppressRuleActions(
 	return actions
 }
 
-// firstInstructionLine returns the 0-based line of the first instruction in the
-// Dockerfile, derived from the already-parsed AST. Everything before this line
-// is parser directives or comments. Returns 0 if there are no instructions.
-func firstInstructionLine(pr *dockerfile.ParseResult) int {
+// parserDirectiveFloor returns the 0-based line after the last parser directive
+// in the Dockerfile. Parser directives (# syntax=, # escape=) are consumed by
+// BuildKit's parser before building the AST, so they don't appear as children.
+// The first child's PrevComment contains comments between parser directives and
+// the first instruction. The floor is: firstChild.StartLine - len(PrevComment) - 1.
+// This is the lowest line where suppress directives may be inserted.
+func parserDirectiveFloor(pr *dockerfile.ParseResult) int {
 	if pr == nil || pr.AST == nil || pr.AST.AST == nil {
 		return 0
 	}
-	for _, child := range pr.AST.AST.Children {
-		if child != nil && child.StartLine > 0 {
-			return child.StartLine - 1 // AST uses 1-based lines
-		}
+	children := pr.AST.AST.Children
+	if len(children) == 0 || children[0] == nil || children[0].StartLine <= 0 {
+		return 0
 	}
-	return 0
+
+	firstChild := children[0]
+	// firstChild.StartLine is 1-based. PrevComment holds the comment lines
+	// between parser directives and this instruction. The line right after
+	// the last parser directive is:
+	//   (firstChild.StartLine - 1) - len(PrevComment)
+	// converted to 0-based.
+	floor := firstChild.StartLine - 1 - len(firstChild.PrevComment)
+	if floor < 0 {
+		return 0
+	}
+	return floor
 }
 
 // suppressLineEdit generates a TextEdit to add a # tally ignore= directive
@@ -129,7 +142,7 @@ func suppressLineEdit(
 	lines []string,
 	dirResult *directive.ParseResult,
 	spanIndex *directive.InstructionSpanIndex,
-	firstInstLine0 int,
+	parserDirFloor0 int,
 	requireReason bool,
 ) *protocol.TextEdit {
 	// Violation line is 1-based; convert to 0-based for line array access.
@@ -168,7 +181,7 @@ func suppressLineEdit(
 
 	// No existing directive — insert a new one above the comment block
 	// preceding the instruction's start line (not the violation line).
-	insertLine0 := findCommentBlockStart(instructionLine0, firstInstLine0, lines)
+	insertLine0 := findCommentBlockStart(instructionLine0, parserDirFloor0, lines)
 
 	// Match indentation of the instruction start line.
 	indent := leadingWhitespace(lines[instructionLine0])
@@ -194,7 +207,7 @@ func suppressFileEdit(
 	ruleCode string,
 	lines []string,
 	dirResult *directive.ParseResult,
-	firstInstLine0 int,
+	parserDirFloor0 int,
 	requireReason bool,
 ) *protocol.TextEdit {
 	// Check existing global directives.
@@ -213,7 +226,7 @@ func suppressFileEdit(
 	}
 
 	// No existing global directive — insert right before the first instruction.
-	// Everything before firstInstLine0 is parser directives or preamble comments.
+	// Everything before parserDirFloor0 is parser directives or preamble comments.
 	reason := ""
 	if requireReason {
 		reason = "TODO"
@@ -222,8 +235,8 @@ func suppressFileEdit(
 
 	return &protocol.TextEdit{
 		Range: protocol.Range{
-			Start: protocol.Position{Line: clampUint32(firstInstLine0), Character: 0},
-			End:   protocol.Position{Line: clampUint32(firstInstLine0), Character: 0},
+			Start: protocol.Position{Line: clampUint32(parserDirFloor0), Character: 0},
+			End:   protocol.Position{Line: clampUint32(parserDirFloor0), Character: 0},
 		},
 		NewText: comment + "\n",
 	}

--- a/internal/lspserver/suppress.go
+++ b/internal/lspserver/suppress.go
@@ -221,6 +221,11 @@ func mergeRuleIntoDirectiveLine(directiveLine int, ruleCode string, lines []stri
 // findCommentBlockStart walks backwards from the instruction line to find
 // the first line of any comment block immediately above it. Returns the
 // 0-based line where the new directive should be inserted.
+//
+// Stops at:
+//   - empty lines or non-comment lines (obvious block boundary)
+//   - bare "#" lines (empty comment — acts as a block separator in BuildKit)
+//   - parser directives (# syntax=, # escape=, # check=) which must stay at the top
 func findCommentBlockStart(instructionLine0 int, lines []string) int {
 	line := instructionLine0
 	for line > 0 {
@@ -228,9 +233,26 @@ func findCommentBlockStart(instructionLine0 int, lines []string) int {
 		if prev == "" || !strings.HasPrefix(prev, "#") {
 			break
 		}
+		// Bare "#" (empty comment) is a block separator.
+		if prev == "#" {
+			break
+		}
+		// Don't walk past parser directives.
+		if isParserDirective(prev) {
+			break
+		}
 		line--
 	}
 	return line
+}
+
+// isParserDirective returns true if the line is a Dockerfile parser directive
+// (# syntax=, # escape=, # check=) that must remain at the top of the file.
+func isParserDirective(trimmedLine string) bool {
+	lower := strings.ToLower(trimmedLine)
+	return strings.HasPrefix(lower, "# syntax=") ||
+		strings.HasPrefix(lower, "# escape=") ||
+		strings.HasPrefix(lower, "# check=")
 }
 
 // findInsertionAfterParserDirectives returns the 0-based line where a global
@@ -240,10 +262,7 @@ func findInsertionAfterParserDirectives(lines []string) int {
 	line := 0
 	for line < len(lines) {
 		trimmed := strings.TrimSpace(lines[line])
-		lower := strings.ToLower(trimmed)
-		if strings.HasPrefix(lower, "# syntax=") ||
-			strings.HasPrefix(lower, "# escape=") ||
-			strings.HasPrefix(lower, "# check=") {
+		if isParserDirective(trimmed) {
 			line++
 			continue
 		}

--- a/internal/lspserver/suppress.go
+++ b/internal/lspserver/suppress.go
@@ -34,6 +34,11 @@ func suppressRuleActions(
 	spanIndex := directive.NewInstructionSpanIndexFromAST(parseResult.AST, sm)
 	dirResult := directive.Parse(sm, nil, spanIndex)
 
+	// The first instruction's start line (0-based) marks where parser directives
+	// end. Derived from the already-parsed AST — no string-based parser directive
+	// detection needed.
+	firstInstLine0 := firstInstructionLine(parseResult)
+
 	requireReason := cfg != nil && cfg.InlineDirectives.RequireReason
 	lines := strings.Split(content, "\n")
 
@@ -59,7 +64,7 @@ func suppressRuleActions(
 		uri := params.TextDocument.Uri
 
 		// Next-line suppress action
-		if edit := suppressLineEdit(v, lines, dirResult, requireReason); edit != nil {
+		if edit := suppressLineEdit(v, lines, dirResult, firstInstLine0, requireReason); edit != nil {
 			suppressLineData := any(map[string]any{"type": "suppress-line", "ruleCode": v.RuleCode})
 			actions = append(actions, protocol.CodeAction{
 				Title: fmt.Sprintf("Suppress %s for this line", v.RuleCode),
@@ -74,7 +79,7 @@ func suppressRuleActions(
 		}
 
 		// File-level suppress action
-		if edit := suppressFileEdit(v.RuleCode, lines, dirResult, requireReason); edit != nil {
+		if edit := suppressFileEdit(v.RuleCode, lines, dirResult, firstInstLine0, requireReason); edit != nil {
 			suppressFileData := any(map[string]any{"type": "suppress-file", "ruleCode": v.RuleCode})
 			actions = append(actions, protocol.CodeAction{
 				Title: fmt.Sprintf("Suppress %s for this file", v.RuleCode),
@@ -92,6 +97,21 @@ func suppressRuleActions(
 	return actions
 }
 
+// firstInstructionLine returns the 0-based line of the first instruction in the
+// Dockerfile, derived from the already-parsed AST. Everything before this line
+// is parser directives or comments. Returns 0 if there are no instructions.
+func firstInstructionLine(pr *dockerfile.ParseResult) int {
+	if pr == nil || pr.AST == nil || pr.AST.AST == nil {
+		return 0
+	}
+	for _, child := range pr.AST.AST.Children {
+		if child != nil && child.StartLine > 0 {
+			return child.StartLine - 1 // AST uses 1-based lines
+		}
+	}
+	return 0
+}
+
 // suppressLineEdit generates a TextEdit to add a # tally ignore= directive
 // for the given violation. It inserts above the comment block preceding the
 // instruction (not between comments and the instruction) to avoid triggering
@@ -103,6 +123,7 @@ func suppressLineEdit(
 	v rules.Violation,
 	lines []string,
 	dirResult *directive.ParseResult,
+	firstInstLine0 int,
 	requireReason bool,
 ) *protocol.TextEdit {
 	// Violation line is 1-based; convert to 0-based for line array access.
@@ -128,8 +149,9 @@ func suppressLineEdit(
 		return mergeRuleIntoDirectiveLine(d.Line, v.RuleCode, lines)
 	}
 
-	// No existing directive — insert a new one above the comment block.
-	insertLine0 := findCommentBlockStart(violationLine0, lines)
+	// No existing directive — insert a new one above the comment block,
+	// but never before the first instruction (which marks the end of parser directives).
+	insertLine0 := findCommentBlockStart(violationLine0, firstInstLine0, lines)
 
 	// Match indentation of the instruction line.
 	indent := leadingWhitespace(lines[violationLine0])
@@ -154,6 +176,7 @@ func suppressFileEdit(
 	ruleCode string,
 	lines []string,
 	dirResult *directive.ParseResult,
+	firstInstLine0 int,
 	requireReason bool,
 ) *protocol.TextEdit {
 	// Check existing global directives.
@@ -171,9 +194,8 @@ func suppressFileEdit(
 		return mergeRuleIntoDirectiveLine(d.Line, ruleCode, lines)
 	}
 
-	// No existing global directive — insert after parser directives (# syntax=, # escape=).
-	insertLine0 := findInsertionAfterParserDirectives(lines)
-
+	// No existing global directive — insert right before the first instruction.
+	// Everything before firstInstLine0 is parser directives or preamble comments.
 	comment := "# tally global ignore=" + ruleCode
 	if requireReason {
 		comment += ";reason=TODO"
@@ -181,8 +203,8 @@ func suppressFileEdit(
 
 	return &protocol.TextEdit{
 		Range: protocol.Range{
-			Start: protocol.Position{Line: clampUint32(insertLine0), Character: 0},
-			End:   protocol.Position{Line: clampUint32(insertLine0), Character: 0},
+			Start: protocol.Position{Line: clampUint32(firstInstLine0), Character: 0},
+			End:   protocol.Position{Line: clampUint32(firstInstLine0), Character: 0},
 		},
 		NewText: comment + "\n",
 	}
@@ -222,13 +244,16 @@ func mergeRuleIntoDirectiveLine(directiveLine int, ruleCode string, lines []stri
 // the first line of any comment block immediately above it. Returns the
 // 0-based line where the new directive should be inserted.
 //
+// floorLine0 is the lowest line we may return (typically the first instruction
+// line from the AST), preventing insertion into the parser-directive preamble.
+//
 // Stops at:
 //   - empty lines or non-comment lines (obvious block boundary)
 //   - bare "#" lines (empty comment — acts as a block separator in BuildKit)
-//   - parser directives (# syntax=, # escape=, # check=) which must stay at the top
-func findCommentBlockStart(instructionLine0 int, lines []string) int {
+//   - floorLine0 (never walks into parser directives)
+func findCommentBlockStart(instructionLine0, floorLine0 int, lines []string) int {
 	line := instructionLine0
-	for line > 0 {
+	for line > floorLine0 {
 		prev := strings.TrimSpace(lines[line-1])
 		if prev == "" || !strings.HasPrefix(prev, "#") {
 			break
@@ -237,36 +262,7 @@ func findCommentBlockStart(instructionLine0 int, lines []string) int {
 		if prev == "#" {
 			break
 		}
-		// Don't walk past parser directives.
-		if isParserDirective(prev) {
-			break
-		}
 		line--
-	}
-	return line
-}
-
-// isParserDirective returns true if the line is a Dockerfile parser directive
-// (# syntax=, # escape=, # check=) that must remain at the top of the file.
-func isParserDirective(trimmedLine string) bool {
-	lower := strings.ToLower(trimmedLine)
-	return strings.HasPrefix(lower, "# syntax=") ||
-		strings.HasPrefix(lower, "# escape=") ||
-		strings.HasPrefix(lower, "# check=")
-}
-
-// findInsertionAfterParserDirectives returns the 0-based line where a global
-// directive should be inserted — after any # syntax= or # escape= parser
-// directives and their trailing blank lines.
-func findInsertionAfterParserDirectives(lines []string) int {
-	line := 0
-	for line < len(lines) {
-		trimmed := strings.TrimSpace(lines[line])
-		if isParserDirective(trimmed) {
-			line++
-			continue
-		}
-		break
 	}
 	return line
 }

--- a/internal/lspserver/suppress.go
+++ b/internal/lspserver/suppress.go
@@ -137,21 +137,24 @@ func suppressLineEdit(
 		return nil
 	}
 
-	// Check if an existing next-line directive already targets this instruction.
+	// Check existing next-line directives that target this instruction.
+	// Any source (tally, hadolint, buildx) can suppress the rule, but we
+	// only merge into tally-sourced directives to avoid mutating foreign syntax.
+	var tallyDirectiveLine *directive.Directive
 	for i := range dirResult.Directives {
 		d := &dirResult.Directives[i]
-		if d.Type != directive.TypeNextLine {
+		if d.Type != directive.TypeNextLine || !d.AppliesTo.Contains(violationLine0) {
 			continue
 		}
-		if !d.AppliesTo.Contains(violationLine0) {
-			continue
-		}
-		// Found an existing directive — check if it already suppresses this rule.
 		if d.SuppressesRule(v.RuleCode) {
-			return nil // already suppressed
+			return nil // already suppressed by any directive source
 		}
-		// Merge: append the rule code to the existing directive line.
-		return mergeRuleIntoDirectiveLine(d.Line, v.RuleCode, lines)
+		if d.Source == directive.SourceTally && tallyDirectiveLine == nil {
+			tallyDirectiveLine = d
+		}
+	}
+	if tallyDirectiveLine != nil {
+		return appendRuleEdit(tallyDirectiveLine.Line, v.RuleCode, lines)
 	}
 
 	// No existing directive — insert a new one above the comment block,
@@ -160,10 +163,11 @@ func suppressLineEdit(
 
 	// Match indentation of the instruction line.
 	indent := leadingWhitespace(lines[violationLine0])
-	comment := indent + "# tally ignore=" + v.RuleCode
+	reason := ""
 	if requireReason {
-		comment += ";reason=TODO"
+		reason = "TODO"
 	}
+	comment := indent + directive.FormatNextLine([]string{v.RuleCode}, reason)
 
 	return &protocol.TextEdit{
 		Range: protocol.Range{
@@ -196,15 +200,16 @@ func suppressFileEdit(
 		if d.SuppressesRule(ruleCode) {
 			return nil // already suppressed
 		}
-		return mergeRuleIntoDirectiveLine(d.Line, ruleCode, lines)
+		return appendRuleEdit(d.Line, ruleCode, lines)
 	}
 
 	// No existing global directive — insert right before the first instruction.
 	// Everything before firstInstLine0 is parser directives or preamble comments.
-	comment := "# tally global ignore=" + ruleCode
+	reason := ""
 	if requireReason {
-		comment += ";reason=TODO"
+		reason = "TODO"
 	}
+	comment := directive.FormatGlobal([]string{ruleCode}, reason)
 
 	return &protocol.TextEdit{
 		Range: protocol.Range{
@@ -215,33 +220,22 @@ func suppressFileEdit(
 	}
 }
 
-// mergeRuleIntoDirectiveLine appends a rule code to an existing directive line.
-// directiveLine is 0-based.
-func mergeRuleIntoDirectiveLine(directiveLine int, ruleCode string, lines []string) *protocol.TextEdit {
-	if directiveLine < 0 || directiveLine >= len(lines) {
+// appendRuleEdit creates a TextEdit that appends a rule code to an existing
+// directive line using directive.AppendRule for the text manipulation.
+// directiveLine0 is 0-based.
+func appendRuleEdit(directiveLine0 int, ruleCode string, lines []string) *protocol.TextEdit {
+	if directiveLine0 < 0 || directiveLine0 >= len(lines) {
 		return nil
 	}
 
-	line := lines[directiveLine]
-
-	// Find the position to insert: before ;reason= if present, otherwise at end of line.
-	insertPos := len(line)
-	if idx := strings.Index(line, ";reason="); idx >= 0 {
-		insertPos = idx
-	}
-
-	// Trim trailing whitespace before insertion point.
-	trimmed := insertPos
-	for trimmed > 0 && line[trimmed-1] == ' ' {
-		trimmed--
-	}
+	edit := directive.AppendRule(lines[directiveLine0], ruleCode)
 
 	return &protocol.TextEdit{
 		Range: protocol.Range{
-			Start: protocol.Position{Line: clampUint32(directiveLine), Character: clampUint32(trimmed)},
-			End:   protocol.Position{Line: clampUint32(directiveLine), Character: clampUint32(insertPos)},
+			Start: protocol.Position{Line: clampUint32(directiveLine0), Character: clampUint32(edit.Start)},
+			End:   protocol.Position{Line: clampUint32(directiveLine0), Character: clampUint32(edit.End)},
 		},
-		NewText: "," + ruleCode,
+		NewText: edit.NewText,
 	}
 }
 

--- a/internal/lspserver/suppress.go
+++ b/internal/lspserver/suppress.go
@@ -1,0 +1,263 @@
+package lspserver
+
+import (
+	"fmt"
+	"strings"
+
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
+
+	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/directive"
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+const suppressCodeActionKind = protocol.CodeActionKind("quickfix.suppress.tally")
+
+// suppressRuleActions generates CodeActions that inject # tally ignore= directives
+// to suppress violations. For each violation in the requested range, up to two
+// actions are emitted: "Suppress {ruleCode} for this line" (next-line directive)
+// and "Suppress {ruleCode} for this file" (global directive).
+func suppressRuleActions(
+	violations []rules.Violation,
+	params *protocol.CodeActionParams,
+	content string,
+	parseResult *dockerfile.ParseResult,
+	cfg *config.Config,
+) []protocol.CodeAction {
+	if parseResult == nil || parseResult.AST == nil {
+		return nil
+	}
+
+	sm := sourcemap.New(parseResult.Source)
+	spanIndex := directive.NewInstructionSpanIndexFromAST(parseResult.AST, sm)
+	dirResult := directive.Parse(sm, nil, spanIndex)
+
+	requireReason := cfg != nil && cfg.InlineDirectives.RequireReason
+	lines := strings.Split(content, "\n")
+
+	type seenKey struct {
+		ruleCode string
+		line     int
+	}
+	seen := make(map[seenKey]struct{})
+	var actions []protocol.CodeAction
+
+	for _, v := range violations {
+		vRange := violationRange(v)
+		if !rangesOverlap(vRange, params.Range) {
+			continue
+		}
+
+		key := seenKey{ruleCode: v.RuleCode, line: v.Location.Start.Line}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		uri := params.TextDocument.Uri
+
+		// Next-line suppress action
+		if edit := suppressLineEdit(v, lines, dirResult, requireReason); edit != nil {
+			suppressLineData := any(map[string]any{"type": "suppress-line", "ruleCode": v.RuleCode})
+			actions = append(actions, protocol.CodeAction{
+				Title: fmt.Sprintf("Suppress %s for this line", v.RuleCode),
+				Kind:  ptrTo(suppressCodeActionKind),
+				Edit: &protocol.WorkspaceEdit{
+					Changes: new(map[protocol.DocumentUri][]*protocol.TextEdit{
+						uri: {edit},
+					}),
+				},
+				Data: &suppressLineData,
+			})
+		}
+
+		// File-level suppress action
+		if edit := suppressFileEdit(v.RuleCode, lines, dirResult, requireReason); edit != nil {
+			suppressFileData := any(map[string]any{"type": "suppress-file", "ruleCode": v.RuleCode})
+			actions = append(actions, protocol.CodeAction{
+				Title: fmt.Sprintf("Suppress %s for this file", v.RuleCode),
+				Kind:  ptrTo(suppressCodeActionKind),
+				Edit: &protocol.WorkspaceEdit{
+					Changes: new(map[protocol.DocumentUri][]*protocol.TextEdit{
+						uri: {edit},
+					}),
+				},
+				Data: &suppressFileData,
+			})
+		}
+	}
+
+	return actions
+}
+
+// suppressLineEdit generates a TextEdit to add a # tally ignore= directive
+// for the given violation. It inserts above the comment block preceding the
+// instruction (not between comments and the instruction) to avoid triggering
+// buildkit/InvalidDefinitionDescription.
+//
+// If an existing next-line directive already covers this instruction, the rule
+// code is appended to it instead.
+func suppressLineEdit(
+	v rules.Violation,
+	lines []string,
+	dirResult *directive.ParseResult,
+	requireReason bool,
+) *protocol.TextEdit {
+	// Violation line is 1-based; convert to 0-based for line array access.
+	violationLine0 := v.Location.Start.Line - 1
+	if violationLine0 < 0 || violationLine0 >= len(lines) {
+		return nil
+	}
+
+	// Check if an existing next-line directive already targets this instruction.
+	for i := range dirResult.Directives {
+		d := &dirResult.Directives[i]
+		if d.Type != directive.TypeNextLine {
+			continue
+		}
+		if !d.AppliesTo.Contains(violationLine0) {
+			continue
+		}
+		// Found an existing directive — check if it already suppresses this rule.
+		if d.SuppressesRule(v.RuleCode) {
+			return nil // already suppressed
+		}
+		// Merge: append the rule code to the existing directive line.
+		return mergeRuleIntoDirectiveLine(d.Line, v.RuleCode, lines)
+	}
+
+	// No existing directive — insert a new one above the comment block.
+	insertLine0 := findCommentBlockStart(violationLine0, lines)
+
+	// Match indentation of the instruction line.
+	indent := leadingWhitespace(lines[violationLine0])
+	comment := indent + "# tally ignore=" + v.RuleCode
+	if requireReason {
+		comment += ";reason=TODO"
+	}
+
+	return &protocol.TextEdit{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: clampUint32(insertLine0), Character: 0},
+			End:   protocol.Position{Line: clampUint32(insertLine0), Character: 0},
+		},
+		NewText: comment + "\n",
+	}
+}
+
+// suppressFileEdit generates a TextEdit to add a # tally global ignore= directive
+// at the top of the file. If an existing global directive exists, the rule code
+// is appended to it.
+func suppressFileEdit(
+	ruleCode string,
+	lines []string,
+	dirResult *directive.ParseResult,
+	requireReason bool,
+) *protocol.TextEdit {
+	// Check existing global directives.
+	for i := range dirResult.Directives {
+		d := &dirResult.Directives[i]
+		if d.Type != directive.TypeGlobal {
+			continue
+		}
+		if d.Source != directive.SourceTally {
+			continue
+		}
+		if d.SuppressesRule(ruleCode) {
+			return nil // already suppressed
+		}
+		return mergeRuleIntoDirectiveLine(d.Line, ruleCode, lines)
+	}
+
+	// No existing global directive — insert after parser directives (# syntax=, # escape=).
+	insertLine0 := findInsertionAfterParserDirectives(lines)
+
+	comment := "# tally global ignore=" + ruleCode
+	if requireReason {
+		comment += ";reason=TODO"
+	}
+
+	return &protocol.TextEdit{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: clampUint32(insertLine0), Character: 0},
+			End:   protocol.Position{Line: clampUint32(insertLine0), Character: 0},
+		},
+		NewText: comment + "\n",
+	}
+}
+
+// mergeRuleIntoDirectiveLine appends a rule code to an existing directive line.
+// directiveLine is 0-based.
+func mergeRuleIntoDirectiveLine(directiveLine int, ruleCode string, lines []string) *protocol.TextEdit {
+	if directiveLine < 0 || directiveLine >= len(lines) {
+		return nil
+	}
+
+	line := lines[directiveLine]
+
+	// Find the position to insert: before ;reason= if present, otherwise at end of line.
+	insertPos := len(line)
+	if idx := strings.Index(line, ";reason="); idx >= 0 {
+		insertPos = idx
+	}
+
+	// Trim trailing whitespace before insertion point.
+	trimmed := insertPos
+	for trimmed > 0 && line[trimmed-1] == ' ' {
+		trimmed--
+	}
+
+	return &protocol.TextEdit{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: clampUint32(directiveLine), Character: clampUint32(trimmed)},
+			End:   protocol.Position{Line: clampUint32(directiveLine), Character: clampUint32(insertPos)},
+		},
+		NewText: "," + ruleCode,
+	}
+}
+
+// findCommentBlockStart walks backwards from the instruction line to find
+// the first line of any comment block immediately above it. Returns the
+// 0-based line where the new directive should be inserted.
+func findCommentBlockStart(instructionLine0 int, lines []string) int {
+	line := instructionLine0
+	for line > 0 {
+		prev := strings.TrimSpace(lines[line-1])
+		if prev == "" || !strings.HasPrefix(prev, "#") {
+			break
+		}
+		line--
+	}
+	return line
+}
+
+// findInsertionAfterParserDirectives returns the 0-based line where a global
+// directive should be inserted — after any # syntax= or # escape= parser
+// directives and their trailing blank lines.
+func findInsertionAfterParserDirectives(lines []string) int {
+	line := 0
+	for line < len(lines) {
+		trimmed := strings.TrimSpace(lines[line])
+		lower := strings.ToLower(trimmed)
+		if strings.HasPrefix(lower, "# syntax=") ||
+			strings.HasPrefix(lower, "# escape=") ||
+			strings.HasPrefix(lower, "# check=") {
+			line++
+			continue
+		}
+		break
+	}
+	return line
+}
+
+// leadingWhitespace returns the leading whitespace (tabs and spaces) of a line.
+func leadingWhitespace(line string) string {
+	for i, c := range line {
+		if c != ' ' && c != '\t' {
+			return line[:i]
+		}
+	}
+	return line
+}

--- a/internal/lspserver/suppress.go
+++ b/internal/lspserver/suppress.go
@@ -65,7 +65,7 @@ func suppressRuleActions(
 		uri := params.TextDocument.Uri
 
 		// Next-line suppress action
-		if edit := suppressLineEdit(v, lines, dirResult, firstInstLine0, requireReason); edit != nil {
+		if edit := suppressLineEdit(v, lines, dirResult, spanIndex, firstInstLine0, requireReason); edit != nil {
 			suppressLineData := any(map[string]any{"type": "suppress-line", "ruleCode": v.RuleCode})
 			actions = append(actions, protocol.CodeAction{
 				Title: fmt.Sprintf("Suppress %s for this line", v.RuleCode),
@@ -128,6 +128,7 @@ func suppressLineEdit(
 	v rules.Violation,
 	lines []string,
 	dirResult *directive.ParseResult,
+	spanIndex *directive.InstructionSpanIndex,
 	firstInstLine0 int,
 	requireReason bool,
 ) *protocol.TextEdit {
@@ -135,6 +136,14 @@ func suppressLineEdit(
 	violationLine0 := v.Location.Start.Line - 1
 	if violationLine0 < 0 || violationLine0 >= len(lines) {
 		return nil
+	}
+
+	// Resolve to the instruction's start line. A violation may point to a
+	// continuation line (e.g. inside a heredoc or after a backslash). The
+	// directive must go above the instruction, not in the middle of it.
+	instructionLine0 := violationLine0
+	if span, ok := spanIndex.ContainingSpan(violationLine0); ok {
+		instructionLine0 = span.StartLine
 	}
 
 	// Check existing next-line directives that target this instruction.
@@ -157,12 +166,12 @@ func suppressLineEdit(
 		return appendRuleEdit(tallyDirectiveLine.Line, v.RuleCode, lines)
 	}
 
-	// No existing directive — insert a new one above the comment block,
-	// but never before the first instruction (which marks the end of parser directives).
-	insertLine0 := findCommentBlockStart(violationLine0, firstInstLine0, lines)
+	// No existing directive — insert a new one above the comment block
+	// preceding the instruction's start line (not the violation line).
+	insertLine0 := findCommentBlockStart(instructionLine0, firstInstLine0, lines)
 
-	// Match indentation of the instruction line.
-	indent := leadingWhitespace(lines[violationLine0])
+	// Match indentation of the instruction start line.
+	indent := leadingWhitespace(lines[instructionLine0])
 	reason := ""
 	if requireReason {
 		reason = "TODO"

--- a/internal/lspserver/suppress.go
+++ b/internal/lspserver/suppress.go
@@ -46,7 +46,8 @@ func suppressRuleActions(
 		ruleCode string
 		line     int
 	}
-	seen := make(map[seenKey]struct{})
+	seen := make(map[seenKey]struct{})    // dedup per-line actions by (rule, line)
+	seenFile := make(map[string]struct{}) // dedup file-level actions by rule only
 	var actions []protocol.CodeAction
 
 	for _, v := range violations {
@@ -78,19 +79,23 @@ func suppressRuleActions(
 			})
 		}
 
-		// File-level suppress action
-		if edit := suppressFileEdit(v.RuleCode, lines, dirResult, firstInstLine0, requireReason); edit != nil {
-			suppressFileData := any(map[string]any{"type": "suppress-file", "ruleCode": v.RuleCode})
-			actions = append(actions, protocol.CodeAction{
-				Title: fmt.Sprintf("Suppress %s for this file", v.RuleCode),
-				Kind:  ptrTo(suppressCodeActionKind),
-				Edit: &protocol.WorkspaceEdit{
-					Changes: new(map[protocol.DocumentUri][]*protocol.TextEdit{
-						uri: {edit},
-					}),
-				},
-				Data: &suppressFileData,
-			})
+		// File-level suppress action (deduplicated by ruleCode only — the same
+		// rule on different lines should produce only one "for this file" action).
+		if _, fileSeen := seenFile[v.RuleCode]; !fileSeen {
+			seenFile[v.RuleCode] = struct{}{}
+			if edit := suppressFileEdit(v.RuleCode, lines, dirResult, firstInstLine0, requireReason); edit != nil {
+				suppressFileData := any(map[string]any{"type": "suppress-file", "ruleCode": v.RuleCode})
+				actions = append(actions, protocol.CodeAction{
+					Title: fmt.Sprintf("Suppress %s for this file", v.RuleCode),
+					Kind:  ptrTo(suppressCodeActionKind),
+					Edit: &protocol.WorkspaceEdit{
+						Changes: new(map[protocol.DocumentUri][]*protocol.TextEdit{
+							uri: {edit},
+						}),
+					},
+					Data: &suppressFileData,
+				})
+			}
 		}
 	}
 

--- a/internal/lspserver/suppress_test.go
+++ b/internal/lspserver/suppress_test.go
@@ -30,7 +30,7 @@ func TestSuppressLineEdit_BasicInsertion(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, false)
+	edit := suppressLineEdit(v, lines, dirResult, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally ignore=hadolint/DL3027\n", edit.NewText)
 	assert.Equal(t, uint32(1), edit.Range.Start.Line, "should insert before the RUN line (0-based line 1)")
@@ -51,7 +51,7 @@ func TestSuppressLineEdit_WithRequireReason(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, true)
+	edit := suppressLineEdit(v, lines, dirResult, 0, true)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally ignore=tally/test-rule;reason=TODO\n", edit.NewText)
 }
@@ -71,7 +71,7 @@ func TestSuppressLineEdit_AboveCommentBlock(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, false)
+	edit := suppressLineEdit(v, lines, dirResult, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally ignore=tally/test-rule\n", edit.NewText)
 	assert.Equal(t, uint32(1), edit.Range.Start.Line,
@@ -93,7 +93,7 @@ func TestSuppressLineEdit_MergesWithExisting(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, false)
+	edit := suppressLineEdit(v, lines, dirResult, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, ",DL3027", edit.NewText, "should append rule to existing directive")
 	assert.Equal(t, uint32(1), edit.Range.Start.Line, "should edit the existing directive line")
@@ -114,7 +114,7 @@ func TestSuppressLineEdit_AlreadySuppressed(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, false)
+	edit := suppressLineEdit(v, lines, dirResult, 0, false)
 	assert.Nil(t, edit, "should return nil when rule is already suppressed")
 }
 
@@ -133,7 +133,7 @@ func TestSuppressLineEdit_Indentation(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, false)
+	edit := suppressLineEdit(v, lines, dirResult, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, "\t# tally ignore=tally/test-rule\n", edit.NewText,
 		"should match leading whitespace of the instruction")
@@ -147,7 +147,7 @@ func TestSuppressFileEdit_BasicInsertion(t *testing.T) {
 	sm := sourcemap.New([]byte(content))
 	dirResult := directive.Parse(sm, nil, nil)
 
-	edit := suppressFileEdit("tally/max-lines", lines, dirResult, false)
+	edit := suppressFileEdit("tally/max-lines", lines, dirResult, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally global ignore=tally/max-lines\n", edit.NewText)
 	assert.Equal(t, uint32(0), edit.Range.Start.Line, "should insert at the top of the file")
@@ -161,7 +161,8 @@ func TestSuppressFileEdit_AfterSyntaxDirective(t *testing.T) {
 	sm := sourcemap.New([]byte(content))
 	dirResult := directive.Parse(sm, nil, nil)
 
-	edit := suppressFileEdit("tally/max-lines", lines, dirResult, false)
+	// FROM is on line 1 (0-based), so firstInstLine0 = 1
+	edit := suppressFileEdit("tally/max-lines", lines, dirResult, 1, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally global ignore=tally/max-lines\n", edit.NewText)
 	assert.Equal(t, uint32(1), edit.Range.Start.Line,
@@ -176,7 +177,7 @@ func TestSuppressFileEdit_MergesWithExistingGlobal(t *testing.T) {
 	sm := sourcemap.New([]byte(content))
 	dirResult := directive.Parse(sm, nil, nil)
 
-	edit := suppressFileEdit("DL3027", lines, dirResult, false)
+	edit := suppressFileEdit("DL3027", lines, dirResult, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, ",DL3027", edit.NewText, "should append to existing global directive")
 	assert.Equal(t, uint32(0), edit.Range.Start.Line)
@@ -190,7 +191,7 @@ func TestSuppressFileEdit_AlreadySuppressed(t *testing.T) {
 	sm := sourcemap.New([]byte(content))
 	dirResult := directive.Parse(sm, nil, nil)
 
-	edit := suppressFileEdit("DL3027", lines, dirResult, false)
+	edit := suppressFileEdit("DL3027", lines, dirResult, 0, false)
 	assert.Nil(t, edit, "should return nil when rule is already globally suppressed")
 }
 
@@ -202,7 +203,7 @@ func TestSuppressFileEdit_WithRequireReason(t *testing.T) {
 	sm := sourcemap.New([]byte(content))
 	dirResult := directive.Parse(sm, nil, nil)
 
-	edit := suppressFileEdit("tally/max-lines", lines, dirResult, true)
+	edit := suppressFileEdit("tally/max-lines", lines, dirResult, 0, true)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally global ignore=tally/max-lines;reason=TODO\n", edit.NewText)
 }
@@ -247,6 +248,7 @@ func TestFindCommentBlockStart(t *testing.T) {
 		name             string
 		lines            []string
 		instructionLine0 int
+		floorLine0       int
 		want             int
 	}{
 		{
@@ -280,10 +282,11 @@ func TestFindCommentBlockStart(t *testing.T) {
 			want:             0,
 		},
 		{
-			name:             "stops at parser directive",
+			name:             "stops at floor (parser directives)",
 			lines:            []string{"# syntax=docker/dockerfile:1", "# escape=\\", "# comment", "FROM alpine"},
 			instructionLine0: 3,
-			want:             2,
+			floorLine0:       3, // FROM is the first instruction
+			want:             3,
 		},
 		{
 			name:             "stops at bare hash",
@@ -295,6 +298,7 @@ func TestFindCommentBlockStart(t *testing.T) {
 			name:             "parser directives contiguous with instruction",
 			lines:            []string{"# syntax=docker/dockerfile:1", "FROM alpine"},
 			instructionLine0: 1,
+			floorLine0:       1,
 			want:             1,
 		},
 	}
@@ -302,45 +306,7 @@ func TestFindCommentBlockStart(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, findCommentBlockStart(tt.instructionLine0, tt.lines))
-		})
-	}
-}
-
-func TestFindInsertionAfterParserDirectives(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		lines []string
-		want  int
-	}{
-		{
-			name:  "no parser directives",
-			lines: []string{"FROM alpine", "RUN make"},
-			want:  0,
-		},
-		{
-			name:  "syntax directive",
-			lines: []string{"# syntax=docker/dockerfile:1", "FROM alpine"},
-			want:  1,
-		},
-		{
-			name:  "syntax + escape",
-			lines: []string{"# syntax=docker/dockerfile:1", "# escape=\\", "FROM alpine"},
-			want:  2,
-		},
-		{
-			name:  "check directive",
-			lines: []string{"# check=skip=DL3006", "FROM alpine"},
-			want:  1,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, findInsertionAfterParserDirectives(tt.lines))
+			assert.Equal(t, tt.want, findCommentBlockStart(tt.instructionLine0, tt.floorLine0, tt.lines))
 		})
 	}
 }

--- a/internal/lspserver/suppress_test.go
+++ b/internal/lspserver/suppress_test.go
@@ -279,6 +279,24 @@ func TestFindCommentBlockStart(t *testing.T) {
 			instructionLine0: 0,
 			want:             0,
 		},
+		{
+			name:             "stops at parser directive",
+			lines:            []string{"# syntax=docker/dockerfile:1", "# escape=\\", "# comment", "FROM alpine"},
+			instructionLine0: 3,
+			want:             2,
+		},
+		{
+			name:             "stops at bare hash",
+			lines:            []string{"FROM alpine", "#", "# description comment", "RUN make"},
+			instructionLine0: 3,
+			want:             2,
+		},
+		{
+			name:             "parser directives contiguous with instruction",
+			lines:            []string{"# syntax=docker/dockerfile:1", "FROM alpine"},
+			instructionLine0: 1,
+			want:             1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/lspserver/suppress_test.go
+++ b/internal/lspserver/suppress_test.go
@@ -1,0 +1,344 @@
+package lspserver
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wharflab/tally/internal/directive"
+	"github.com/wharflab/tally/internal/dockerfile"
+	protocol "github.com/wharflab/tally/internal/lsp/protocol"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+func TestSuppressLineEdit_BasicInsertion(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\nRUN apt-get update\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 2, 0, 2, 17),
+		"hadolint/DL3027",
+		"msg",
+		rules.SeverityWarning,
+	)
+
+	edit := suppressLineEdit(v, lines, dirResult, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, "# tally ignore=hadolint/DL3027\n", edit.NewText)
+	assert.Equal(t, uint32(1), edit.Range.Start.Line, "should insert before the RUN line (0-based line 1)")
+}
+
+func TestSuppressLineEdit_WithRequireReason(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\nRUN apt-get update\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 2, 0, 2, 17),
+		"tally/test-rule",
+		"msg",
+		rules.SeverityWarning,
+	)
+
+	edit := suppressLineEdit(v, lines, dirResult, true)
+	require.NotNil(t, edit)
+	assert.Equal(t, "# tally ignore=tally/test-rule;reason=TODO\n", edit.NewText)
+}
+
+func TestSuppressLineEdit_AboveCommentBlock(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\n# builder builds the app\nRUN make build\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 3, 0, 3, 14),
+		"tally/test-rule",
+		"msg",
+		rules.SeverityWarning,
+	)
+
+	edit := suppressLineEdit(v, lines, dirResult, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, "# tally ignore=tally/test-rule\n", edit.NewText)
+	assert.Equal(t, uint32(1), edit.Range.Start.Line,
+		"should insert above the comment block, not between comment and instruction")
+}
+
+func TestSuppressLineEdit_MergesWithExisting(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\n# tally ignore=DL3008\nRUN apt-get update\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 3, 0, 3, 17),
+		"DL3027",
+		"msg",
+		rules.SeverityWarning,
+	)
+
+	edit := suppressLineEdit(v, lines, dirResult, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, ",DL3027", edit.NewText, "should append rule to existing directive")
+	assert.Equal(t, uint32(1), edit.Range.Start.Line, "should edit the existing directive line")
+}
+
+func TestSuppressLineEdit_AlreadySuppressed(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\n# tally ignore=DL3027\nRUN apt-get update\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 3, 0, 3, 17),
+		"DL3027",
+		"msg",
+		rules.SeverityWarning,
+	)
+
+	edit := suppressLineEdit(v, lines, dirResult, false)
+	assert.Nil(t, edit, "should return nil when rule is already suppressed")
+}
+
+func TestSuppressLineEdit_Indentation(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\n\tRUN apt-get update\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 2, 1, 2, 18),
+		"tally/test-rule",
+		"msg",
+		rules.SeverityWarning,
+	)
+
+	edit := suppressLineEdit(v, lines, dirResult, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, "\t# tally ignore=tally/test-rule\n", edit.NewText,
+		"should match leading whitespace of the instruction")
+}
+
+func TestSuppressFileEdit_BasicInsertion(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\nRUN apt-get update\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	edit := suppressFileEdit("tally/max-lines", lines, dirResult, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, "# tally global ignore=tally/max-lines\n", edit.NewText)
+	assert.Equal(t, uint32(0), edit.Range.Start.Line, "should insert at the top of the file")
+}
+
+func TestSuppressFileEdit_AfterSyntaxDirective(t *testing.T) {
+	t.Parallel()
+
+	content := "# syntax=docker/dockerfile:1\nFROM alpine\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	edit := suppressFileEdit("tally/max-lines", lines, dirResult, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, "# tally global ignore=tally/max-lines\n", edit.NewText)
+	assert.Equal(t, uint32(1), edit.Range.Start.Line,
+		"should insert after the # syntax= parser directive")
+}
+
+func TestSuppressFileEdit_MergesWithExistingGlobal(t *testing.T) {
+	t.Parallel()
+
+	content := "# tally global ignore=DL3008\nFROM alpine\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	edit := suppressFileEdit("DL3027", lines, dirResult, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, ",DL3027", edit.NewText, "should append to existing global directive")
+	assert.Equal(t, uint32(0), edit.Range.Start.Line)
+}
+
+func TestSuppressFileEdit_AlreadySuppressed(t *testing.T) {
+	t.Parallel()
+
+	content := "# tally global ignore=DL3027\nFROM alpine\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	edit := suppressFileEdit("DL3027", lines, dirResult, false)
+	assert.Nil(t, edit, "should return nil when rule is already globally suppressed")
+}
+
+func TestSuppressFileEdit_WithRequireReason(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\n"
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New([]byte(content))
+	dirResult := directive.Parse(sm, nil, nil)
+
+	edit := suppressFileEdit("tally/max-lines", lines, dirResult, true)
+	require.NotNil(t, edit)
+	assert.Equal(t, "# tally global ignore=tally/max-lines;reason=TODO\n", edit.NewText)
+}
+
+func TestSuppressRuleActions_EmitsLineAndFileActions(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\nRUN apt-get update\n"
+	source := []byte(content)
+
+	// Parse just like the real code does.
+	parseResult := parseDockerfile(t, source)
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 2, 0, 2, 17),
+		"hadolint/DL3027",
+		"msg",
+		rules.SeverityWarning,
+	)
+	v.DocURL = "https://example.com"
+
+	params := makeCodeActionParams("file:///test/Dockerfile", fullRange(), &protocol.CodeActionContext{})
+	actions := suppressRuleActions([]rules.Violation{v}, params, content, parseResult, nil)
+
+	require.Len(t, actions, 2)
+	assert.Contains(t, actions[0].Title, "Suppress hadolint/DL3027 for this line")
+	assert.Contains(t, actions[1].Title, "Suppress hadolint/DL3027 for this file")
+
+	// Verify stable Data field.
+	for _, a := range actions {
+		require.NotNil(t, a.Data)
+		data, ok := (*a.Data).(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "hadolint/DL3027", data["ruleCode"])
+	}
+}
+
+func TestFindCommentBlockStart(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		lines            []string
+		instructionLine0 int
+		want             int
+	}{
+		{
+			name:             "no comment above",
+			lines:            []string{"FROM alpine", "RUN make"},
+			instructionLine0: 1,
+			want:             1,
+		},
+		{
+			name:             "single comment",
+			lines:            []string{"FROM alpine", "# comment", "RUN make"},
+			instructionLine0: 2,
+			want:             1,
+		},
+		{
+			name:             "multi-line comment block",
+			lines:            []string{"FROM alpine", "# comment1", "# comment2", "RUN make"},
+			instructionLine0: 3,
+			want:             1,
+		},
+		{
+			name:             "blank line separates",
+			lines:            []string{"FROM alpine", "", "# comment", "RUN make"},
+			instructionLine0: 3,
+			want:             2,
+		},
+		{
+			name:             "first line of file",
+			lines:            []string{"FROM alpine"},
+			instructionLine0: 0,
+			want:             0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, findCommentBlockStart(tt.instructionLine0, tt.lines))
+		})
+	}
+}
+
+func TestFindInsertionAfterParserDirectives(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		lines []string
+		want  int
+	}{
+		{
+			name:  "no parser directives",
+			lines: []string{"FROM alpine", "RUN make"},
+			want:  0,
+		},
+		{
+			name:  "syntax directive",
+			lines: []string{"# syntax=docker/dockerfile:1", "FROM alpine"},
+			want:  1,
+		},
+		{
+			name:  "syntax + escape",
+			lines: []string{"# syntax=docker/dockerfile:1", "# escape=\\", "FROM alpine"},
+			want:  2,
+		},
+		{
+			name:  "check directive",
+			lines: []string{"# check=skip=DL3006", "FROM alpine"},
+			want:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, findInsertionAfterParserDirectives(tt.lines))
+		})
+	}
+}
+
+func TestLeadingWhitespace(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, leadingWhitespace("RUN make"))
+	assert.Equal(t, "  ", leadingWhitespace("  RUN make"))
+	assert.Equal(t, "\t", leadingWhitespace("\tRUN make"))
+	assert.Equal(t, "\t  ", leadingWhitespace("\t  RUN make"))
+}
+
+// parseDockerfile parses a Dockerfile from source bytes for testing.
+func parseDockerfile(t *testing.T, source []byte) *dockerfile.ParseResult {
+	t.Helper()
+	result, err := dockerfile.Parse(bytes.NewReader(source), nil)
+	require.NoError(t, err)
+	return result
+}

--- a/internal/lspserver/suppress_test.go
+++ b/internal/lspserver/suppress_test.go
@@ -78,6 +78,35 @@ func TestSuppressLineEdit_AboveCommentBlock(t *testing.T) {
 		"should insert above the comment block, not between comment and instruction")
 }
 
+func TestSuppressLineEdit_DescriptionAboveFirstInstruction(t *testing.T) {
+	t.Parallel()
+
+	// # syntax= on line 0, description comment on line 1, FROM on line 2.
+	// The directive must go above the description (line 1), not between
+	// description and FROM (which would trigger InvalidDefinitionDescription).
+	content := "# syntax=docker/dockerfile:1\n# builder is the build stage\nFROM alpine AS builder\n"
+	source := []byte(content)
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New(source)
+
+	parseResult := parseDockerfile(t, source)
+	spanIndex := directive.NewInstructionSpanIndexFromAST(parseResult.AST, sm)
+	dirResult := directive.Parse(sm, nil, spanIndex)
+
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 3, 0, 3, 22),
+		"tally/test-rule",
+		"msg",
+		rules.SeverityWarning,
+	)
+
+	edit := suppressLineEdit(v, lines, dirResult, spanIndex, 1, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, "# tally ignore=tally/test-rule\n", edit.NewText)
+	assert.Equal(t, uint32(1), edit.Range.Start.Line,
+		"should insert above the description comment (line 1), not between it and FROM (line 2)")
+}
+
 func TestSuppressLineEdit_MergesWithExisting(t *testing.T) {
 	t.Parallel()
 
@@ -345,11 +374,11 @@ func TestFindCommentBlockStart(t *testing.T) {
 			want:             0,
 		},
 		{
-			name:             "stops at floor (parser directives)",
+			name:             "walks through comments above first instruction",
 			lines:            []string{"# syntax=docker/dockerfile:1", "# escape=\\", "# comment", "FROM alpine"},
 			instructionLine0: 3,
-			floorLine0:       3, // FROM is the first instruction
-			want:             3,
+			floorLine0:       2, // floor is after parser directives (line 0-1), not at FROM
+			want:             2, // walks back through "# comment" but stops at the floor
 		},
 		{
 			name:             "stops at bare hash",
@@ -361,7 +390,7 @@ func TestFindCommentBlockStart(t *testing.T) {
 			name:             "parser directives contiguous with instruction",
 			lines:            []string{"# syntax=docker/dockerfile:1", "FROM alpine"},
 			instructionLine0: 1,
-			floorLine0:       1,
+			floorLine0:       1, // floor is after parser directive (line 0)
 			want:             1,
 		},
 	}

--- a/internal/lspserver/suppress_test.go
+++ b/internal/lspserver/suppress_test.go
@@ -290,6 +290,15 @@ func TestSuppressRuleActions_EmitsLineAndFileActions(t *testing.T) {
 	assert.Contains(t, actions[0].Title, "Suppress hadolint/DL3027 for this line")
 	assert.Contains(t, actions[1].Title, "Suppress hadolint/DL3027 for this file")
 
+	// Verify Edit.Changes is populated with actual text edits.
+	for i, a := range actions {
+		require.NotNil(t, a.Edit, "action %d should have an Edit", i)
+		require.NotNil(t, a.Edit.Changes, "action %d Edit.Changes should not be nil", i)
+		edits := (*a.Edit.Changes)["file:///test/Dockerfile"]
+		require.NotEmpty(t, edits, "action %d should have edits for the document URI", i)
+		assert.NotEmpty(t, edits[0].NewText, "action %d edit should have non-empty NewText", i)
+	}
+
 	// Verify stable Data field.
 	for _, a := range actions {
 		require.NotNil(t, a.Data)

--- a/internal/lspserver/suppress_test.go
+++ b/internal/lspserver/suppress_test.go
@@ -30,7 +30,7 @@ func TestSuppressLineEdit_BasicInsertion(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, 0, false)
+	edit := suppressLineEdit(v, lines, dirResult, nil, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally ignore=hadolint/DL3027\n", edit.NewText)
 	assert.Equal(t, uint32(1), edit.Range.Start.Line, "should insert before the RUN line (0-based line 1)")
@@ -51,7 +51,7 @@ func TestSuppressLineEdit_WithRequireReason(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, 0, true)
+	edit := suppressLineEdit(v, lines, dirResult, nil, 0, true)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally ignore=tally/test-rule;reason=TODO\n", edit.NewText)
 }
@@ -71,7 +71,7 @@ func TestSuppressLineEdit_AboveCommentBlock(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, 0, false)
+	edit := suppressLineEdit(v, lines, dirResult, nil, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, "# tally ignore=tally/test-rule\n", edit.NewText)
 	assert.Equal(t, uint32(1), edit.Range.Start.Line,
@@ -93,7 +93,7 @@ func TestSuppressLineEdit_MergesWithExisting(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, 0, false)
+	edit := suppressLineEdit(v, lines, dirResult, nil, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, ",DL3027", edit.NewText, "should append rule to existing directive")
 	assert.Equal(t, uint32(1), edit.Range.Start.Line, "should edit the existing directive line")
@@ -114,7 +114,7 @@ func TestSuppressLineEdit_AlreadySuppressed(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, 0, false)
+	edit := suppressLineEdit(v, lines, dirResult, nil, 0, false)
 	assert.Nil(t, edit, "should return nil when rule is already suppressed")
 }
 
@@ -133,10 +133,39 @@ func TestSuppressLineEdit_Indentation(t *testing.T) {
 		rules.SeverityWarning,
 	)
 
-	edit := suppressLineEdit(v, lines, dirResult, 0, false)
+	edit := suppressLineEdit(v, lines, dirResult, nil, 0, false)
 	require.NotNil(t, edit)
 	assert.Equal(t, "\t# tally ignore=tally/test-rule\n", edit.NewText,
 		"should match leading whitespace of the instruction")
+}
+
+func TestSuppressLineEdit_HeredocViolation(t *testing.T) {
+	t.Parallel()
+
+	// A ShellCheck violation inside a heredoc body (line 4, 1-based) must produce
+	// a directive above the RUN instruction (line 2), not inside the heredoc.
+	content := "FROM alpine\nRUN <<EOF\necho hello\necho $unquoted\nEOF\n"
+	source := []byte(content)
+	lines := strings.Split(content, "\n")
+	sm := sourcemap.New(source)
+
+	parseResult := parseDockerfile(t, source)
+	spanIndex := directive.NewInstructionSpanIndexFromAST(parseResult.AST, sm)
+	dirResult := directive.Parse(sm, nil, spanIndex)
+
+	// Violation on line 4 (1-based) — inside the heredoc body.
+	v := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 4, 5, 4, 14),
+		"shellcheck/SC2086",
+		"Double quote to prevent globbing and word splitting.",
+		rules.SeverityWarning,
+	)
+
+	edit := suppressLineEdit(v, lines, dirResult, spanIndex, 0, false)
+	require.NotNil(t, edit)
+	assert.Equal(t, "# tally ignore=shellcheck/SC2086\n", edit.NewText)
+	assert.Equal(t, uint32(1), edit.Range.Start.Line,
+		"should insert above the RUN instruction (0-based line 1), not inside the heredoc")
 }
 
 func TestSuppressFileEdit_BasicInsertion(t *testing.T) {

--- a/internal/lspserver/suppress_test.go
+++ b/internal/lspserver/suppress_test.go
@@ -241,6 +241,40 @@ func TestSuppressRuleActions_EmitsLineAndFileActions(t *testing.T) {
 	}
 }
 
+func TestSuppressRuleActions_DedupFileAction(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine\nRUN echo a\nRUN echo b\n"
+	source := []byte(content)
+	parseResult := parseDockerfile(t, source)
+
+	// Same rule on two different lines.
+	v1 := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 2, 0, 2, 10),
+		"tally/test-rule", "msg", rules.SeverityWarning,
+	)
+	v2 := rules.NewViolation(
+		rules.NewRangeLocation("Dockerfile", 3, 0, 3, 10),
+		"tally/test-rule", "msg", rules.SeverityWarning,
+	)
+
+	params := makeCodeActionParams("file:///test/Dockerfile", fullRange(), &protocol.CodeActionContext{})
+	actions := suppressRuleActions([]rules.Violation{v1, v2}, params, content, parseResult, nil)
+
+	// Should get 2 per-line actions + 1 file action = 3 total (not 4).
+	var lineActions, fileActions int
+	for _, a := range actions {
+		if strings.Contains(a.Title, "for this line") {
+			lineActions++
+		}
+		if strings.Contains(a.Title, "for this file") {
+			fileActions++
+		}
+	}
+	assert.Equal(t, 2, lineActions, "should have one line action per violation")
+	assert.Equal(t, 1, fileActions, "should deduplicate file action by ruleCode")
+}
+
 func TestFindCommentBlockStart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/lsptest/__snapshots__/TestLSP_CodeAction_1.snap.json
+++ b/internal/lsptest/__snapshots__/TestLSP_CodeAction_1.snap.json
@@ -67,5 +67,97 @@
   "isPreferred": true,
   "kind": "quickfix",
   "title": "Fix blank lines between instructions"
+ },
+ {
+  "edit": {
+   "changes": {
+    "file:///tmp/test-codeaction/Dockerfile": [
+     {
+      "newText": "# tally ignore=buildkit/MaintainerDeprecated\n",
+      "range": {
+       "end": {
+        "character": 0,
+        "line": 1
+       },
+       "start": {
+        "character": 0,
+        "line": 1
+       }
+      }
+     }
+    ]
+   }
+  },
+  "kind": "quickfix.suppress.tally",
+  "title": "Suppress buildkit/MaintainerDeprecated for this line"
+ },
+ {
+  "edit": {
+   "changes": {
+    "file:///tmp/test-codeaction/Dockerfile": [
+     {
+      "newText": "# tally global ignore=buildkit/MaintainerDeprecated\n",
+      "range": {
+       "end": {
+        "character": 0,
+        "line": 0
+       },
+       "start": {
+        "character": 0,
+        "line": 0
+       }
+      }
+     }
+    ]
+   }
+  },
+  "kind": "quickfix.suppress.tally",
+  "title": "Suppress buildkit/MaintainerDeprecated for this file"
+ },
+ {
+  "edit": {
+   "changes": {
+    "file:///tmp/test-codeaction/Dockerfile": [
+     {
+      "newText": "# tally ignore=tally/newline-between-instructions\n",
+      "range": {
+       "end": {
+        "character": 0,
+        "line": 1
+       },
+       "start": {
+        "character": 0,
+        "line": 1
+       }
+      }
+     }
+    ]
+   }
+  },
+  "kind": "quickfix.suppress.tally",
+  "title": "Suppress tally/newline-between-instructions for this line"
+ },
+ {
+  "edit": {
+   "changes": {
+    "file:///tmp/test-codeaction/Dockerfile": [
+     {
+      "newText": "# tally global ignore=tally/newline-between-instructions\n",
+      "range": {
+       "end": {
+        "character": 0,
+        "line": 0
+       },
+       "start": {
+        "character": 0,
+        "line": 0
+       }
+      }
+     }
+    ]
+   }
+  },
+  "kind": "quickfix.suppress.tally",
+  "title": "Suppress tally/newline-between-instructions for this file"
  }
 ]

--- a/internal/lsptest/__snapshots__/TestLSP_CodeAction_1.snap.json
+++ b/internal/lsptest/__snapshots__/TestLSP_CodeAction_1.snap.json
@@ -69,6 +69,10 @@
   "title": "Fix blank lines between instructions"
  },
  {
+  "data": {
+   "ruleCode": "buildkit/MaintainerDeprecated",
+   "type": "suppress-line"
+  },
   "edit": {
    "changes": {
     "file:///tmp/test-codeaction/Dockerfile": [
@@ -92,6 +96,10 @@
   "title": "Suppress buildkit/MaintainerDeprecated for this line"
  },
  {
+  "data": {
+   "ruleCode": "buildkit/MaintainerDeprecated",
+   "type": "suppress-file"
+  },
   "edit": {
    "changes": {
     "file:///tmp/test-codeaction/Dockerfile": [
@@ -115,6 +123,10 @@
   "title": "Suppress buildkit/MaintainerDeprecated for this file"
  },
  {
+  "data": {
+   "ruleCode": "tally/newline-between-instructions",
+   "type": "suppress-line"
+  },
   "edit": {
    "changes": {
     "file:///tmp/test-codeaction/Dockerfile": [
@@ -138,6 +150,10 @@
   "title": "Suppress tally/newline-between-instructions for this line"
  },
  {
+  "data": {
+   "ruleCode": "tally/newline-between-instructions",
+   "type": "suppress-file"
+  },
   "edit": {
    "changes": {
     "file:///tmp/test-codeaction/Dockerfile": [

--- a/internal/lsptest/__snapshots__/TestLSP_ExecuteCommandApplyAllFixesRealWorld_1.snap.Dockerfile
+++ b/internal/lsptest/__snapshots__/TestLSP_ExecuteCommandApplyAllFixesRealWorld_1.snap.Dockerfile
@@ -1,0 +1,406 @@
+ARG BUILDER_IMAGE=ubuntu:22.04
+ARG RUNTIME_IMAGE=ubuntu:22.04
+
+FROM $BUILDER_IMAGE AS python_builder_1
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates curl wget \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+ARG MAMBA_VERSION
+
+RUN curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/download/${MAMBA_VERSION}/Mambaforge-${MAMBA_VERSION}-Linux-x86_64.sh \
+	&& chmod +x ~/mambaforge.sh \
+	&& ~/mambaforge.sh -b -p /opt/conda \
+	&& rm ~/mambaforge.sh
+
+ARG PYTHON_VERSION
+
+RUN /opt/conda/bin/conda config --set auto_activate_base false \
+	&& /opt/conda/bin/conda create --name default python=${PYTHON_VERSION} \
+&& echo "#! /bin/bash\n\n# script to activate the conda environment" > ~/.bashrc \
+&& echo "export PS1='Docker> '" >> ~/.bashrc \
+&& /opt/conda/bin/conda init bash \
+&& echo "\nconda activate default" >> ~/.bashrc \
+&& /opt/conda/bin/conda clean -a
+
+ENV BASH_ENV=~/.bashrc
+ENV PATH="${PATH}:/opt/conda/envs/default/bin"
+
+RUN ln -s /opt/conda/envs/default/bin/pip /usr/local/bin/pip \
+	&& ln -s /opt/conda/envs/default/bin/python /usr/local/bin/python \
+	&& /opt/conda/bin/conda config --set ssl_verify False \
+	&& pip install --no-cache-dir --upgrade pip --no-cache-dir --trusted-host pypi.org --trusted-host files.pythonhosted.org
+RUN pip install --no-cache-dir pyOpenSSL --upgrade
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+#ARG PYTHON_VERSION
+#RUN /opt/conda/bin/conda remove -y python=3.10 && /opt/conda/bin/conda install -y python=$PYTHON_VERSION && /opt/conda/bin/conda clean -ya
+
+RUN apt-get update \
+	&& apt-get install -y libopenmpi-dev \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+RUN pip install --no-cache-dir -U "cython<3.0.0" wheel \
+    && pip install pyyaml==5.4.1 --no-build-isolation \
+    && pip install --no-cache-dir -U "awscli>1.27,<2" boto3 "click==8.1.2,<9" "cmake>=3.24.3,<3.25" "cryptography>41" ipython "mpi4py>=3.1.4,<3.2" "opencv-python>=4.6.0,<4.7" packaging Pillow "psutil>=5.9.4,<5.10" "pyyaml>=5.4,<5.5"
+
+ARG TRITON_VERSION
+
+RUN pip install --no-cache-dir -U "sagemaker>=2,<3" sagemaker-experiments==0.* sagemaker-pytorch-training smclarify triton==${TRITON_VERSION}
+RUN pip install --no-cache-dir -U "bokeh>=3.0.1,<4" "imageio>=2.22,<3" "numba>=0.56.4,<0.57" "opencv-python>=4.6,<5" "plotly>=5.11,<6" "seaborn>=0.12,<1" "shap>=0.41,<1"
+RUN apt-get update \
+	&& apt-get install -y build-essential \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+
+ARG DATASETS_VERSION
+ARG DIFFUSERS_VERSION
+ARG TRANSFORMERS_VERSION
+
+RUN pip install --no-cache-dir dill==0.3.6 evaluate gevent~=23.9.0 kenlm==0.1 multiprocess==0.70.14 pyarrow~=14.0.1 sagemaker==2.132.0 \
+                               transformers[sklearn,sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
+                               datasets==${DATASETS_VERSION} \
+                               diffusers==${DIFFUSERS_VERSION} \
+                               $PT_TORCHAUDIO_URL
+RUN pip install --no-cache-dir setuptools==69.5.1
+
+COPY requirements1.txt .
+
+RUN pip install --no-cache-dir -r requirements1.txt
+
+ARG SMD_MODEL_PARALLEL_URL
+
+RUN pip install --no-cache-dir -U ${SMD_MODEL_PARALLEL_URL}
+
+ARG SMD_DATA_PARALLEL_URL
+
+RUN pip install --no-cache-dir ${SMD_DATA_PARALLEL_URL}
+
+FROM $RUNTIME_IMAGE AS runtime
+
+ARG TARGETARCH
+ARG EFA_PATH=/opt/amazon/efa
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
+
+ARG PYTHON_SHORT_VERSION
+ARG PYTHON_VERSION
+ARG PYTHON
+ARG PYTHON
+ARG HOME_DIR
+
+ENV NVIDIA_REQUIRE_CUDA=cuda>=11.7 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471 brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=titan,driver>=470,driver<471 brand=titanrtx,driver>=470,driver<471 brand=tesla,driver>=510,driver<511 brand=unknown,driver>=510,driver<511 brand=nvidia,driver>=510,driver<511 brand=nvidiartx,driver>=510,driver<511 brand=geforce,driver>=510,driver<511 brand=geforcertx,driver>=510,driver<511 brand=quadro,driver>=510,driver<511 brand=quadrortx,driver>=510,driver<511 brand=titan,driver>=510,driver<511 brand=titanrtx,driver>=510,driver<511
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV LD_LIBRARY_PATH=/opt/conda/lib:/usr/local/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV PATH="${PATH}:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV TORCH_CUDA_ARCH_LIST="3.7 5.0 7.0+PTX 8.0"
+ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
+ENV CUDNN_VERSION=8.5.0.96
+ENV NCCL_VERSION=2.14.3
+ENV HOROVOD_VERSION=0.26.1
+ENV EFA_VERSION=1.19.0
+ENV OMPI_VERSION=4.1.1
+ENV BRANCH_OFI=1.4.0-aws
+ENV GDRCOPY_VERSION=2.3.1
+ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
+ENV OPEN_MPI_PATH=/opt/amazon/openmpi
+ENV DGLBACKEND=pytorch
+ENV MANUAL_BUILD=0
+ENV RDMAV_FORK_SAFE=1
+ENV DLC_CONTAINER_TYPE=training
+
+LABEL org.opencontainers.image.ref.name=ubuntu
+LABEL org.opencontainers.image.version=22.04
+
+#CMD ["/bin/bash"]
+
+RUN apt-get update \
+    && apt-get install -y build-essential libbz2-dev libffi-dev libgdbm-dev liblzma-dev libncurses5-dev libnss3-dev libreadline-dev libsqlite3-dev libssl-dev wget zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+#RUN cd /tmp \
+#    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
+#    && tar -xvf Python-${PYTHON_VERSION}.tgz \
+#    && cd Python-${PYTHON_VERSION} \
+#    && ./configure --enable-optimizations \
+#    && make -j8 && make install && cd .. && rm Python-${PYTHON_VERSION}.tgz && rm -r Python-${PYTHON_VERSION} && ln -s /usr/local/bin/python3 /usr/local/bin/python && ln -s /usr/local/bin/pip3 /usr/local/bin/pip && python -m pip install --upgrade pip && rm -r /root/.cache/pip
+
+WORKDIR /app
+
+ENV NVARCH=x86_64
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates curl gnupg2 \
+	&& curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/${NVARCH}/3bf863cc.pub | apt-key add - \
+	&& echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/${NVARCH} /" > /etc/apt/sources.list.d/cuda.list \
+	&& apt-get purge --autoremove -y curl \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV NV_CUDA_COMPAT_PACKAGE=cuda-compat-11-7
+ENV NV_CUDA_CUDART_VERSION=11.7.99-1
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends cuda-cudart-11-7=${NV_CUDA_CUDART_VERSION} ${NV_CUDA_COMPAT_PACKAGE} \
+	&& rm -rf /var/lib/apt/lists/*
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf \
+	&& echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV DEBIAN_FRONTEND=noninteractive LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/lib
+
+RUN apt-get update \
+	&& apt-get upgrade -y \
+	&& apt-get autoremove -y \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+ARG CUBLAS_VERSION=11.10.3.66
+
+RUN apt-get update \
+	&& apt-get -y upgrade --only-upgrade systemd \
+	&& apt-get install -y --allow-change-held-packages --no-install-recommends build-essential ca-certificates check cmake cuda-command-line-tools-11-7 cuda-cudart-11-7 cuda-libraries-11-7 curl emacs git hwloc jq libcufft-dev-11-7 libcurand-dev-11-7 libcurl4-openssl-dev libcusolver-dev-11-7 libcusparse-dev-11-7 libgl1-mesa-glx libglib2.0-0 libgomp1 libhwloc-dev libibverbs-dev libnuma-dev libnuma1 libsm6 libssl-dev libssl3 libsubunit-dev libsubunit0 libtool libxext6 libxrender-dev openssl pkg-config python3-dev unzip vim wget zlib1g-dev libcublas-11-7=${CUBLAS_VERSION}-1 libcublas-dev-11-7=${CUBLAS_VERSION}-1 libcudnn8=$CUDNN_VERSION-1+cuda11.7 \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+RUN cd /tmp && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 && cd nccl && make -j $(nproc) src.build BUILDDIR=/usr/local && rm -rf /tmp/nccl
+RUN mkdir /tmp/efa \
+	&& cd /tmp/efa \
+	&& curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_VERSION}.tar.gz \
+	&& tar -xf aws-efa-installer-${EFA_VERSION}.tar.gz \
+	&& cd aws-efa-installer \
+	&& apt-get update \
+	&& ./efa_installer.sh -y --skip-kmod -g \
+	&& rm -rf $OPEN_MPI_PATH \
+	&& rm -rf /tmp/efa \
+	&& rm -rf /tmp/aws-efa-installer-${EFA_VERSION}.tar.gz \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+RUN mkdir /tmp/openmpi \
+	&& cd /tmp/openmpi \
+	&& wget --quiet https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OMPI_VERSION}.tar.gz \
+	&& tar zxf openmpi-${OMPI_VERSION}.tar.gz \
+	&& cd openmpi-${OMPI_VERSION} \
+	&& ./configure --enable-orterun-prefix-by-default --prefix=$OPEN_MPI_PATH --with-cuda \
+	&& make -j $(nproc) all \
+	&& make install \
+	&& ldconfig \
+	&& cd / \
+	&& rm -rf /tmp/openmpi
+
+ ENV PATH="${PATH}:/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/opt/conda/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}/opt/amazon/openmpi/lib/:/opt/amazon/efa/lib/"
+
+RUN cd /tmp && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} && cd gdrcopy && sed -ie '12s@$@ -L /usr/local/cuda/lib64/stubs/@' tests/Makefile && make install && rm -rf /tmp/gdrcopy
+
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+RUN apt-get update -q \
+	&& apt-get install -q -y --no-install-recommends bzip2 ca-certificates git libglib2.0-0 libsm6 libxext6 libxrender1 mercurial openssh-client procps subversion wget \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+#ARG CONDA_VERSION=py39_22.11.1-1
+#RUN set -x &&     UNAME_M="$(uname -m)" &&     if [ "${UNAME_M}" = "x86_64" ]; then         MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh";         SHA256SUM="e685005710679914a909bfb9c52183b3ccc56ad7bb84acc861d596fcbe5d28bb";     elif [ "${UNAME_M}" = "s390x" ]; then         MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-s390x.sh";         SHA256SUM="a150511e7fd19d07b770f278fb5dd2df4bc24a8f55f06d6274774f209a36c766";     elif [ "${UNAME_M}" = "aarch64" ]; then         MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-aarch64.sh";         SHA256SUM="48a96df9ff56f7421b6dd7f9f71d548023847ba918c3826059918c08326c2017";     elif [ "${UNAME_M}" = "ppc64le" ]; then         MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-ppc64le.sh";         SHA256SUM="4c86c3383bb27b44f7059336c3a46c34922df42824577b93eadecefbf7423836";     fi &&     wget "${MINICONDA_URL}" -O miniconda.sh -q &&     echo "${SHA256SUM} miniconda.sh" > shasum &&     if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi &&     mkdir -p /opt &&     bash miniconda.sh -b -p /opt/conda &&     rm miniconda.sh shasum &&     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh &&     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc &&     echo "conda activate base" >> ~/.bashrc &&     find /opt/conda/ -follow -type f -name '*.a' -delete &&     find /opt/conda/ -follow -type f -name '*.js.map' -delete &&     /opt/conda/bin/conda clean -afy
+
+ARG MAMBA_VERSION
+
+RUN curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/download/${MAMBA_VERSION}/Mambaforge-${MAMBA_VERSION}-Linux-x86_64.sh \
+	&& chmod +x ~/mambaforge.sh \
+	&& ~/mambaforge.sh -b -p /opt/conda \
+	&& rm ~/mambaforge.sh
+RUN /opt/conda/bin/conda install conda-libmamba-solver --solver classic \
+	&& /opt/conda/bin/conda config --set solver libmamba
+
+ARG PYTHON_VERSION
+
+RUN /opt/conda/bin/conda config --set auto_activate_base false \
+	&& /opt/conda/bin/conda create --name default python=${PYTHON_VERSION} \
+&& echo "#! /bin/bash\n\n# script to activate the conda environment" > ~/.bashrc \
+&& echo "export PS1='Docker> '" >> ~/.bashrc \
+&& /opt/conda/bin/conda init bash \
+&& echo "\nconda activate default" >> ~/.bashrc \
+&& /opt/conda/bin/conda clean -a
+
+ENV BASH_ENV=~/.bashrc
+ENV PATH="${PATH}:/opt/conda/envs/default/bin"
+
+#RUN conda config --set auto_activate_base false && conda create --name default python={PYHON_VERSION} && echo "source activate default" >> ~/.bashrc
+#RUN "source activate default"
+
+RUN ln -s /opt/conda/envs/default/bin/pip /usr/local/bin/pip \
+	&& ln -s /opt/conda/envs/default/bin/python /usr/local/bin/python \
+	&& /opt/conda/bin/conda config --set ssl_verify False \
+	&& pip install --no-cache-dir --upgrade pip --no-cache-dir --trusted-host pypi.org --trusted-host files.pythonhosted.org
+RUN pip install --no-cache-dir pyOpenSSL --upgrade
+RUN /opt/conda/bin/conda install -y -c conda-forge cython mkl mkl-include parso typing h5py requests pyopenssl libgcc conda-content-trust charset-normalizer accelerate \
+	&& /opt/conda/bin/conda install -c dglteam -y dgl-cuda11.7=0.9.1 \
+	&& /opt/conda/bin/conda install -c pytorch -y magma-cuda117 \
+    && /opt/conda/bin/conda install -c fastai fastai \
+	&& pip uninstall -y dataclasses \
+	&& /opt/conda/bin/conda clean -ya
+RUN rm -rf /root/micromamba/
+RUN rm -rf /opt/conda/lib/libtinfo.so
+
+COPY --from=python_builder_1 /opt/conda /opt/conda
+
+ARG PYTORCH_VERSION
+ARG PYTORCH_VERSION_SUFFIX
+ARG TORCHVISION_VERSION
+ARG TORCHVISION_VERSION_SUFFIX
+ARG TORCHAUDIO_VERSION
+ARG TORCHAUDIO_VERSION_SUFFIX
+ARG PYTORCH_DOWNLOAD_URL
+
+#RUN if [ ! $TORCHAUDIO_VERSION ];     then         TORCHAUDIO=;     else         TORCHAUDIO=torchaudio==${TORCHAUDIO_VERSION}${TORCHAUDIO_VERSION_SUFFIX};     fi &&     if [ ! $PYTORCH_DOWNLOAD_URL ];     then         pip install --no-cache-dir -U            torch==${PYTORCH_VERSION}${PYTORCH_VERSION_SUFFIX}             torchvision==${TORCHVISION_VERSION}${TORCHVISION_VERSION_SUFFIX}             ${TORCHAUDIO};     else         pip install --no-cache-dir -U             torch==${PYTORCH_VERSION}${PYTORCH_VERSION_SUFFIX}             torchvision==${TORCHVISION_VERSION}${TORCHVISION_VERSION_SUFFIX}             ${TORCHAUDIO}             -f ${PYTORCH_DOWNLOAD_URL};     fi &&     rm -r /root/.cache/pip
+
+RUN apt-get update \
+	&& apt-get install -y git libaio-dev libaio1 pdsh pigz \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+
+ARG FLASH_ATTN_VERSION
+
+RUN pip install --no-cache-dir --user flash-attn==${FLASH_ATTN_VERSION}
+
+ WORKDIR /root
+
+ COPY --chmod=+x deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-1.13/license.txt
+RUN rm -rf /root/.cache
+
+ARG PT_TORCHDATA_URL
+ARG PT_TORCHAUDIO_URL
+ARG PT_TORCHVISION_URL
+ARG PT_SM_TRAINING_URL
+
+RUN pip uninstall -y torch torchvision torchaudio torchdata \
+	&& pip install --no-cache-dir -U ${PT_SM_TRAINING_URL} ${PT_TORCHVISION_URL} ${PT_TORCHAUDIO_URL} ${PT_TORCHDATA_URL}
+
+ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/lib:/opt/amazon/openmpi/lib/:/opt/amazon/efa/lib/"
+
+RUN echo $PATH
+RUN echo $LD_LIBRARY_PATH
+RUN pip install -U --force-reinstall --no-cache-dir setuptools==70.1.0 wheel==0.43.0
+RUN pip install --force-reinstall --no-cache-dir setuptools==69.5.1
+RUN git clone https://github.com/NVIDIA/apex && cd apex && git checkout aa756ce && pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
+RUN mv $OPEN_MPI_PATH/bin/mpirun $OPEN_MPI_PATH/bin/mpirun.real \
+	&& echo '#!/bin/bash' > $OPEN_MPI_PATH/bin/mpirun \
+	&& echo "${OPEN_MPI_PATH}/bin/mpirun.real --allow-run-as-root \"\$@\"" >> $OPEN_MPI_PATH/bin/mpirun \
+	&& chmod a+x $OPEN_MPI_PATH/bin/mpirun \
+	&& echo "hwloc_base_binding_policy = none" >> $OPEN_MPI_PATH/etc/openmpi-mca-params.conf \
+	&& echo "rmaps_base_mapping_policy = slot" >> $OPEN_MPI_PATH/etc/openmpi-mca-params.conf \
+	&& echo NCCL_DEBUG=INFO >> /etc/nccl.conf \
+	&& echo NCCL_SOCKET_IFNAME=^docker0 >> /etc/nccl.conf
+RUN mkdir /tmp/efa-ofi-nccl && cd /tmp/efa-ofi-nccl && git clone https://github.com/aws/aws-ofi-nccl.git -b v${BRANCH_OFI} && cd aws-ofi-nccl && ./autogen.sh && ./configure --with-libfabric=/opt/amazon/efa --with-mpi=/opt/amazon/openmpi --with-cuda=/usr/local/cuda --with-nccl=/usr/local --prefix=/usr/local && make && make install && rm -rf /tmp/efa-ofi-nccl && rm -rf /var/lib/apt/lists/* && apt-get clean
+RUN apt-get update \
+	&& apt-get install -y --allow-downgrades --allow-change-held-packages --no-install-recommends \
+	&& apt-get install -y --no-install-recommends openssh-client openssh-server \
+	&& mkdir -p /var/run/sshd \
+	&& cat /etc/ssh/ssh_config | grep -v StrictHostKeyChecking > /etc/ssh/ssh_config.new \
+	&& echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config.new \
+	&& mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+RUN mkdir -p /var/run/sshd \
+	&& sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+RUN rm -rf /root/.ssh/ \
+	&& mkdir -p /root/.ssh/ \
+	&& ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa \
+	&& cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
+	&& printf "Host *\n StrictHostKeyChecking no\n" >> /root/.ssh/config
+
+ARG CUDA_HOME=/usr/local/cuda
+
+RUN pip uninstall -y horovod \
+	&& ldconfig /usr/local/cuda-11.7/targets/x86_64-linux/lib/stubs \
+	&& HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_CUDA_HOME=/usr/local/cuda-11.7 HOROVOD_WITH_PYTORCH=1 pip install --no-cache-dir horovod==${HOROVOD_VERSION} \
+	&& ldconfig
+RUN mkdir -p /etc/pki/tls/certs \
+	&& cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
+RUN conda install -y -c conda-forge scikit-learn pandas
+
+WORKDIR /
+
+RUN wget --progress=dot:giga https://sourceforge.net/projects/boost/files/boost/1.73.0/boost_1_73_0.tar.gz/download -O boost_1_73_0.tar.gz \
+	&& tar -xzf boost_1_73_0.tar.gz \
+	&& cd boost_1_73_0 \
+	&& ./bootstrap.sh \
+	&& ./b2 threading=multi --prefix=/opt/conda -j 64 cxxflags=-fPIC cflags=-fPIC install \
+	|| true \
+	&& cd .. \
+	&& rm -rf boost_1_73_0.tar.gz \
+	&& rm -rf boost_1_73_0 \
+	&& cd /opt/conda/include/boost
+
+WORKDIR /opt/
+
+COPY --chmod=+x start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
+
+WORKDIR /root
+
+ARG SMDEBUG_VERSION=1.0.34
+
+RUN cd /tmp && git clone https://github.com/awslabs/sagemaker-debugger --branch ${SMDEBUG_VERSION} --depth 1 --single-branch && cd sagemaker-debugger && pip install . && rm -rf /tmp/*
+RUN rm /etc/apt/sources.list.d/* && git clone https://github.com/KarypisLab/GKlib && cd GKlib && make config && make && make install && cd .. && git clone https://github.com/KarypisLab/METIS.git && cd METIS && make config shared=1 cc=gcc prefix=/root/local && make install && cd .. && rm -rf METIS GKlib && rm -rf /var/lib/apt/lists/* && apt-get clean
+
+ARG RMM_VERSION=0.15.0
+
+RUN wget -nv https://github.com/rapidsai/rmm/archive/v${RMM_VERSION}.tar.gz \
+	&& tar -xvf v${RMM_VERSION}.tar.gz \
+	&& cd rmm-${RMM_VERSION} \
+	&& INSTALL_PREFIX=/usr/local ./build.sh librmm \
+	&& cd .. \
+	&& rm -rf v${RMM_VERSION}.tar* \
+	&& rm -rf rmm-${RMM_VERSION}
+
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/conda/lib/python3.9/site-packages/smdistributed/dataparallel/lib"
+
+RUN apt-get update \
+	&& apt-get install -y --allow-change-held-packages --no-install-recommends libunwind-dev \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& apt-get clean
+
+ARG SMPPY_BINARY
+
+RUN wget -nv https://smppy.s3.amazonaws.com/pytorch/cu117/${SMPPY_BINARY} \
+	&& pip install ${SMPPY_BINARY} \
+	&& rm ${SMPPY_BINARY}
+
+WORKDIR /
+
+RUN HOME_DIR=/root \
+	&& curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+	&& unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+	&& cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+	&& chmod +x /usr/local/bin/testOSSCompliance \
+	&& chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+	&& ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+	&& rm -rf ${HOME_DIR}/oss_compliance* \
+	&& rm -rf /tmp/tmp*
+RUN rm -rf /root/.cache | true
+RUN apt-get update \
+	&& apt-get -y upgrade --only-upgrade systemd openssl cryptsetup \
+	&& apt-get install -y git-lfs \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+RUN HOME_DIR=/root \
+	&& curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+	&& unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+	&& cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+	&& chmod +x /usr/local/bin/testOSSCompliance \
+	&& chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+	&& ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+	&& rm -rf ${HOME_DIR}/oss_compliance*
+
+COPY changehostname.c /changehostname.c
+
+ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
+
+CMD ["/bin/bash"]

--- a/internal/lsptest/__snapshots__/TestLSP_Initialize_1.snap.json
+++ b/internal/lsptest/__snapshots__/TestLSP_Initialize_1.snap.json
@@ -3,6 +3,7 @@
   "codeActionProvider": {
    "codeActionKinds": [
     "quickfix",
+    "quickfix.suppress.tally",
     "source.fixAll.tally"
    ]
   },
@@ -14,7 +15,8 @@
   "documentFormattingProvider": true,
   "executeCommandProvider": {
    "commands": [
-    "tally.applyAllFixes"
+    "tally.applyAllFixes",
+    "tally.openRuleDoc"
    ]
   },
   "semanticTokensProvider": {

--- a/internal/lsptest/lsp_test.go
+++ b/internal/lsptest/lsp_test.go
@@ -463,6 +463,39 @@ func TestLSP_ExecuteCommandApplyAllFixes(t *testing.T) {
 	snaps.WithConfig(snaps.Raw(), snaps.Ext(".Dockerfile")).MatchStandaloneSnapshot(t, fixed)
 }
 
+// TestLSP_ExecuteCommandApplyAllFixesRealWorld runs fix-all (with iterative mode)
+// on the same real-world Dockerfile used by TestLSP_FormattingRealWorld.
+// The VS Code smoke test uses this snapshot as the expected fix-all output.
+func TestLSP_ExecuteCommandApplyAllFixesRealWorld(t *testing.T) {
+	t.Parallel()
+	ts := startTestServer(t)
+	ts.initialize(t)
+
+	original, err := os.ReadFile("../integration/testdata/benchmark-real-world-fix/Dockerfile")
+	require.NoError(t, err)
+
+	uri := "file:///tmp/test-fixall-realworld/Dockerfile"
+	ts.openDocument(t, uri, string(original))
+	ts.waitDiagnostics(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), diagTimeout)
+	defer cancel()
+
+	var edit workspaceEdit
+	args := []any{uri}
+	err = ts.conn.Call(ctx, "workspace/executeCommand", &executeCommandParams{
+		Command:   "tally.applyAllFixes",
+		Arguments: &args,
+	}).Await(ctx, &edit)
+	require.NoError(t, err)
+
+	edits := edit.Changes[uri]
+	require.NotEmpty(t, edits, "expected executeCommand to return edits")
+
+	fixed := applyEdits(t, uri, string(original), edits)
+	snaps.WithConfig(snaps.Raw(), snaps.Ext(".Dockerfile")).MatchStandaloneSnapshot(t, fixed)
+}
+
 func TestLSP_NoPushDiagnosticsWhenClientSupportsPull(t *testing.T) {
 	t.Parallel()
 	ts := startTestServer(t)

--- a/internal/lsptest/setup_test.go
+++ b/internal/lsptest/setup_test.go
@@ -447,6 +447,7 @@ type codeAction struct {
 	Diagnostics []diagnostic      `json:"diagnostics,omitempty"`
 	Edit        *workspaceEdit    `json:"edit,omitempty"`
 	Command     *protocol.Command `json:"command,omitempty"`
+	Data        any               `json:"data,omitempty"`
 }
 
 type workspaceEdit struct {


### PR DESCRIPTION
## Summary

Adapts three patterns from the [ESLint VSCode extension](https://github.com/microsoft/vscode-eslint) to tally's LSP server:

- **Suppress Rule CodeAction** (`quickfix.suppress.tally`): generates "Suppress {rule} for this line/file" actions that inject `# tally ignore=` directives. Uses cached parse result + `directive.Parse()` for existing directive detection. Smart merging, comment-block-aware insertion (avoids triggering `buildkit/InvalidDefinitionDescription`), respects `RequireReason`. Carries stable `Data` field for future "suppress and report false positive" composition.

- **Show Documentation CodeAction**: command-based action that sends `window/showDocument` to open rule docs in the system browser. Gated on client `ShowDocumentClientCapabilities.Support`. New `tally.openRuleDoc` server command.

- **Iterative Fix-All**: `computeFixEdits` now supports `"all"` mode (iterative lint+fix up to 10 passes until convergence) and `"problems"` mode (single-pass, previous behavior). Default is `"all"`.

### Supporting changes

- Expanded `lintCacheEntry` to retain `*config.Config` and `*dockerfile.ParseResult` alongside violations
- Three new settings (`suppressRuleEnabled`, `showDocumentationEnabled`, `fixAllMode`) wired through Go server, VS Code extension, and IntelliJ plugin

## Test plan

- [x] Unit tests for suppress (insertion, merging, indentation, RequireReason, dedup, comment-block-aware)
- [x] Unit tests for show-doc (DocURL present/absent, dedup, out-of-range, arg parsing)
- [x] Unit tests for settings (defaults, explicit values, invalid fixAllMode fallback)
- [x] LSP integration test snapshots updated
- [x] `make test` — 6183 tests pass
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Fix all mode" setting (choices: "all" or "problems") controlling fix-all behavior and UI in IntelliJ/VS Code.
  * Code action to suppress rule violations by inserting per-line or file-level ignore directives.
  * Code action to open rule documentation in the browser.
  * New editor settings to enable/disable suppress and documentation actions.

* **Tests / Reliability**
  * Added tests and snapshots covering fix-all behavior, suppress actions, and documentation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->