### PR TITLE
feat(powershell): add error-action-preference rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ tally integrates rules from multiple sources:
 | Source | Rules | Description |
 |--------|-------|-------------|
 | **[BuildKit](https://docs.docker.com/reference/build-checks/)** | 22/22 rules | Docker's official Dockerfile checks (captured + reimplemented) |
-| **tally** | 55 rules | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
+| **tally** | 56 rules | Custom rules including secret detection with [gitleaks](https://github.com/gitleaks/gitleaks) |
 | **[Hadolint](https://github.com/hadolint/hadolint)** | 37 rules | Hadolint-compatible Dockerfile rules (expanding) |
 <!-- END RULES_TABLE -->
 

--- a/RULES.md
+++ b/RULES.md
@@ -15,7 +15,7 @@ tally supports rules from multiple sources, each with its own namespace prefix.
 <!-- BEGIN RULES_SUMMARY -->
 | Namespace | Implemented | Covered by BuildKit | Total |
 |-----------|-------------|---------------------|-------|
-| tally | 55 | - | 55 |
+| tally | 56 | - | 56 |
 | buildkit | 17 + 5 captured | - | 22 |
 | hadolint | 27 | 10 | 66 |
 <!-- END RULES_SUMMARY -->
@@ -63,6 +63,7 @@ See the [tally rules documentation](_docs/rules/tally/) for detailed description
 | [`tally/prefer-package-cache-mounts`](_docs/rules/tally/prefer-package-cache-mounts.mdx) 🔧 | Suggests BuildKit cache mounts for package install/build commands and removes cache cleanup commands | Info | Performance | Enabled |
 | [`tally/php/composer-no-dev-in-production`](_docs/rules/tally/php/composer-no-dev-in-production.mdx) 🔧 | Production Composer install commands should include `--no-dev` | Warning | Security | Enabled |
 | [`tally/php/no-xdebug-in-final-image`](_docs/rules/tally/php/no-xdebug-in-final-image.mdx) 🔧 | Final image installs or enables Xdebug, a development-only tool | Warning | Best Practices | Enabled |
+| [`tally/powershell/error-action-preference`](_docs/rules/tally/powershell/error-action-preference.mdx) 🔧 | PowerShell `RUN` should set `$ErrorActionPreference = 'Stop'` and `$PSNativeCommandUseErrorActionPreference = $true` | Warning | Correctness | Enabled |
 | [`tally/powershell/prefer-shell-instruction`](_docs/rules/tally/powershell/prefer-shell-instruction.mdx) 🔧 | Prefers a PowerShell `SHELL` instruction over repeated `pwsh` or `powershell -Command` wrappers in `RUN` | Style | Style | Enabled (experimental) |
 | [`tally/gpu/cuda-version-mismatch`](_docs/rules/tally/gpu/cuda-version-mismatch.mdx) 🔧 | CUDA-specific pip/conda wheel version does not match base image CUDA toolkit | Warning | Correctness | Enabled |
 | [`tally/gpu/no-buildtime-gpu-queries`](_docs/rules/tally/gpu/no-buildtime-gpu-queries.mdx) | GPU hardware queries in RUN will fail at build time | Error | Correctness | Enabled |

--- a/_docs/docs.json
+++ b/_docs/docs.json
@@ -139,6 +139,7 @@
           {
             "group": "PowerShell",
             "pages": [
+              "rules/tally/powershell/error-action-preference",
               "rules/tally/powershell/prefer-shell-instruction"
             ]
           },

--- a/_docs/rules/tally/powershell/error-action-preference.mdx
+++ b/_docs/rules/tally/powershell/error-action-preference.mdx
@@ -91,3 +91,12 @@ The fix uses `FixSuggestion` safety, requiring `--fix-unsafe` to apply.
   fix is skipped as overlapping.
 - **`tally/prefer-run-heredoc`** (priority 100): when converting multi-statement RUNs to heredocs, the heredoc formatter automatically injects both
   preferences if missing.
+
+## References
+
+- [`$ErrorActionPreference`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables#erroractionpreference)
+  -- Microsoft Learn: controls how PowerShell responds to non-terminating errors. Default is `Continue` (silently
+  swallow); `Stop` converts them to terminating errors.
+- [`$PSNativeCommandUseErrorActionPreference`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables#psnativecommanduserroractionpreference)
+  -- Microsoft Learn: when `$true`, non-zero exit codes from native commands are treated as errors according to
+  `$ErrorActionPreference`. Added in PowerShell 7.3; default is `$false`.

--- a/_docs/rules/tally/powershell/error-action-preference.mdx
+++ b/_docs/rules/tally/powershell/error-action-preference.mdx
@@ -1,0 +1,93 @@
+---
+title: "tally/powershell/error-action-preference"
+description: "Require `$ErrorActionPreference = 'Stop'` and `$PSNativeCommandUseErrorActionPreference = $true` in PowerShell RUN instructions."
+---
+
+Require `$ErrorActionPreference = 'Stop'` and `$PSNativeCommandUseErrorActionPreference = $true` in PowerShell `RUN` instructions.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning |
+| Category | Correctness |
+| Default | Enabled |
+| Auto-fix | Yes (`--fix --fix-unsafe`) |
+
+## Description
+
+This rule detects PowerShell `RUN` instructions that lack fail-fast error handling. It checks for two related preferences:
+
+1. **`$ErrorActionPreference = 'Stop'`** -- catches non-terminating PowerShell cmdlet errors that would otherwise be silently swallowed.
+2. **`$PSNativeCommandUseErrorActionPreference = $true`** -- extends error handling to native command exit codes (e.g., `git`, `dotnet`, `curl`) in
+   PowerShell 7.3+.
+
+The rule fires on both Linux and Windows stages whenever PowerShell is the effective shell (via `SHELL` instruction or explicit `powershell -Command`
+/ `pwsh -Command` wrappers).
+
+## Why this matters
+
+PowerShell does not fail-fast by default. Without `$ErrorActionPreference = 'Stop'`, an intermediate `Invoke-WebRequest` can fail silently, then
+`Start-Process` runs on a missing installer, then `Remove-Item` succeeds because nothing was there. The cascading silent failures are the real danger
+in multi-statement Docker build steps.
+
+The `$PSNativeCommandUseErrorActionPreference` variable was added in PowerShell 7.3 to close a gap: even with `$ErrorActionPreference = 'Stop'`,
+non-zero exit codes from native executables were ignored. Setting it to `$true` extends the fail-fast behavior to all commands.
+
+## Examples
+
+### Before (violation)
+
+```dockerfile
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force; Write-Host "done"
+```
+
+### After (fixed with `--fix --fix-unsafe`)
+
+```dockerfile
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+RUN Install-Module PSReadLine -Force; Write-Host "done"
+```
+
+### Already clean (no violation)
+
+```dockerfile
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+RUN Install-Module PSReadLine -Force; Write-Host "done"
+```
+
+## Configuration
+
+### `min-statements`
+
+Minimum number of PowerShell statements in a `RUN` to trigger the rule.
+
+- **Type:** integer
+- **Default:** `2`
+- **Minimum:** `1`
+
+Set to `1` to also catch non-terminating error swallowing on single-command `RUN` instructions.
+
+```toml
+[rules.tally."powershell/error-action-preference"]
+min-statements = 1
+```
+
+## Fix behavior
+
+The auto-fix modifies or inserts a `SHELL` instruction at the stage level, injecting whichever preferences are missing:
+
+- **Existing `SHELL` instruction**: appends the missing preferences to the last argument.
+- **No `SHELL` instruction**: inserts a new `SHELL` instruction after the `FROM`.
+- **Explicit wrapper** (`RUN powershell -Command ...`): no auto-fix (stage-level fix not applicable).
+
+The fix uses `FixSuggestion` safety, requiring `--fix-unsafe` to apply.
+
+## Interaction with other rules
+
+- **`tally/powershell/prefer-shell-instruction`** (priority 95): runs first. If it inserts a SHELL with the full prelude, the error-action-preference
+  fix is skipped as overlapping.
+- **`tally/prefer-run-heredoc`** (priority 100): when converting multi-statement RUNs to heredocs, the heredoc formatter automatically injects both
+  preferences if missing.

--- a/_docs/rules/tally/powershell/error-action-preference.mdx
+++ b/_docs/rules/tally/powershell/error-action-preference.mdx
@@ -77,11 +77,12 @@ min-statements = 1
 
 ## Fix behavior
 
-The auto-fix modifies or inserts a `SHELL` instruction at the stage level, injecting whichever preferences are missing:
+The auto-fix injects whichever preferences are missing. The strategy depends on the shell context:
 
 - **Existing `SHELL` instruction**: appends the missing preferences to the last argument.
 - **No `SHELL` instruction**: inserts a new `SHELL` instruction after the `FROM`.
-- **Explicit wrapper** (`RUN powershell -Command ...`): no auto-fix (stage-level fix not applicable).
+- **Explicit wrapper** (`RUN powershell -Command ...`): inserts the missing preferences at the
+  start of the inner script, right before the first command.
 
 The fix uses `FixSuggestion` safety, requiring `--fix-unsafe` to apply.
 

--- a/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.Dockerfile
@@ -4,7 +4,7 @@ FROM teeks99/msvc-win:14.0
   # [tally] settings to opt out from telemetry
   ENV POWERSHELL_TELEMETRY_OPTOUT=1
 
-SHELL ["powershell", "-command"]
+SHELL ["powershell", "-command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
 
 # Install Chocolatey
 RUN <<EOF

--- a/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.Dockerfile
@@ -4,7 +4,7 @@ FROM teeks99/msvc-win:14.0
   # [tally] settings to opt out from telemetry
   ENV POWERSHELL_TELEMETRY_OPTOUT=1
 
-SHELL ["powershell", "-command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+SHELL ["powershell", "-command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
 
 # Install Chocolatey
 RUN <<EOF

--- a/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.md
+++ b/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.md
@@ -1,12 +1,13 @@
 note: 4 slow check(s) skipped (image not found)
-Fixed 13 issues
+Fixed 12 issues
 Skipped 1 fixes
 note: 1 AI fix(es) failed (see details below)
 note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registered: ai-autofix
-**4 issues** in `<stdin>`
+**5 issues** in `<stdin>`
 
 | Line | Issue |
 |------|-------|
+| 13 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
 | - | ℹ️ `HEALTHCHECK` instruction missing |
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 13 | 💅 expected blank line between COPY and RUN |

--- a/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.md
+++ b/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.md
@@ -1,5 +1,5 @@
 note: 4 slow check(s) skipped (image not found)
-Fixed 11 issues
+Fixed 13 issues
 Skipped 1 fixes
 note: 1 AI fix(es) failed (see details below)
 note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registered: ai-autofix

--- a/internal/integration/__snapshots__/TestFixRealWorldMetalama_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorldMetalama_1.snap.Dockerfile
@@ -8,7 +8,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025
 ENV POWERSHELL_TELEMETRY_OPTOUT=1
 
 # The initial shell is Windows PowerShell (use full path to avoid HCS issues)
-SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
 
 # Prepare environment
 ENV PSExecutionPolicyPreference=Bypass

--- a/internal/integration/__snapshots__/TestFixRealWorldMetalama_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorldMetalama_1.snap.Dockerfile
@@ -8,7 +8,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025
 ENV POWERSHELL_TELEMETRY_OPTOUT=1
 
 # The initial shell is Windows PowerShell (use full path to avoid HCS issues)
-SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command"]
+SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
 
 # Prepare environment
 ENV PSExecutionPolicyPreference=Bypass

--- a/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-backtick-multiline-native-only_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-backtick-multiline-native-only_1.snap.Dockerfile
@@ -1,0 +1,7 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+RUN Invoke-WebRequest -Uri https://example.com/setup.exe `
+      -OutFile C:\setup.exe; `
+    Start-Process C:\setup.exe -Wait; `
+    Remove-Item C:\setup.exe -Force

--- a/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-cross-prefer-shell-instruction_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-cross-prefer-shell-instruction_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh","-Command","$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+RUN Install-Module PSReadLine -Force
+RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip

--- a/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-explicit-wrapper-backtick_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-explicit-wrapper-backtick_1.snap.Dockerfile
@@ -1,0 +1,6 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN powershell -Command `
+    $ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; Invoke-WebRequest -Uri https://example.com/setup.exe -OutFile C:\setup.exe; `
+    Start-Process C:\setup.exe -Wait; `
+    Remove-Item C:\setup.exe -Force

--- a/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-insert-shell-after-from_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-insert-shell-after-from_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+RUN Install-Module PSReadLine -Force; Write-Host done

--- a/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-missing-both_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-missing-both_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+RUN Install-Module PSReadLine -Force; Write-Host done

--- a/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-single-cmd-no-fix_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-single-cmd-no-fix_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force

--- a/internal/integration/__snapshots__/TestLint_powershell-error-action-preference_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_powershell-error-action-preference_1.snap.json
@@ -60,28 +60,7 @@
           "message": "PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true",
           "rule": "tally/powershell/error-action-preference",
           "severity": "warning",
-          "sourceCode": "RUN Install-Module Az -Force; Write-Host \"two\"",
-          "suggestedFix": {
-            "description": "Add $ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; to SHELL instruction",
-            "edits": [
-              {
-                "location": {
-                  "end": {
-                    "column": 25,
-                    "line": 8
-                  },
-                  "file": "testdata/powershell-error-action-preference/Dockerfile",
-                  "start": {
-                    "column": 25,
-                    "line": 8
-                  }
-                },
-                "newText": ", \"$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;\""
-              }
-            ],
-            "priority": 96,
-            "safety": 1
-          }
+          "sourceCode": "RUN Install-Module Az -Force; Write-Host \"two\""
         },
         {
           "detail": "Without $PSNativeCommandUseErrorActionPreference = $true, non-zero exit codes from native commands (git, dotnet, curl) are ignored even when $ErrorActionPreference is 'Stop' (PowerShell 7.3+).",

--- a/internal/integration/__snapshots__/TestLint_powershell-error-action-preference_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_powershell-error-action-preference_1.snap.json
@@ -1,0 +1,179 @@
+{
+  "files": [
+    {
+      "file": "testdata/powershell-error-action-preference/Dockerfile",
+      "violations": [
+        {
+          "detail": "Without $ErrorActionPreference = 'Stop', PowerShell silently continues after non-terminating errors. $PSNativeCommandUseErrorActionPreference = $true extends error handling to native command exit codes (PowerShell 7.3+).",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/powershell/error-action-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 9
+            },
+            "file": "testdata/powershell-error-action-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 9
+            }
+          },
+          "message": "PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true",
+          "rule": "tally/powershell/error-action-preference",
+          "severity": "warning",
+          "sourceCode": "RUN Install-Module PSReadLine -Force; Write-Host \"one\"",
+          "suggestedFix": {
+            "description": "Add $ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; to SHELL instruction",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 25,
+                    "line": 8
+                  },
+                  "file": "testdata/powershell-error-action-preference/Dockerfile",
+                  "start": {
+                    "column": 25,
+                    "line": 8
+                  }
+                },
+                "newText": ", \"$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;\""
+              }
+            ],
+            "priority": 96,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Without $ErrorActionPreference = 'Stop', PowerShell silently continues after non-terminating errors. $PSNativeCommandUseErrorActionPreference = $true extends error handling to native command exit codes (PowerShell 7.3+).",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/powershell/error-action-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 10
+            },
+            "file": "testdata/powershell-error-action-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 10
+            }
+          },
+          "message": "PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true",
+          "rule": "tally/powershell/error-action-preference",
+          "severity": "warning",
+          "sourceCode": "RUN Install-Module Az -Force; Write-Host \"two\"",
+          "suggestedFix": {
+            "description": "Add $ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; to SHELL instruction",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 25,
+                    "line": 8
+                  },
+                  "file": "testdata/powershell-error-action-preference/Dockerfile",
+                  "start": {
+                    "column": 25,
+                    "line": 8
+                  }
+                },
+                "newText": ", \"$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;\""
+              }
+            ],
+            "priority": 96,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Without $PSNativeCommandUseErrorActionPreference = $true, non-zero exit codes from native commands (git, dotnet, curl) are ignored even when $ErrorActionPreference is 'Stop' (PowerShell 7.3+).",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/powershell/error-action-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 15
+            },
+            "file": "testdata/powershell-error-action-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 15
+            }
+          },
+          "message": "PowerShell RUN is missing $PSNativeCommandUseErrorActionPreference = $true",
+          "rule": "tally/powershell/error-action-preference",
+          "severity": "warning",
+          "sourceCode": "RUN Install-Module PSReadLine -Force; Write-Host \"three\"",
+          "suggestedFix": {
+            "description": "Add $PSNativeCommandUseErrorActionPreference = $true; to SHELL instruction",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 60,
+                    "line": 14
+                  },
+                  "file": "testdata/powershell-error-action-preference/Dockerfile",
+                  "start": {
+                    "column": 60,
+                    "line": 14
+                  }
+                },
+                "newText": " $PSNativeCommandUseErrorActionPreference = $true;"
+              }
+            ],
+            "priority": 96,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Without $ErrorActionPreference = 'Stop', PowerShell silently continues after non-terminating errors. $PSNativeCommandUseErrorActionPreference = $true extends error handling to native command exit codes (PowerShell 7.3+).",
+          "docUrl": "https://wharflab.github.io/tally/rules/tally/powershell/error-action-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 19
+            },
+            "file": "testdata/powershell-error-action-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 19
+            }
+          },
+          "message": "PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true",
+          "rule": "tally/powershell/error-action-preference",
+          "severity": "warning",
+          "sourceCode": "RUN pwsh -Command \"Install-Module PSReadLine -Force; Write-Host done\"",
+          "suggestedFix": {
+            "description": "Add PowerShell error-handling preferences to wrapper script",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 19
+                  },
+                  "file": "testdata/powershell-error-action-preference/Dockerfile",
+                  "start": {
+                    "column": 19,
+                    "line": 19
+                  }
+                },
+                "newText": "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; "
+              }
+            ],
+            "priority": 96,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 4,
+    "warnings": 4
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "files_scanned": 1,
-  "rules_enabled": 96,
+  "rules_enabled": 97,
   "summary": {
     "errors": 0,
     "files": 0,

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1823,6 +1823,24 @@ severity = "warning"
 			wantApplied: 1,
 		},
 
+		// Cross-rule: error-action-preference + prefer-shell-instruction both
+		// enabled on repeated pwsh wrappers. prefer-shell-instruction (95) runs
+		// first and inserts SHELL with the full prelude; error-action-preference
+		// (96) fix is skipped because its SHELL edit overlaps.
+		{
+			name: "powershell-error-action-preference-cross-prefer-shell-instruction",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"RUN pwsh -Command Install-Module PSReadLine -Force\n" +
+				"RUN pwsh -Command Invoke-WebRequest https://example.com -OutFile /tmp/f.zip\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules(
+					"tally/powershell/error-action-preference",
+					"tally/powershell/prefer-shell-instruction",
+				)...),
+			wantApplied: 1, // only prefer-shell-instruction applies
+		},
+
 		// Prefer canonical STOPSIGNAL: missing SIG prefix → SIGTERM (FixSafe)
 		{
 			name:  "prefer-canonical-stopsignal-prefix",

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1823,6 +1823,18 @@ severity = "warning"
 			wantApplied: 1,
 		},
 
+		// PowerShell error-action-preference: PowerShell base image with no SHELL
+		// instruction → inserts a new SHELL after FROM with the prelude.
+		{
+			name: "powershell-error-action-preference-insert-shell-after-from",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"RUN Install-Module PSReadLine -Force; Write-Host done\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/error-action-preference")...),
+			wantApplied: 1,
+		},
+
 		// Cross-rule: error-action-preference + prefer-shell-instruction both
 		// enabled on repeated pwsh wrappers. prefer-shell-instruction (95) runs
 		// first and inserts SHELL with the full prelude; error-action-preference

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1767,6 +1767,62 @@ severity = "warning"
 			wantApplied: 0,
 		},
 
+		// PowerShell error-action-preference: SHELL missing prelude → insert prelude (FixSuggestion)
+		{
+			name: "powershell-error-action-preference-missing-both",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"SHELL [\"pwsh\", \"-Command\"]\n" +
+				"RUN Install-Module PSReadLine -Force; Write-Host done\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/error-action-preference")...),
+			wantApplied: 1,
+		},
+		// PowerShell error-action-preference: single-command RUN — no fix (below threshold)
+		{
+			name: "powershell-error-action-preference-single-cmd-no-fix",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"SHELL [\"pwsh\", \"-Command\"]\n" +
+				"RUN Install-Module PSReadLine -Force\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/error-action-preference")...),
+			wantApplied: 0,
+		},
+		// PowerShell error-action-preference: backtick escape, multiline RUN,
+		// SHELL already has Stop — only PSNativeCommandUseErrorActionPreference missing.
+		{
+			name: "powershell-error-action-preference-backtick-multiline-native-only",
+			input: "# escape=`\n" +
+				"FROM mcr.microsoft.com/windows/servercore:ltsc2022\n" +
+				"SHELL [\"powershell\", \"-Command\", \"$ErrorActionPreference = 'Stop';\"]\n" +
+				"RUN Invoke-WebRequest -Uri https://example.com/setup.exe `\n" +
+				"      -OutFile C:\\setup.exe; `\n" +
+				"    Start-Process C:\\setup.exe -Wait; `\n" +
+				"    Remove-Item C:\\setup.exe -Force\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/error-action-preference")...),
+			wantApplied: 1,
+		},
+		// PowerShell error-action-preference: explicit powershell -Command wrapper
+		// with backtick-continued multiline body. Both preludes missing; fix
+		// prepends them to the inner script.
+		{
+			name: "powershell-error-action-preference-explicit-wrapper-backtick",
+			input: "# escape=`\n" +
+				"FROM mcr.microsoft.com/windows/servercore:ltsc2022\n" +
+				"RUN powershell -Command `\n" +
+				"    Invoke-WebRequest -Uri https://example.com/setup.exe " +
+				"-OutFile C:\\setup.exe; `\n" +
+				"    Start-Process C:\\setup.exe -Wait; `\n" +
+				"    Remove-Item C:\\setup.exe -Force\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/error-action-preference")...),
+			wantApplied: 1,
+		},
+
 		// Prefer canonical STOPSIGNAL: missing SIG prefix → SIGTERM (FixSafe)
 		{
 			name:  "prefer-canonical-stopsignal-prefix",

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -248,6 +248,14 @@ func lintCases(t *testing.T) []lintCase {
 				mustSelectRules("tally/powershell/prefer-shell-instruction", "hadolint/DL4005")...),
 			wantExit: 1,
 		},
+
+		// PowerShell: error-action-preference
+		{
+			name:     "powershell-error-action-preference",
+			dir:      "powershell-error-action-preference",
+			args:     append([]string{"--format", "json"}, mustSelectRules("tally/powershell/error-action-preference")...),
+			wantExit: 1,
+		},
 		{
 			name:     "php-composer-no-dev-in-production",
 			dir:      "php-composer-no-dev-in-production",

--- a/internal/integration/testdata/powershell-error-action-preference/Dockerfile
+++ b/internal/integration/testdata/powershell-error-action-preference/Dockerfile
@@ -1,0 +1,24 @@
+# Stage 1: SHELL with full prelude — no violations expected
+FROM mcr.microsoft.com/powershell:ubuntu-22.04 AS clean
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+RUN Install-Module PSReadLine -Force; Write-Host "done"
+
+# Stage 2: SHELL without prelude — multi-command RUNs should trigger
+FROM mcr.microsoft.com/powershell:ubuntu-22.04 AS missing-both
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force; Write-Host "one"
+RUN Install-Module Az -Force; Write-Host "two"
+
+# Stage 3: SHELL has Stop but no native preference
+FROM mcr.microsoft.com/powershell:ubuntu-22.04 AS missing-native
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
+RUN Install-Module PSReadLine -Force; Write-Host "three"
+
+# Stage 4: Explicit wrapper from non-PS shell
+FROM ubuntu:22.04 AS explicit-wrapper
+RUN pwsh -Command "Install-Module PSReadLine -Force; Write-Host done"
+
+# Stage 5: Single-command RUN should not trigger (default threshold=2)
+FROM mcr.microsoft.com/powershell:ubuntu-22.04 AS single-cmd
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force

--- a/internal/registry/containers.go
+++ b/internal/registry/containers.go
@@ -191,6 +191,7 @@ func (r *ContainersResolver) resolveFromManifest(
 		Digest:         manifestDigest.String(),
 		HasHealthcheck: extractHasHealthcheck(configBytes),
 		WorkingDir:     ociConfig.Config.WorkingDir,
+		Shell:          extractShell(configBytes),
 	}
 
 	// Platform mismatch check for single-manifest images.

--- a/internal/registry/oci.go
+++ b/internal/registry/oci.go
@@ -38,6 +38,23 @@ func extractHasHealthcheck(configBytes []byte) bool {
 	return hc != nil && len(hc.Test) > 0 && hc.Test[0] != "NONE"
 }
 
+// extractShell extracts the SHELL configuration from a Docker image config blob.
+// The OCI image spec does not include Shell, but Docker image configs do.
+func extractShell(configBytes []byte) []string {
+	var dockerCfg struct {
+		Config struct {
+			Shell []string `json:"Shell,omitempty"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(configBytes, &dockerCfg); err != nil {
+		return nil
+	}
+	if len(dockerCfg.Config.Shell) == 0 {
+		return nil
+	}
+	return dockerCfg.Config.Shell
+}
+
 // readAll reads up to maxBytes from r.
 func readAll(r io.Reader, maxBytes int64) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(r, maxBytes))

--- a/internal/registry/resolver.go
+++ b/internal/registry/resolver.go
@@ -51,6 +51,11 @@ type ImageConfig struct {
 	// WorkingDir is the image's configured working directory (from WORKDIR).
 	// Empty string means no explicit WORKDIR was set (default is /).
 	WorkingDir string
+
+	// Shell is the image's configured default shell (from SHELL instruction).
+	// Nil means no explicit SHELL was set (Docker defaults apply).
+	// This is a Docker extension — not part of the OCI image spec.
+	Shell []string
 }
 
 // ResolveRequest is the typed input for the registry async resolver.

--- a/internal/rules/tally/powershell/__snapshots__/TestErrorActionPreferenceRule_DefaultConfig_1.snap.json
+++ b/internal/rules/tally/powershell/__snapshots__/TestErrorActionPreferenceRule_DefaultConfig_1.snap.json
@@ -1,0 +1,3 @@
+{
+ "min-statements": 2
+}

--- a/internal/rules/tally/powershell/__snapshots__/TestErrorActionPreferenceRule_Metadata_1.snap.json
+++ b/internal/rules/tally/powershell/__snapshots__/TestErrorActionPreferenceRule_Metadata_1.snap.json
@@ -1,0 +1,10 @@
+{
+ "Category": "correctness",
+ "Code": "tally/powershell/error-action-preference",
+ "DefaultSeverity": "warning",
+ "Description": "PowerShell RUN should set $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true",
+ "DocURL": "https://wharflab.github.io/tally/rules/tally/powershell/error-action-preference/",
+ "FixPriority": 96,
+ "IsExperimental": false,
+ "Name": "Require PowerShell error-handling preferences"
+}

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -292,20 +292,24 @@ func (r *ErrorActionPreferenceRule) buildWrapperFix(
 		return nil
 	}
 
-	// Anchor the search to text after the -Command argument so we don't
-	// accidentally match a token that appears in the outer wrapper prefix
-	// (e.g., `RUN pwsh -Command "pwsh -Command ..."`).
-	commandArgIdx := findCommandArgEnd(source)
+	// Anchor the search past the executable name to avoid matching tokens
+	// in the "RUN powershell" prefix itself.
+	exeLower := strings.ToLower(invocation.executable)
+	anchorIdx := strings.Index(strings.ToLower(source), exeLower)
+	if anchorIdx < 0 {
+		return nil
+	}
+	searchStart := anchorIdx + len(exeLower)
 
 	firstToken := firstNonWhitespaceWord(invocation.script)
 	if firstToken == "" {
 		return nil
 	}
-	relIdx := strings.Index(source[commandArgIdx:], firstToken)
+	relIdx := strings.Index(source[searchStart:], firstToken)
 	if relIdx < 0 {
 		return nil
 	}
-	insertByte := commandArgIdx + relIdx
+	insertByte := searchStart + relIdx
 
 	prelude := buildPreludeString(needStop, needNative) + " "
 	insertLine, insertCol := sourcemap.ByteToLineCol(source, insertByte)
@@ -335,20 +339,6 @@ func firstNonWhitespaceWord(s string) string {
 		return trimmed[:idx]
 	}
 	return trimmed
-}
-
-// findCommandArgEnd returns the byte offset in source just past the
-// "-Command" (or "-c") argument of a `powershell`/`pwsh` wrapper.
-// If not found, returns 0 so the caller falls back to a full search.
-func findCommandArgEnd(source string) int {
-	lower := strings.ToLower(source)
-	for _, flag := range []string{"-command", "-c"} {
-		idx := strings.Index(lower, flag)
-		if idx >= 0 {
-			return idx + len(flag)
-		}
-	}
-	return 0
 }
 
 // shellPreludeStateFromCmd checks the SHELL command args for the two prelude variables.

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -292,16 +292,20 @@ func (r *ErrorActionPreferenceRule) buildWrapperFix(
 		return nil
 	}
 
-	// Find the first token of the inner script in the raw source.
-	// This is stable across continuation-line joining.
+	// Anchor the search to text after the -Command argument so we don't
+	// accidentally match a token that appears in the outer wrapper prefix
+	// (e.g., `RUN pwsh -Command "pwsh -Command ..."`).
+	commandArgIdx := findCommandArgEnd(source)
+
 	firstToken := firstNonWhitespaceWord(invocation.script)
 	if firstToken == "" {
 		return nil
 	}
-	insertByte := strings.Index(source, firstToken)
-	if insertByte < 0 {
+	relIdx := strings.Index(source[commandArgIdx:], firstToken)
+	if relIdx < 0 {
 		return nil
 	}
+	insertByte := commandArgIdx + relIdx
 
 	prelude := buildPreludeString(needStop, needNative) + " "
 	insertLine, insertCol := sourcemap.ByteToLineCol(source, insertByte)
@@ -331,6 +335,20 @@ func firstNonWhitespaceWord(s string) string {
 		return trimmed[:idx]
 	}
 	return trimmed
+}
+
+// findCommandArgEnd returns the byte offset in source just past the
+// "-Command" (or "-c") argument of a `powershell`/`pwsh` wrapper.
+// If not found, returns 0 so the caller falls back to a full search.
+func findCommandArgEnd(source string) int {
+	lower := strings.ToLower(source)
+	for _, flag := range []string{"-command", "-c"} {
+		idx := strings.Index(lower, flag)
+		if idx >= 0 {
+			return idx + len(flag)
+		}
+	}
+	return 0
 }
 
 // shellPreludeStateFromCmd checks the SHELL command args for the two prelude variables.

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -1,0 +1,597 @@
+package powershell
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/semantic"
+	shellutil "github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+// ErrorActionPreferenceRuleCode is the full rule code.
+const ErrorActionPreferenceRuleCode = rules.TallyRulePrefix + "powershell/error-action-preference"
+
+const defaultPwshExecutable = "pwsh"
+
+// ErrorActionPreferenceConfig is the configuration for the rule.
+type ErrorActionPreferenceConfig struct {
+	// MinStatements is the minimum number of PowerShell statements to trigger the rule.
+	// Default is 2 (multi-statement RUNs). Set to 1 to also catch non-terminating
+	// errors on single-command RUNs.
+	MinStatements *int `json:"min-statements,omitempty" koanf:"min-statements"`
+}
+
+// DefaultErrorActionPreferenceConfig returns the default configuration.
+func DefaultErrorActionPreferenceConfig() ErrorActionPreferenceConfig {
+	minStatements := 2
+	return ErrorActionPreferenceConfig{
+		MinStatements: &minStatements,
+	}
+}
+
+// ErrorActionPreferenceRule warns when multi-statement PowerShell RUN instructions
+// lack $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true.
+type ErrorActionPreferenceRule struct{}
+
+// NewErrorActionPreferenceRule creates a new rule instance.
+func NewErrorActionPreferenceRule() *ErrorActionPreferenceRule {
+	return &ErrorActionPreferenceRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *ErrorActionPreferenceRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code: ErrorActionPreferenceRuleCode,
+		Name: "Require PowerShell error-handling preferences",
+		Description: "PowerShell RUN should set $ErrorActionPreference = 'Stop'" +
+			" and $PSNativeCommandUseErrorActionPreference = $true",
+		DocURL:          rules.TallyDocURL(ErrorActionPreferenceRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "correctness",
+		FixPriority:     96, //nolint:mnd // After prefer-shell-instruction (95), before heredoc (100).
+	}
+}
+
+// DefaultConfig returns the default configuration.
+func (r *ErrorActionPreferenceRule) DefaultConfig() any {
+	return DefaultErrorActionPreferenceConfig()
+}
+
+// Check runs the rule.
+func (r *ErrorActionPreferenceRule) Check(input rules.LintInput) []rules.Violation {
+	if len(powershellStages(input)) == 0 {
+		return nil
+	}
+
+	cfg := r.resolveConfig(input.Config)
+	minStatements := 2
+	if cfg.MinStatements != nil && *cfg.MinStatements >= 1 {
+		minStatements = *cfg.MinStatements
+	}
+
+	meta := r.Metadata()
+	sm := input.SourceMap()
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		stageInfo := stageInfoForIndex(input.Semantic, stageIdx)
+		p := checkParams{
+			file:          input.File,
+			meta:          meta,
+			sm:            sm,
+			stageIdx:      stageIdx,
+			info:          stageInfo,
+			minStatements: minStatements,
+		}
+		violations = append(violations, r.checkStage(input, sm, stageIdx, stage, stageInfo, p)...)
+	}
+
+	return violations
+}
+
+func stageInfoForIndex(sem *semantic.Model, idx int) *semantic.StageInfo {
+	if sem == nil {
+		return nil
+	}
+	return sem.StageInfo(idx)
+}
+
+// checkParams groups shared parameters for per-RUN checking.
+type checkParams struct {
+	file          string
+	meta          rules.RuleMetadata
+	sm            *sourcemap.SourceMap
+	stageIdx      int
+	info          *semantic.StageInfo
+	minStatements int
+}
+
+func (r *ErrorActionPreferenceRule) checkStage(
+	input rules.LintInput,
+	_ *sourcemap.SourceMap,
+	stageIdx int,
+	stage instructions.Stage,
+	_ *semantic.StageInfo,
+	params checkParams,
+) []rules.Violation {
+	var violations []rules.Violation
+
+	// Track the effective SHELL args through the stage to detect prelude.
+	activeShellCmd := initialStageShellCmd(input.Semantic, stageIdx)
+
+	for _, cmd := range stage.Commands {
+		if sc, ok := cmd.(*instructions.ShellCommand); ok && len(sc.Shell) > 0 {
+			activeShellCmd = sc.Shell
+			continue
+		}
+
+		run, ok := cmd.(*instructions.RunCommand)
+		if !ok || !run.PrependShell || len(run.CmdLine) == 0 {
+			continue
+		}
+
+		v := r.checkRun(params, run, run.CmdLine[0], activeShellCmd)
+		if v != nil {
+			violations = append(violations, *v)
+		}
+	}
+
+	return violations
+}
+
+func (r *ErrorActionPreferenceRule) checkRun(
+	p checkParams,
+	run *instructions.RunCommand,
+	script string,
+	activeShellCmd []string,
+) *rules.Violation {
+	// Determine effective shell variant at this RUN.
+	variant := shellutil.VariantBash
+	if p.info != nil && len(run.Location()) > 0 {
+		variant = p.info.ShellVariantAtLine(run.Location()[0].Start.Line)
+	}
+
+	if variant.IsPowerShell() {
+		return r.checkPowerShellRun(p, run, script, activeShellCmd)
+	}
+
+	// Path B: explicit powershell/pwsh wrapper in a non-PowerShell shell.
+	return r.checkExplicitWrapper(p, run, script)
+}
+
+func (r *ErrorActionPreferenceRule) checkPowerShellRun(
+	p checkParams,
+	run *instructions.RunCommand,
+	script string,
+	activeShellCmd []string,
+) *rules.Violation {
+	count := shellutil.CountChainedCommands(script, shellutil.VariantPowerShell)
+	if count < p.minStatements {
+		return nil
+	}
+
+	// Check SHELL-level prelude using the tracked active shell args.
+	shellHasStop, shellHasNative := shellPreludeStateFromCmd(activeShellCmd)
+
+	// Check script-body prelude.
+	scriptHasStop, scriptHasNative, scriptHasWrongStop := scanScriptPrelude(script)
+
+	hasStop := shellHasStop || scriptHasStop
+	hasNative := shellHasNative || scriptHasNative
+
+	if hasStop && hasNative {
+		return nil
+	}
+
+	loc := rules.NewLocationFromRanges(p.file, run.Location())
+	if loc.IsFileLevel() {
+		return nil
+	}
+
+	msg, detail := buildViolationMessage(hasStop, hasNative, scriptHasWrongStop)
+	v := rules.NewViolation(loc, p.meta.Code, msg, p.meta.DefaultSeverity).
+		WithDocURL(p.meta.DocURL).
+		WithDetail(detail)
+	v.StageIndex = p.stageIdx
+
+	if fix := r.buildStageFix(p, run, activeShellCmd, !hasStop, !hasNative); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+
+	return &v
+}
+
+func (r *ErrorActionPreferenceRule) checkExplicitWrapper(
+	p checkParams,
+	run *instructions.RunCommand,
+	script string,
+) *rules.Violation {
+	invocation, ok := parseExplicitPowerShellInvocation(script)
+	if !ok {
+		return nil
+	}
+
+	innerScript := invocation.script
+	count := shellutil.CountChainedCommands(innerScript, shellutil.VariantPowerShell)
+	if count < p.minStatements {
+		return nil
+	}
+
+	scriptHasStop, scriptHasNative, scriptHasWrongStop := scanScriptPrelude(innerScript)
+
+	if scriptHasStop && scriptHasNative {
+		return nil
+	}
+
+	loc := rules.NewLocationFromRanges(p.file, run.Location())
+	if loc.IsFileLevel() {
+		return nil
+	}
+
+	msg, detail := buildViolationMessage(scriptHasStop, scriptHasNative, scriptHasWrongStop)
+	v := rules.NewViolation(loc, p.meta.Code, msg, p.meta.DefaultSeverity).
+		WithDocURL(p.meta.DocURL).
+		WithDetail(detail)
+	v.StageIndex = p.stageIdx
+
+	if fix := r.buildWrapperFix(p, run, script, invocation, !scriptHasStop, !scriptHasNative); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+
+	return &v
+}
+
+// buildWrapperFix inserts missing prelude(s) at the inner script start of an
+// explicit wrapper. Uses a zero-width insertion so it never conflicts with
+// edits from other rules targeting the same RUN body.
+//
+// Because BuildKit flattens continuation lines in CmdLine[0], we cannot use
+// ResolveRunSource (which tries to find the flattened script in raw source).
+// Instead we scan the raw source lines for the first inner-script token.
+func (r *ErrorActionPreferenceRule) buildWrapperFix(
+	p checkParams,
+	run *instructions.RunCommand,
+	_ string,
+	invocation explicitPowerShellInvocation,
+	needStop bool,
+	needNative bool,
+) *rules.SuggestedFix {
+	if p.sm == nil || len(run.Location()) == 0 {
+		return nil
+	}
+
+	startLine := run.Location()[0].Start.Line
+	endLine := run.Location()[len(run.Location())-1].End.Line
+
+	// Use Snippet to get the raw source (0-based line args).
+	source := p.sm.Snippet(startLine-1, endLine-1)
+	if source == "" {
+		return nil
+	}
+
+	// Find the first token of the inner script in the raw source.
+	// This is stable across continuation-line joining.
+	firstToken := firstNonWhitespaceWord(invocation.script)
+	if firstToken == "" {
+		return nil
+	}
+	insertByte := strings.Index(source, firstToken)
+	if insertByte < 0 {
+		return nil
+	}
+
+	prelude := buildPreludeString(needStop, needNative) + " "
+	insertLine, insertCol := sourcemap.ByteToLineCol(source, insertByte)
+
+	return &rules.SuggestedFix{
+		Description: "Add PowerShell error-handling preferences to wrapper script",
+		Safety:      rules.FixSuggestion,
+		Priority:    p.meta.FixPriority,
+		Edits: []rules.TextEdit{
+			{
+				// Zero-width insertion: Start == End.
+				Location: rules.NewRangeLocation(
+					p.file,
+					startLine+insertLine, insertCol,
+					startLine+insertLine, insertCol,
+				),
+				NewText: prelude,
+			},
+		},
+	}
+}
+
+// firstNonWhitespaceWord returns the first whitespace-delimited word from s.
+func firstNonWhitespaceWord(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if idx := strings.IndexAny(trimmed, " \t\n\r;"); idx > 0 {
+		return trimmed[:idx]
+	}
+	return trimmed
+}
+
+// shellPreludeStateFromCmd checks the SHELL command args for the two prelude variables.
+func shellPreludeStateFromCmd(shellCmd []string) (hasStop, hasNative bool) {
+	if len(shellCmd) <= 1 {
+		return false, false
+	}
+
+	joined := strings.ToLower(strings.Join(shellCmd[1:], " "))
+	hasStop = strings.Contains(joined, "$erroractionpreference") && strings.Contains(joined, "stop")
+	hasNative = strings.Contains(joined, "$psnativecommanduseerroractionpreference") && strings.Contains(joined, "true")
+	return hasStop, hasNative
+}
+
+// scanScriptPrelude checks the PowerShell script body for prelude assignments.
+func scanScriptPrelude(script string) (hasStop, hasNative, hasWrongStop bool) {
+	stmts := shellutil.ExtractChainedCommands(script, shellutil.VariantPowerShell)
+	for _, stmt := range stmts {
+		trimmed := strings.TrimSpace(stmt)
+		name, value, ok := shellutil.PowerShellAssignment(trimmed)
+		if !ok {
+			continue
+		}
+
+		switch {
+		case strings.EqualFold(name, "$ErrorActionPreference"):
+			if strings.EqualFold(shellutil.DropQuotes(value), "Stop") {
+				hasStop = true
+			} else {
+				hasWrongStop = true
+			}
+		case strings.EqualFold(name, "$PSNativeCommandUseErrorActionPreference"):
+			if strings.EqualFold(strings.TrimSpace(value), "$true") {
+				hasNative = true
+			}
+		}
+	}
+	return hasStop, hasNative, hasWrongStop
+}
+
+func buildViolationMessage(hasStop, hasNative, hasWrongStop bool) (msg, detail string) {
+	switch {
+	case !hasStop && !hasNative:
+		if hasWrongStop {
+			msg = "PowerShell RUN sets $ErrorActionPreference to a non-Stop value and is missing $PSNativeCommandUseErrorActionPreference"
+			detail = "$ErrorActionPreference should be 'Stop' so that errors are not silently swallowed. " +
+				"$PSNativeCommandUseErrorActionPreference = $true extends this to native command exit codes (PowerShell 7.3+)."
+		} else {
+			msg = "PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true"
+			detail = "Without $ErrorActionPreference = 'Stop', PowerShell silently continues after non-terminating errors. " +
+				"$PSNativeCommandUseErrorActionPreference = $true extends error handling to native command exit codes (PowerShell 7.3+)."
+		}
+	case !hasStop:
+		if hasWrongStop {
+			msg = "PowerShell RUN sets $ErrorActionPreference to a non-Stop value"
+			detail = "$ErrorActionPreference should be 'Stop' so that non-terminating errors halt the build."
+		} else {
+			msg = "PowerShell RUN is missing $ErrorActionPreference = 'Stop'"
+			detail = "Without $ErrorActionPreference = 'Stop', PowerShell silently continues after non-terminating errors."
+		}
+	case !hasNative:
+		msg = "PowerShell RUN is missing $PSNativeCommandUseErrorActionPreference = $true"
+		detail = "Without $PSNativeCommandUseErrorActionPreference = $true, non-zero exit codes from native commands (git, dotnet, curl) " +
+			"are ignored even when $ErrorActionPreference is 'Stop' (PowerShell 7.3+)."
+	}
+	return msg, detail
+}
+
+// buildStageFix creates a fix that modifies or inserts a SHELL instruction at stage level.
+func (r *ErrorActionPreferenceRule) buildStageFix(
+	p checkParams,
+	_ *instructions.RunCommand,
+	activeShellCmd []string,
+	needStop bool,
+	needNative bool,
+) *rules.SuggestedFix {
+	if p.info == nil || p.info.Stage == nil {
+		return nil
+	}
+
+	shellVariant := shellutil.VariantFromShellCmd(activeShellCmd)
+	if !shellVariant.IsPowerShell() {
+		return nil
+	}
+
+	priority := p.meta.FixPriority
+
+	// Find the actual SHELL instruction in the stage commands to modify.
+	if shellCmd := findPowerShellInstruction(p.info.Stage.Commands); shellCmd != nil {
+		return r.buildShellModifyFixFromCmd(p.file, p.sm, shellCmd, priority, needStop, needNative)
+	}
+
+	// No SHELL instruction found: insert one after FROM.
+	return r.buildShellInsertFix(p.file, p.sm, p.info, priority, needStop, needNative)
+}
+
+func findPowerShellInstruction(commands []instructions.Command) *instructions.ShellCommand {
+	for _, cmd := range commands {
+		sc, ok := cmd.(*instructions.ShellCommand)
+		if !ok || len(sc.Shell) == 0 {
+			continue
+		}
+		if shellutil.VariantFromShellCmd(sc.Shell).IsPowerShell() {
+			return sc
+		}
+	}
+	return nil
+}
+
+func (r *ErrorActionPreferenceRule) buildShellModifyFixFromCmd(
+	file string,
+	sm *sourcemap.SourceMap,
+	shellCmd *instructions.ShellCommand,
+	priority int,
+	needStop bool,
+	needNative bool,
+) *rules.SuggestedFix {
+	if sm == nil || len(shellCmd.Location()) == 0 {
+		return nil
+	}
+	shellLine := shellCmd.Location()[0].Start.Line
+	if shellLine <= 0 {
+		return nil
+	}
+
+	sourceLine := sm.Line(shellLine - 1)
+	if sourceLine == "" {
+		return nil
+	}
+
+	preludeToAdd := buildPreludeString(needStop, needNative)
+
+	// Determine where and how to insert the prelude into the SHELL instruction.
+	// Format: SHELL ["exe", "args...", "last-arg"]
+	existing := extractShellLastArg(sourceLine)
+	isCommandOnly := strings.EqualFold(strings.TrimSpace(existing), "-Command")
+
+	if isCommandOnly {
+		// Last arg is just "-Command" — add a new array element with the prelude.
+		// Insert `, "<prelude>"` before the closing `]`.
+		closeBracket := strings.LastIndex(sourceLine, "]")
+		if closeBracket < 0 {
+			return nil
+		}
+		newText := `, "` + preludeToAdd + `"`
+		return &rules.SuggestedFix{
+			Description: fmt.Sprintf("Add %s to SHELL instruction", preludeToAdd),
+			Safety:      rules.FixSuggestion,
+			Priority:    priority,
+			Edits: []rules.TextEdit{
+				{
+					Location: rules.NewRangeLocation(
+						file, shellLine, closeBracket, shellLine, closeBracket,
+					),
+					NewText: newText,
+				},
+			},
+		}
+	}
+
+	// Last arg already has content (e.g., existing prelude). Append the missing
+	// prelude(s) just before the closing quote of that arg.
+	lastQuote := strings.LastIndex(sourceLine, `"`)
+	if lastQuote < 0 {
+		return nil
+	}
+	sep := " "
+	if !strings.HasSuffix(strings.TrimSpace(existing), ";") {
+		sep = "; "
+	}
+	newText := sep + preludeToAdd
+
+	return &rules.SuggestedFix{
+		Description: fmt.Sprintf("Add %s to SHELL instruction", preludeToAdd),
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		Edits: []rules.TextEdit{
+			{
+				Location: rules.NewRangeLocation(
+					file, shellLine, lastQuote, shellLine, lastQuote,
+				),
+				NewText: newText,
+			},
+		},
+	}
+}
+
+func (r *ErrorActionPreferenceRule) buildShellInsertFix(
+	file string,
+	sm *sourcemap.SourceMap,
+	info *semantic.StageInfo,
+	priority int,
+	needStop bool,
+	needNative bool,
+) *rules.SuggestedFix {
+	if info.Stage == nil || len(info.Stage.Location) == 0 {
+		return nil
+	}
+
+	// Insert SHELL after the FROM instruction.
+	fromEndLine := info.Stage.Location[len(info.Stage.Location)-1].End.Line
+	insertLine := fromEndLine + 1
+
+	executable := shellExecutableForStage(info)
+	preludeToAdd := buildPreludeString(needStop, needNative)
+
+	shellInstruction := `SHELL ["` + executable + `", "-Command", "` + preludeToAdd + `"]`
+
+	indent := ""
+	if sm != nil && fromEndLine > 0 && fromEndLine <= sm.LineCount() {
+		indent = leadingIndentForLine(sm.Line(fromEndLine - 1))
+	}
+
+	return &rules.SuggestedFix{
+		Description: "Insert PowerShell SHELL instruction with error-handling preferences",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		Edits: []rules.TextEdit{
+			{
+				Location: rules.NewRangeLocation(file, insertLine, 0, insertLine, 0),
+				NewText:  indent + shellInstruction + "\n",
+			},
+		},
+	}
+}
+
+func shellExecutableForStage(info *semantic.StageInfo) string {
+	if info == nil {
+		return defaultPwshExecutable
+	}
+	// Use the executable from the current shell setting if available.
+	if len(info.ShellSetting.Shell) > 0 {
+		exe := info.ShellSetting.Shell[0]
+		norm := shellutil.NormalizeShellExecutableName(exe)
+		if norm == "powershell" || norm == defaultPwshExecutable {
+			return exe
+		}
+	}
+	// Default for most modern PowerShell images.
+	return defaultPwshExecutable
+}
+
+func buildPreludeString(needStop, needNative bool) string {
+	var parts []string
+	if needStop {
+		parts = append(parts, "$ErrorActionPreference = 'Stop';")
+	}
+	if needNative {
+		parts = append(parts, "$PSNativeCommandUseErrorActionPreference = $true;")
+	}
+	return strings.Join(parts, " ")
+}
+
+// extractShellLastArg extracts the content of the last quoted argument in a SHELL instruction.
+func extractShellLastArg(line string) string {
+	// Find the last pair of quotes.
+	lastClose := strings.LastIndex(line, `"`)
+	if lastClose < 1 {
+		return ""
+	}
+	lastOpen := strings.LastIndex(line[:lastClose], `"`)
+	if lastOpen < 0 {
+		return ""
+	}
+	return line[lastOpen+1 : lastClose]
+}
+
+func leadingIndentForLine(line string) string {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	return line[:i]
+}
+
+func (r *ErrorActionPreferenceRule) resolveConfig(config any) ErrorActionPreferenceConfig {
+	return configutil.Coerce(config, DefaultErrorActionPreferenceConfig())
+}
+
+func init() {
+	rules.Register(NewErrorActionPreferenceRule())
+}

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -126,12 +126,14 @@ func (r *ErrorActionPreferenceRule) checkStage(
 	// on the same SHELL instruction.
 	stageFixEmitted := false
 
-	// Track the effective SHELL args through the stage to detect prelude.
+	// Track the effective SHELL args and instruction through the stage.
 	activeShellCmd := initialStageShellCmd(input.Semantic, stageIdx)
+	var activeShellInstr *instructions.ShellCommand // nil when no SHELL instruction precedes
 
 	for _, cmd := range stage.Commands {
 		if sc, ok := cmd.(*instructions.ShellCommand); ok && len(sc.Shell) > 0 {
 			activeShellCmd = sc.Shell
+			activeShellInstr = sc
 			stageFixEmitted = false // new SHELL resets tracking
 			continue
 		}
@@ -141,7 +143,7 @@ func (r *ErrorActionPreferenceRule) checkStage(
 			continue
 		}
 
-		v := r.checkRun(params, run, run.CmdLine[0], activeShellCmd)
+		v := r.checkRun(params, run, run.CmdLine[0], activeShellCmd, activeShellInstr)
 		if v != nil {
 			// Suppress duplicate stage-level SHELL fixes. When multiple
 			// RUNs in the same SHELL-based stage trigger, only the first
@@ -167,6 +169,7 @@ func (r *ErrorActionPreferenceRule) checkRun(
 	run *instructions.RunCommand,
 	script string,
 	activeShellCmd []string,
+	activeShellInstr *instructions.ShellCommand,
 ) *rules.Violation {
 	// Determine effective shell variant at this RUN.
 	variant := shellutil.VariantBash
@@ -175,7 +178,7 @@ func (r *ErrorActionPreferenceRule) checkRun(
 	}
 
 	if variant.IsPowerShell() {
-		return r.checkPowerShellRun(p, run, script, activeShellCmd)
+		return r.checkPowerShellRun(p, run, script, activeShellCmd, activeShellInstr)
 	}
 
 	// Path B: explicit powershell/pwsh wrapper in a non-PowerShell shell.
@@ -187,6 +190,7 @@ func (r *ErrorActionPreferenceRule) checkPowerShellRun(
 	run *instructions.RunCommand,
 	script string,
 	activeShellCmd []string,
+	activeShellInstr *instructions.ShellCommand,
 ) *rules.Violation {
 	count := shellutil.CountChainedCommands(script, shellutil.VariantPowerShell)
 	if count < p.minStatements {
@@ -217,7 +221,7 @@ func (r *ErrorActionPreferenceRule) checkPowerShellRun(
 		WithDetail(detail)
 	v.StageIndex = p.stageIdx
 
-	if fix := r.buildStageFix(p, run, activeShellCmd, !hasStop, !hasNative); fix != nil {
+	if fix := r.buildStageFix(p, activeShellCmd, activeShellInstr, !hasStop, !hasNative); fix != nil {
 		v = v.WithSuggestedFix(fix)
 	}
 
@@ -420,8 +424,8 @@ func buildViolationMessage(hasStop, hasNative, hasWrongStop bool) (msg, detail s
 // buildStageFix creates a fix that modifies or inserts a SHELL instruction at stage level.
 func (r *ErrorActionPreferenceRule) buildStageFix(
 	p checkParams,
-	_ *instructions.RunCommand,
 	activeShellCmd []string,
+	activeShellInstr *instructions.ShellCommand,
 	needStop bool,
 	needNative bool,
 ) *rules.SuggestedFix {
@@ -436,26 +440,13 @@ func (r *ErrorActionPreferenceRule) buildStageFix(
 
 	priority := p.meta.FixPriority
 
-	// Find the actual SHELL instruction in the stage commands to modify.
-	if shellCmd := findPowerShellInstruction(p.info.Stage.Commands); shellCmd != nil {
-		return r.buildShellModifyFixFromCmd(p.file, p.sm, shellCmd, priority, needStop, needNative)
+	// Modify the nearest preceding PowerShell SHELL instruction for this RUN.
+	if activeShellInstr != nil {
+		return r.buildShellModifyFixFromCmd(p.file, p.sm, activeShellInstr, priority, needStop, needNative)
 	}
 
-	// No SHELL instruction found: insert one after FROM.
+	// No SHELL instruction precedes this RUN: insert one after FROM.
 	return r.buildShellInsertFix(p.file, p.sm, p.info, priority, needStop, needNative)
-}
-
-func findPowerShellInstruction(commands []instructions.Command) *instructions.ShellCommand {
-	for _, cmd := range commands {
-		sc, ok := cmd.(*instructions.ShellCommand)
-		if !ok || len(sc.Shell) == 0 {
-			continue
-		}
-		if shellutil.VariantFromShellCmd(sc.Shell).IsPowerShell() {
-			return sc
-		}
-	}
-	return nil
 }
 
 func (r *ErrorActionPreferenceRule) buildShellModifyFixFromCmd(

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -339,9 +339,12 @@ func shellPreludeStateFromCmd(shellCmd []string) (hasStop, hasNative bool) {
 		return false, false
 	}
 
-	joined := strings.ToLower(strings.Join(shellCmd[1:], " "))
-	hasStop = strings.Contains(joined, "$erroractionpreference") && strings.Contains(joined, "stop")
-	hasNative = strings.Contains(joined, "$psnativecommanduseerroractionpreference") && strings.Contains(joined, "true")
+	// The prelude lives in the last SHELL arg (e.g., the string after
+	// "-Command"). Parse it with the same assignment-based logic used for
+	// script bodies so we don't misclassify unrelated tokens like
+	// "Stop-Process" or a stray "$true".
+	script := shellCmd[len(shellCmd)-1]
+	hasStop, hasNative, _ = scanScriptPrelude(script)
 	return hasStop, hasNative
 }
 

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -348,14 +348,21 @@ func shellPreludeStateFromCmd(shellCmd []string) (hasStop, hasNative bool) {
 	return hasStop, hasNative
 }
 
-// scanScriptPrelude checks the PowerShell script body for prelude assignments.
+// scanScriptPrelude checks the leading PowerShell assignments in a script body.
+// It stops at the first non-assignment statement so that preferences set after
+// commands (e.g., `Invoke-WebRequest ...; $ErrorActionPreference = 'Stop'`) are
+// not treated as a prelude -- the risky command already ran before fail-fast was
+// enabled.
 func scanScriptPrelude(script string) (hasStop, hasNative, hasWrongStop bool) {
 	stmts := shellutil.ExtractChainedCommands(script, shellutil.VariantPowerShell)
 	for _, stmt := range stmts {
 		trimmed := strings.TrimSpace(stmt)
+		if trimmed == "" {
+			continue
+		}
 		name, value, ok := shellutil.PowerShellAssignment(trimmed)
 		if !ok {
-			continue
+			break // first non-assignment ends the prelude
 		}
 
 		switch {

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -121,12 +121,18 @@ func (r *ErrorActionPreferenceRule) checkStage(
 ) []rules.Violation {
 	var violations []rules.Violation
 
+	// Track whether a stage-level SHELL fix has already been emitted so that
+	// multiple RUN violations in the same stage don't produce duplicate edits
+	// on the same SHELL instruction.
+	stageFixEmitted := false
+
 	// Track the effective SHELL args through the stage to detect prelude.
 	activeShellCmd := initialStageShellCmd(input.Semantic, stageIdx)
 
 	for _, cmd := range stage.Commands {
 		if sc, ok := cmd.(*instructions.ShellCommand); ok && len(sc.Shell) > 0 {
 			activeShellCmd = sc.Shell
+			stageFixEmitted = false // new SHELL resets tracking
 			continue
 		}
 
@@ -137,6 +143,18 @@ func (r *ErrorActionPreferenceRule) checkStage(
 
 		v := r.checkRun(params, run, run.CmdLine[0], activeShellCmd)
 		if v != nil {
+			// Suppress duplicate stage-level SHELL fixes. When multiple
+			// RUNs in the same SHELL-based stage trigger, only the first
+			// violation carries the SHELL edit; the rest report without a
+			// fix to avoid overlapping edits on the same SHELL line.
+			// Wrapper fixes (explicit powershell -Command) are per-RUN
+			// body insertions and are never suppressed.
+			variant := shellutil.VariantFromShellCmd(activeShellCmd)
+			if v.SuggestedFix != nil && variant.IsPowerShell() && stageFixEmitted {
+				v.SuggestedFix = nil
+			} else if v.SuggestedFix != nil && variant.IsPowerShell() {
+				stageFixEmitted = true
+			}
 			violations = append(violations, *v)
 		}
 	}

--- a/internal/rules/tally/powershell/error_action_preference_test.go
+++ b/internal/rules/tally/powershell/error_action_preference_test.go
@@ -285,6 +285,14 @@ func TestScanScriptPrelude(t *testing.T) {
 			script:        "$ErrorActionPreference = 'Continue'; Install-Module PSReadLine -Force",
 			wantWrongStop: true,
 		},
+		{
+			name:   "assignment after command is not prelude",
+			script: "Invoke-WebRequest https://example.com; $ErrorActionPreference = 'Stop'",
+		},
+		{
+			name:   "native after command is not prelude",
+			script: "Write-Host hi; $PSNativeCommandUseErrorActionPreference = $true",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rules/tally/powershell/error_action_preference_test.go
+++ b/internal/rules/tally/powershell/error_action_preference_test.go
@@ -216,6 +216,24 @@ func TestShellPreludeState(t *testing.T) {
 			wantStop:   false,
 			wantNative: true,
 		},
+		{
+			name: "false positive: Stop-Process not ErrorActionPreference",
+			shellArgs: []string{
+				"pwsh", "-Command",
+				"$ErrorActionPreference = 'Continue'; Stop-Process -Name foo",
+			},
+			wantStop:   false,
+			wantNative: false,
+		},
+		{
+			name: "false positive: unrelated $true not native preference",
+			shellArgs: []string{
+				"pwsh", "-Command",
+				"$ErrorActionPreference = 'Stop'; $someFlag = $true",
+			},
+			wantStop:   true,
+			wantNative: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rules/tally/powershell/error_action_preference_test.go
+++ b/internal/rules/tally/powershell/error_action_preference_test.go
@@ -1,0 +1,332 @@
+package powershell
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestErrorActionPreferenceRule_Metadata(t *testing.T) {
+	t.Parallel()
+	snaps.MatchStandaloneJSON(t, NewErrorActionPreferenceRule().Metadata())
+}
+
+func TestErrorActionPreferenceRule_DefaultConfig(t *testing.T) {
+	t.Parallel()
+	snaps.MatchStandaloneJSON(t, DefaultErrorActionPreferenceConfig())
+}
+
+func TestErrorActionPreferenceRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewErrorActionPreferenceRule(), []testutil.RuleTestCase{
+		// === No violations ===
+		{
+			Name: "single-command powershell RUN (default min-statements=2)",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-powershell stage",
+			Content: `FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y curl
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "SHELL with full prelude and multi-command RUN",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+RUN Install-Module PSReadLine -Force; Write-Host done
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "script body includes both preludes",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN $ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; Install-Module PSReadLine -Force; Write-Host done
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "explicit wrapper with both preludes in script",
+			Content: "FROM ubuntu:22.04\n" +
+				"RUN pwsh -Command \"$ErrorActionPreference = 'Stop'; " +
+				"$PSNativeCommandUseErrorActionPreference = $true; " +
+				"Install-Module PSReadLine -Force; Write-Host done\"\n",
+			WantViolations: 0,
+		},
+		{
+			Name: "single explicit wrapper (below default threshold)",
+			Content: `FROM ubuntu:22.04
+RUN pwsh -Command Install-Module PSReadLine -Force
+`,
+			WantViolations: 0,
+		},
+
+		// === Violations ===
+		{
+			Name: "multi-command PS RUN missing both preludes",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force; Write-Host done
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "SHELL without prelude and multi-command RUN",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force; Invoke-WebRequest https://example.com -OutFile /tmp/file.zip
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "explicit pwsh wrapper with multi-statement script",
+			Content: `FROM ubuntu:22.04
+RUN pwsh -Command "Install-Module PSReadLine -Force; Write-Host done"
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "linux stage with pwsh multi-commands (cross-platform)",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force; Install-Module Az -Force
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ErrorActionPreference set to Continue (wrong value)",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN $ErrorActionPreference = 'Continue'; Install-Module PSReadLine -Force; Write-Host done
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "has Stop but missing PSNativeCommandUseErrorActionPreference",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN $ErrorActionPreference = 'Stop'; Install-Module PSReadLine -Force; Write-Host done
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "SHELL has Stop but no native preference",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
+RUN Install-Module PSReadLine -Force; Write-Host done
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "multiple RUNs in same stage each trigger",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force; Write-Host one
+RUN Install-Module Az -Force; Write-Host two
+`,
+			WantViolations: 2,
+		},
+		{
+			Name: "windows stage with powershell wrapper",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN powershell -Command "Install-Module PSReadLine -Force; Write-Host done"
+`,
+			WantViolations: 1,
+		},
+	})
+}
+
+func TestErrorActionPreferenceRule_CheckWithConfig(t *testing.T) {
+	t.Parallel()
+
+	minOne := 1
+	testutil.RunRuleTests(t, NewErrorActionPreferenceRule(), []testutil.RuleTestCase{
+		{
+			Name: "single-command with min-statements=1 triggers",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force
+`,
+			Config:         &ErrorActionPreferenceConfig{MinStatements: &minOne},
+			WantViolations: 1,
+		},
+		{
+			Name: "single-command with min-statements=1 and prelude is clean",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+RUN Install-Module PSReadLine -Force
+`,
+			Config:         &ErrorActionPreferenceConfig{MinStatements: &minOne},
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestShellPreludeState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		shellArgs  []string
+		wantStop   bool
+		wantNative bool
+	}{
+		{
+			name:       "nil shell args",
+			shellArgs:  nil,
+			wantStop:   false,
+			wantNative: false,
+		},
+		{
+			name:       "just executable",
+			shellArgs:  []string{"pwsh"},
+			wantStop:   false,
+			wantNative: false,
+		},
+		{
+			name:       "only -Command flag",
+			shellArgs:  []string{"pwsh", "-Command"},
+			wantStop:   false,
+			wantNative: false,
+		},
+		{
+			name:       "full prelude",
+			shellArgs:  []string{"pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"},
+			wantStop:   true,
+			wantNative: true,
+		},
+		{
+			name:       "only Stop",
+			shellArgs:  []string{"pwsh", "-Command", "$ErrorActionPreference = 'Stop';"},
+			wantStop:   true,
+			wantNative: false,
+		},
+		{
+			name:       "only native",
+			shellArgs:  []string{"pwsh", "-Command", "$PSNativeCommandUseErrorActionPreference = $true;"},
+			wantStop:   false,
+			wantNative: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotStop, gotNative := shellPreludeStateFromCmd(tt.shellArgs)
+			if gotStop != tt.wantStop {
+				t.Errorf("shellPreludeState() stop = %v, want %v", gotStop, tt.wantStop)
+			}
+			if gotNative != tt.wantNative {
+				t.Errorf("shellPreludeState() native = %v, want %v", gotNative, tt.wantNative)
+			}
+		})
+	}
+}
+
+func TestScanScriptPrelude(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		script        string
+		wantStop      bool
+		wantNative    bool
+		wantWrongStop bool
+	}{
+		{
+			name:   "no prelude",
+			script: "Install-Module PSReadLine -Force; Write-Host done",
+		},
+		{
+			name:     "has Stop",
+			script:   "$ErrorActionPreference = 'Stop'; Install-Module PSReadLine -Force",
+			wantStop: true,
+		},
+		{
+			name:       "has native",
+			script:     "$PSNativeCommandUseErrorActionPreference = $true; Install-Module PSReadLine -Force",
+			wantNative: true,
+		},
+		{
+			name:       "has both",
+			script:     "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; Install-Module PSReadLine -Force",
+			wantStop:   true,
+			wantNative: true,
+		},
+		{
+			name:          "wrong Stop value",
+			script:        "$ErrorActionPreference = 'Continue'; Install-Module PSReadLine -Force",
+			wantWrongStop: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotStop, gotNative, gotWrongStop := scanScriptPrelude(tt.script)
+			if gotStop != tt.wantStop {
+				t.Errorf("scanScriptPrelude() stop = %v, want %v", gotStop, tt.wantStop)
+			}
+			if gotNative != tt.wantNative {
+				t.Errorf("scanScriptPrelude() native = %v, want %v", gotNative, tt.wantNative)
+			}
+			if gotWrongStop != tt.wantWrongStop {
+				t.Errorf("scanScriptPrelude() wrongStop = %v, want %v", gotWrongStop, tt.wantWrongStop)
+			}
+		})
+	}
+}
+
+func TestBuildViolationMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		hasStop      bool
+		hasNative    bool
+		hasWrongStop bool
+		wantMsg      string
+	}{
+		{
+			name:    "both missing",
+			wantMsg: "PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true",
+		},
+		{
+			name:         "both missing with wrong Stop",
+			hasWrongStop: true,
+			wantMsg:      "PowerShell RUN sets $ErrorActionPreference to a non-Stop value and is missing $PSNativeCommandUseErrorActionPreference",
+		},
+		{
+			name:      "only Stop missing",
+			hasNative: true,
+			wantMsg:   "PowerShell RUN is missing $ErrorActionPreference = 'Stop'",
+		},
+		{
+			name:    "only native missing",
+			hasStop: true,
+			wantMsg: "PowerShell RUN is missing $PSNativeCommandUseErrorActionPreference = $true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotMsg, gotDetail := buildViolationMessage(tt.hasStop, tt.hasNative, tt.hasWrongStop)
+			if gotMsg != tt.wantMsg {
+				t.Errorf("got message %q, want %q", gotMsg, tt.wantMsg)
+			}
+			if gotDetail == "" {
+				t.Error("expected non-empty detail")
+			}
+		})
+	}
+}

--- a/internal/rules/tally/powershell/error_action_preference_test.go
+++ b/internal/rules/tally/powershell/error_action_preference_test.go
@@ -171,6 +171,62 @@ RUN Install-Module PSReadLine -Force
 	})
 }
 
+func TestErrorActionPreferenceRule_OverlapWithPreferShellInstruction(t *testing.T) {
+	t.Parallel()
+
+	// When prefer-shell-instruction's fix has been applied, the SHELL
+	// instruction carries the full prelude. error-action-preference must
+	// not fire in this case.
+	testutil.RunRuleTests(t, NewErrorActionPreferenceRule(), []testutil.RuleTestCase{
+		{
+			Name: "SHELL with full prelude from prefer-shell-instruction fix",
+			Content: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				`SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; ` +
+				`$PSNativeCommandUseErrorActionPreference = $true; ` +
+				`$ProgressPreference = 'SilentlyContinue';"]` + "\n" +
+				"RUN Install-Module PSReadLine -Force; Write-Host done\n",
+			WantViolations: 0,
+		},
+		{
+			Name: "SHELL with partial prelude still triggers for missing native",
+			Content: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				`SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]` + "\n" +
+				"RUN Install-Module PSReadLine -Force; Write-Host done\n",
+			WantViolations: 1,
+		},
+	})
+}
+
+func TestErrorActionPreferenceRule_OverlapWithPreferRunHeredoc(t *testing.T) {
+	t.Parallel()
+
+	// prefer-run-heredoc converts multi-statement RUNs to heredoc syntax and
+	// injects the prelude in the heredoc body. However, rules check the
+	// original source, so error-action-preference should still fire on the
+	// pre-heredoc form (heredoc conversion happens at fix time, not detection).
+	testutil.RunRuleTests(t, NewErrorActionPreferenceRule(), []testutil.RuleTestCase{
+		{
+			Name: "multi-command RUN eligible for heredoc still triggers",
+			Content: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				`SHELL ["pwsh", "-Command"]` + "\n" +
+				"RUN Install-Module PSReadLine -Force; Write-Host done\n",
+			WantViolations: 1,
+		},
+		{
+			Name: "heredoc RUN with prelude already present does not trigger",
+			Content: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				`SHELL ["pwsh", "-Command"]` + "\n" +
+				"RUN <<EOF\n" +
+				"$ErrorActionPreference = 'Stop'\n" +
+				"$PSNativeCommandUseErrorActionPreference = $true\n" +
+				"Install-Module PSReadLine -Force\n" +
+				"Write-Host done\n" +
+				"EOF\n",
+			WantViolations: 0,
+		},
+	})
+}
+
 func TestShellPreludeState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/powershell/prefer_shell_instruction.go
+++ b/internal/rules/tally/powershell/prefer_shell_instruction.go
@@ -1107,25 +1107,13 @@ func sourceRangeEdit(file, source string, startLine, byteStart, byteEnd int, new
 		return nil
 	}
 
-	startLineOffset, startCol := byteToLineCol(source, byteStart)
-	endLineOffset, endCol := byteToLineCol(source, byteEnd)
+	startLineOffset, startCol := sourcemap.ByteToLineCol(source, byteStart)
+	endLineOffset, endCol := sourcemap.ByteToLineCol(source, byteEnd)
 
 	return &rules.TextEdit{
 		Location: rules.NewRangeLocation(file, startLine+startLineOffset, startCol, startLine+endLineOffset, endCol),
 		NewText:  newText,
 	}
-}
-
-func byteToLineCol(s string, offset int) (int, int) {
-	line := 0
-	lineStart := 0
-	for i := range offset {
-		if s[i] == '\n' {
-			line++
-			lineStart = i + 1
-		}
-	}
-	return line, offset - lineStart
 }
 
 func parseExplicitPowerShellInvocation(script string) (explicitPowerShellInvocation, bool) {

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -452,26 +452,13 @@ func sourceRangeEdit(file, sourceFull string, startLine, byteStart, byteEnd int,
 	}
 
 	// Convert byte offsets to line:col positions.
-	sLine, sCol := byteToLineCol(sourceFull, byteStart)
-	eLine, eCol := byteToLineCol(sourceFull, byteEnd)
+	sLine, sCol := sourcemap.ByteToLineCol(sourceFull, byteStart)
+	eLine, eCol := sourcemap.ByteToLineCol(sourceFull, byteEnd)
 
 	return &rules.TextEdit{
 		Location: rules.NewRangeLocation(file, startLine+sLine, sCol, startLine+eLine, eCol),
 		NewText:  newText,
 	}
-}
-
-// byteToLineCol converts a byte offset in a string to (line, col) where line is 0-based.
-func byteToLineCol(s string, offset int) (int, int) {
-	line := 0
-	lineStart := 0
-	for i := range offset {
-		if s[i] == '\n' {
-			line++
-			lineStart = i + 1
-		}
-	}
-	return line, offset - lineStart
 }
 
 // collectNewMounts returns mounts in merged that are entirely new (no existing

--- a/internal/semantic/base_image_os_test.go
+++ b/internal/semantic/base_image_os_test.go
@@ -238,6 +238,72 @@ func TestBuilderRealWorldPowerShellAlpineFixtureStaysLinux(t *testing.T) {
 	}
 }
 
+func TestBuilderPowerShellImageSetsShellVariant(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		content     string
+		wantOS      BaseImageOS
+		wantVariant shell.Variant
+		wantExe     string
+	}{
+		{
+			name:        "linux powershell ubuntu",
+			content:     "FROM mcr.microsoft.com/powershell:ubuntu-22.04\nRUN Write-Host hi\n",
+			wantOS:      BaseImageOSLinux,
+			wantVariant: shell.VariantPowerShell,
+			wantExe:     "pwsh",
+		},
+		{
+			name:        "linux powershell alpine",
+			content:     "FROM mcr.microsoft.com/powershell:lts-alpine-3.17\nRUN Write-Host hi\n",
+			wantOS:      BaseImageOSLinux,
+			wantVariant: shell.VariantPowerShell,
+			wantExe:     "pwsh",
+		},
+		{
+			name:        "windows powershell nanoserver",
+			content:     "FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022\nRUN Write-Host hi\n",
+			wantOS:      BaseImageOSWindows,
+			wantVariant: shell.VariantPowerShell,
+			wantExe:     "powershell",
+		},
+		{
+			name: "explicit SHELL overrides powershell image default",
+			content: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"SHELL [\"/bin/bash\", \"-c\"]\nRUN echo hi\n",
+			wantOS:      BaseImageOSLinux,
+			wantVariant: shell.VariantBash,
+			wantExe:     "/bin/bash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pr := parseDockerfile(t, tt.content)
+			model := NewModel(pr, nil, "Dockerfile")
+
+			info := model.StageInfo(0)
+			if info == nil {
+				t.Fatal("expected stage info")
+			}
+			if info.BaseImageOS != tt.wantOS {
+				t.Fatalf("BaseImageOS = %v, want %v", info.BaseImageOS, tt.wantOS)
+			}
+			// Check initial shell variant (before any mid-stage SHELL).
+			if info.ShellSetting.Variant != tt.wantVariant {
+				t.Fatalf("ShellSetting.Variant = %v, want %v", info.ShellSetting.Variant, tt.wantVariant)
+			}
+			if len(info.ShellSetting.Shell) > 0 && info.ShellSetting.Shell[0] != tt.wantExe {
+				t.Fatalf("ShellSetting.Shell[0] = %q, want %q", info.ShellSetting.Shell[0], tt.wantExe)
+			}
+		})
+	}
+}
+
 func TestBuilderResolvesBaseImageArgsForShellHeuristics(t *testing.T) {
 	t.Parallel()
 

--- a/internal/semantic/builder.go
+++ b/internal/semantic/builder.go
@@ -111,6 +111,24 @@ func (b *Builder) Build() *Model {
 			}
 		}
 
+		// Known PowerShell images (mcr.microsoft.com/powershell:*) ship with
+		// pwsh as the default shell. Set it before the POSIX refinement so
+		// PowerShell takes priority. On Windows PowerShell images the shell
+		// executable is "powershell" (Windows PowerShell); on Linux it is "pwsh".
+		if info.ShellSetting.Source == ShellSourceDefault &&
+			isPowerShellImageName(effectiveBaseName) {
+			exe := "pwsh"
+			if info.BaseImageOS == BaseImageOSWindows {
+				exe = windowsPowerShellExe
+			}
+			info.ShellSetting = ShellSetting{
+				Shell:   []string{exe, "-Command"},
+				Variant: shell.VariantPowerShell,
+				Source:  ShellSourceDefault,
+				Line:    -1,
+			}
+		}
+
 		// Refine the default shell variant for Linux distros whose /bin/sh
 		// is a strict POSIX shell (dash or ash) rather than bash.
 		// The default is VariantBash (correct for most distros); narrow to
@@ -461,7 +479,7 @@ func (b *Builder) processShellCommand(c *instructions.ShellCommand, info *StageI
 	// pwsh is cross-platform and must not imply Windows on its own.
 	if info.BaseImageOS == BaseImageOSUnknown && len(shellCmd) > 0 {
 		switch shell.NormalizeShellExecutableName(shellCmd[0]) {
-		case windowsCmdShellName, "powershell":
+		case windowsCmdShellName, windowsPowerShellExe:
 			info.BaseImageOS = BaseImageOSWindows
 		}
 	}

--- a/internal/semantic/stage_info.go
+++ b/internal/semantic/stage_info.go
@@ -75,6 +75,13 @@ const defaultWindowsShellExe = "cmd" //nolint:customlint // not a Dockerfile CMD
 // windowsCmdShellName is the normalized executable name for the Windows cmd shell.
 const windowsCmdShellName = "cmd" //nolint:customlint // executable name, not Dockerfile CMD instruction
 
+// windowsPowerShellExe is the Windows PowerShell executable name.
+const windowsPowerShellExe = "powershell"
+
+// mcrDomain is the Microsoft Container Registry domain used for Windows,
+// .NET, and PowerShell base images.
+const mcrDomain = "mcr.microsoft.com"
+
 // DefaultWindowsShell returns the default shell for Windows containers.
 // Returns a fresh copy to avoid mutation.
 func DefaultWindowsShell() []string {
@@ -330,7 +337,7 @@ func detectBaseImageOS(baseName, platform string) BaseImageOS {
 func isWindowsImageName(lower string) bool {
 	domain, repoPath, tag := parseImageRef(lower)
 
-	if domain != "mcr.microsoft.com" {
+	if domain != mcrDomain {
 		return false
 	}
 
@@ -373,7 +380,7 @@ func isLinuxImageName(lower string) bool {
 	}
 
 	// MCR Linux images (dotnet on Linux, powershell on Linux)
-	if domain == "mcr.microsoft.com" {
+	if domain == mcrDomain {
 		if strings.HasPrefix(repoPath, "dotnet/") || strings.HasPrefix(repoPath, "powershell") {
 			if !strings.Contains(tag, "nanoserver") && !strings.Contains(tag, "windowsservercore") {
 				return true
@@ -414,6 +421,15 @@ func IsDashDefaultShell(baseName string) bool {
 var dashDefaultDistros = map[string]bool{
 	"debian": true,
 	"ubuntu": true,
+}
+
+// isPowerShellImageName reports whether the image is a known PowerShell image
+// (e.g., mcr.microsoft.com/powershell:*). These images ship with pwsh as the
+// entrypoint regardless of the underlying OS (Linux or Windows).
+func isPowerShellImageName(baseName string) bool {
+	lower := strings.ToLower(baseName)
+	domain, repoPath, _ := parseImageRef(lower)
+	return domain == mcrDomain && (repoPath == windowsPowerShellExe || strings.HasPrefix(repoPath, windowsPowerShellExe+"/"))
 }
 
 // baseImageShortName extracts the short repository name from a base image
@@ -512,7 +528,7 @@ func addInstructionOSHeuristics(cmd instructions.Command, windowsScore, linuxSco
 
 func addShellSignalScore(shellName string, windowsScore, linuxScore *int) {
 	switch shell.NormalizeShellExecutableName(shellName) {
-	case windowsCmdShellName, "powershell":
+	case windowsCmdShellName, windowsPowerShellExe:
 		*windowsScore += 6
 	case "sh", "bash", "dash", "ash", "zsh", "ksh", "mksh":
 		*linuxScore += 6

--- a/internal/sourcemap/sourcemap.go
+++ b/internal/sourcemap/sourcemap.go
@@ -124,6 +124,25 @@ func (sm *SourceMap) SnippetAround(line, before, after int) string {
 	return sm.Snippet(startLine, endLine)
 }
 
+// ByteToLineCol converts a byte offset within a text string to a 0-based
+// (lineOffset, column) pair. lineOffset is relative to the start of the text
+// (not an absolute Dockerfile line number). Callers typically add a base line
+// number to get an absolute position:
+//
+//	lineOff, col := sourcemap.ByteToLineCol(source, bytePos)
+//	absLine := instructionStartLine + lineOff
+func ByteToLineCol(s string, offset int) (lineOffset, col int) {
+	line := 0
+	lineStart := 0
+	for i := range offset {
+		if s[i] == '\n' {
+			line++
+			lineStart = i + 1
+		}
+	}
+	return line, offset - lineStart
+}
+
 // Source returns the raw source content.
 // The returned slice should not be modified.
 func (sm *SourceMap) Source() []byte {

--- a/internal/sourcemap/sourcemap.go
+++ b/internal/sourcemap/sourcemap.go
@@ -132,6 +132,13 @@ func (sm *SourceMap) SnippetAround(line, before, after int) string {
 //	lineOff, col := sourcemap.ByteToLineCol(source, bytePos)
 //	absLine := instructionStartLine + lineOff
 func ByteToLineCol(s string, offset int) (lineOffset, col int) {
+	if offset <= 0 {
+		return 0, 0
+	}
+	if offset > len(s) {
+		offset = len(s)
+	}
+
 	line := 0
 	lineStart := 0
 	for i := range offset {

--- a/internal/sourcemap/sourcemap_test.go
+++ b/internal/sourcemap/sourcemap_test.go
@@ -314,3 +314,39 @@ func TestSource(t *testing.T) {
 		t.Errorf("Source() = %q, want %q", string(got), string(source))
 	}
 }
+
+func TestByteToLineCol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		s        string
+		offset   int
+		wantLine int
+		wantCol  int
+	}{
+		{name: "start of string", s: "hello\nworld", offset: 0, wantLine: 0, wantCol: 0},
+		{name: "mid first line", s: "hello\nworld", offset: 3, wantLine: 0, wantCol: 3},
+		{name: "at newline", s: "hello\nworld", offset: 5, wantLine: 0, wantCol: 5},
+		{name: "start of second line", s: "hello\nworld", offset: 6, wantLine: 1, wantCol: 0},
+		{name: "mid second line", s: "hello\nworld", offset: 8, wantLine: 1, wantCol: 2},
+		{name: "end of string", s: "hello\nworld", offset: 11, wantLine: 1, wantCol: 5},
+		{name: "three lines", s: "a\nbb\nccc", offset: 7, wantLine: 2, wantCol: 2},
+		{name: "negative offset clamped", s: "hello", offset: -1, wantLine: 0, wantCol: 0},
+		{name: "zero offset", s: "hello", offset: 0, wantLine: 0, wantCol: 0},
+		{name: "offset beyond length clamped", s: "hello", offset: 100, wantLine: 0, wantCol: 5},
+		{name: "empty string zero", s: "", offset: 0, wantLine: 0, wantCol: 0},
+		{name: "empty string positive", s: "", offset: 5, wantLine: 0, wantCol: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotLine, gotCol := ByteToLineCol(tt.s, tt.offset)
+			if gotLine != tt.wantLine || gotCol != tt.wantCol {
+				t.Errorf("ByteToLineCol(%q, %d) = (%d, %d), want (%d, %d)",
+					tt.s, tt.offset, gotLine, gotCol, tt.wantLine, tt.wantCol)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `tally/powershell/error-action-preference` rule that warns when PowerShell RUN instructions lack `$ErrorActionPreference = 'Stop'` and/or `$PSNativeCommandUseErrorActionPreference = $true`
- Extract duplicated `byteToLineCol` into shared `sourcemap.ByteToLineCol`, deduplicating copies in `prefer_shell_instruction.go` and `prefer_package_cache_mounts.go`
- Configurable `min-statements` threshold (default 2; set to 1 for single-command coverage)

### Detection

Fires on any OS (Linux + Windows) via two paths:
- **SHELL-based**: checks SHELL args + script body for both variables
- **Explicit wrapper** (`RUN powershell -Command ...`): parses inner script

### Fix

- **Existing SHELL**: appends missing preference(s) to the last arg, or adds a new arg element
- **No SHELL**: inserts `SHELL` instruction after `FROM`
- **Explicit wrapper**: zero-width insertion at inner script start (no full rewrite)

Priority 96 (after `prefer-shell-instruction` at 95, before `prefer-run-heredoc` at 100).

### Test coverage

- 18 unit test cases (detection, config, helpers)
- 5-stage integration fixture (clean, missing-both, missing-native, explicit wrapper, single-cmd)
- 4 fix integration cases including backtick escape + multiline body

## Test plan

- [x] `go test ./...` passes
- [x] `make lint` — 0 issues
- [x] `make cpd` — clean
- [x] Fix snapshots verified: SHELL modification, SHELL insertion, zero-width wrapper insertion
- [x] Backtick escape (`# escape=`​`` ` ``) multiline cases covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PowerShell rule (tally/powershell/error-action-preference) to enforce fail-fast error handling in PowerShell RUN steps; total custom rules now 56.

* **Documentation**
  * Updated README/RULES summaries and added a detailed rule page with examples, configuration and auto-fix behavior.

* **Tests**
  * Added integration fixtures, unit tests, and updated snapshots covering linting and auto-fix scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->