### PR TITLE
fix(prefer-package-cache-mounts): preserve heredoc structure in fix edits

### DIFF
--- a/internal/integration/__snapshots__/TestFix_prefer-package-cache-mounts-apt-heredoc-mutated-plus-new-mount_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-package-cache-mounts-apt-heredoc-mutated-plus-new-mount_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:24.04
+RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked --mount=type=cache,target=/var/lib/apt,id=aptlib,sharing=locked <<EOF
+apt-get update && apt-get install -y gcc
+EOF

--- a/internal/integration/__snapshots__/TestFix_prefer-package-cache-mounts-dnf-heredoc-cleanup_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-package-cache-mounts-dnf-heredoc-cleanup_1.snap.Dockerfile
@@ -1,0 +1,5 @@
+FROM amazonlinux:2023
+RUN --mount=type=cache,target=/var/cache/dnf,id=dnf,sharing=locked <<'EOF'
+dnf -y update
+dnf -y install java-21-amazon-corretto-headless
+EOF

--- a/internal/integration/__snapshots__/TestFix_prefer-package-cache-mounts-dnf-heredoc-tab-strip-mid-cleanup_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-package-cache-mounts-dnf-heredoc-tab-strip-mid-cleanup_1.snap.Dockerfile
@@ -1,0 +1,5 @@
+FROM amazonlinux:2023
+RUN --mount=type=cache,target=/var/cache/dnf,id=dnf,sharing=locked <<-EOF
+	dnf -y update
+	dnf -y install java-21-amazon-corretto-headless
+EOF

--- a/internal/integration/__snapshots__/TestLint_prefer-package-cache-mounts_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-package-cache-mounts_1.snap.json
@@ -945,8 +945,8 @@
               {
                 "location": {
                   "end": {
-                    "column": 3,
-                    "line": 26
+                    "column": 4,
+                    "line": 23
                   },
                   "file": "testdata/prefer-package-cache-mounts/Dockerfile",
                   "start": {
@@ -954,7 +954,21 @@
                     "line": 23
                   }
                 },
-                "newText": "--mount=type=cache,target=/root/.npm,id=npm npm install\n"
+                "newText": "--mount=type=cache,target=/root/.npm,id=npm "
+              },
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 26
+                  },
+                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 25
+                  }
+                },
+                "newText": ""
               }
             ],
             "priority": 90,

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -773,6 +773,21 @@ severity = "error"
 			wantApplied: 1,
 		},
 		{
+			name: "prefer-package-cache-mounts-dnf-heredoc-cleanup",
+			input: "FROM amazonlinux:2023\n" +
+				"RUN --mount=type=cache,target=/var/cache/dnf,id=dnf <<'EOF'\n" +
+				"dnf -y update\n" +
+				"dnf -y install java-21-amazon-corretto-headless\n" +
+				"dnf clean all\n" +
+				"EOF\n",
+			args: []string{
+				"--fix-unsafe",
+				"--fix",
+				"--select", "tally/prefer-package-cache-mounts",
+			},
+			wantApplied: 1,
+		},
+		{
 			name: "prefer-package-cache-mounts-bun-install-cache-dir-env",
 			input: "FROM oven/bun:1.2\n" +
 				"ENV BUN_INSTALL_CACHE_DIR=/tmp/bun-cache\n" +

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -803,6 +803,19 @@ severity = "error"
 			wantApplied: 1,
 		},
 		{
+			name: "prefer-package-cache-mounts-apt-heredoc-mutated-plus-new-mount",
+			input: "FROM ubuntu:24.04\n" +
+				"RUN --mount=type=cache,target=/var/cache/apt,id=apt <<EOF\n" +
+				"apt-get update && apt-get install -y gcc && apt-get clean\n" +
+				"EOF\n",
+			args: []string{
+				"--fix-unsafe",
+				"--fix",
+				"--select", "tally/prefer-package-cache-mounts",
+			},
+			wantApplied: 1,
+		},
+		{
 			name: "prefer-package-cache-mounts-bun-install-cache-dir-env",
 			input: "FROM oven/bun:1.2\n" +
 				"ENV BUN_INSTALL_CACHE_DIR=/tmp/bun-cache\n" +

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -788,6 +788,21 @@ severity = "error"
 			wantApplied: 1,
 		},
 		{
+			name: "prefer-package-cache-mounts-dnf-heredoc-tab-strip-mid-cleanup",
+			input: "FROM amazonlinux:2023\n" +
+				"RUN --mount=type=cache,target=/var/cache/dnf,id=dnf <<-EOF\n" +
+				"\tdnf -y update\n" +
+				"\tdnf clean all\n" +
+				"\tdnf -y install java-21-amazon-corretto-headless\n" +
+				"EOF\n",
+			args: []string{
+				"--fix-unsafe",
+				"--fix",
+				"--select", "tally/prefer-package-cache-mounts",
+			},
+			wantApplied: 1,
+		},
+		{
 			name: "prefer-package-cache-mounts-bun-install-cache-dir-env",
 			input: "FROM oven/bun:1.2\n" +
 				"ENV BUN_INSTALL_CACHE_DIR=/tmp/bun-cache\n" +

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -254,20 +254,31 @@ func buildTailRewrite(p cacheMountEditParams, mounts []*instructions.Mount) []ru
 	}}
 }
 
-// buildMountFlagEdit replaces only the mount flags on the RUN line (from after
-// "RUN " to the start of the heredoc marker or script), preserving the heredoc
-// body verbatim. Used for heredoc RUNs when mounts are mutated.
+// buildMountFlagEdit replaces only the mount flags on the RUN instruction
+// (from after "RUN " to the start of the heredoc marker), preserving the
+// heredoc body verbatim. Used for heredoc RUNs when mounts are mutated.
+// Handles both << and <<- (tab-stripping) markers, and line continuations
+// where the marker may not be on the same line as RUN.
 func buildMountFlagEdit(p cacheMountEditParams, mounts []*instructions.Mount) []rules.TextEdit {
 	if p.sm == nil || len(p.runLoc) == 0 {
 		return nil
 	}
 	startLine := p.runLoc[0].Start.Line
 	startCol := runKeywordEndColumn(p.runLoc, p.sm)
+	endLine := p.runLoc[len(p.runLoc)-1].End.Line
 
-	// Find the heredoc marker ("<<") on the first line to know where flags end.
-	line := p.sm.Line(startLine - 1)
-	heredocIdx := strings.Index(line, "<<")
-	if heredocIdx < 0 {
+	// Search all lines of the RUN instruction for the heredoc marker ("<<" or "<<-").
+	heredocLine := -1
+	heredocCol := -1
+	for lineIdx := startLine - 1; lineIdx < endLine && lineIdx < p.sm.LineCount(); lineIdx++ {
+		line := p.sm.Line(lineIdx)
+		if col := strings.Index(line, "<<"); col >= 0 {
+			heredocLine = lineIdx + 1 // 1-based
+			heredocCol = col
+			break
+		}
+	}
+	if heredocLine < 0 {
 		return nil
 	}
 
@@ -277,7 +288,7 @@ func buildMountFlagEdit(p cacheMountEditParams, mounts []*instructions.Mount) []
 	}
 
 	return []rules.TextEdit{{
-		Location: rules.NewRangeLocation(p.file, startLine, startCol, startLine, heredocIdx),
+		Location: rules.NewRangeLocation(p.file, startLine, startCol, heredocLine, heredocCol),
 		NewText:  newFlags,
 	}}
 }

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -169,17 +169,23 @@ func buildCacheMountEdits(p cacheMountEditParams) ([]rules.TextEdit, []cacheEnvE
 
 	mutated := mountsMutated(existing, merged)
 
-	// Pre-compute cleanup edits for the non-mutated path.
+	isHeredoc := len(run.Files) > 0
+
+	// Pre-compute cleanup edits.
 	var cleanupEdits []rules.TextEdit
-	if !mutated && p.scriptCleaned {
-		cleanupEdits = computeCleanupEdits(p.file, run, runLoc, p.sm, p.shellVariant, p.cleaners)
+	if p.scriptCleaned {
+		if isHeredoc {
+			cleanupEdits = computeHeredocCleanupEdits(p.file, run, runLoc, p.sm, p.cleaners)
+		} else if !mutated {
+			cleanupEdits = computeCleanupEdits(p.file, run, runLoc, p.sm, p.shellVariant, p.cleaners)
+		}
 	}
 
 	// Will a tail rewrite be emitted? If so, the mount insertion must be skipped
 	// (the tail rewrite includes mounts via formatRunFlags). Tail rewrites happen
-	// when mounts are mutated OR when cleanup falls back to a full rewrite
-	// (e.g., heredoc RUNs where targeted cleanup edits are not available).
-	needsTailRewrite := mutated || (p.scriptCleaned && len(cleanupEdits) == 0)
+	// when mounts are mutated OR when cleanup falls back to a full rewrite.
+	// Heredoc RUNs never use tail rewrites: they use targeted mount + line edits.
+	needsTailRewrite := !isHeredoc && (mutated || (p.scriptCleaned && len(cleanupEdits) == 0))
 
 	// Edit 1: zero-length insertion for new mount flags right after "RUN ".
 	// Skipped when a tail rewrite will handle mounts to avoid overlapping edits.
@@ -194,8 +200,18 @@ func buildCacheMountEdits(p cacheMountEditParams) ([]rules.TextEdit, []cacheEnvE
 		})
 	}
 
+	// For heredoc RUNs with mutated mounts, produce a targeted mount-flag edit
+	// instead of rewriting the entire instruction.
+	if isHeredoc && mutated {
+		edits = append(edits, buildMountFlagEdit(p, merged)...)
+	}
+
 	// Edit 2+: cleanup and/or mount rewrite.
 	switch {
+	case isHeredoc:
+		// Heredoc: use line-based cleanup edits (mount handled above).
+		edits = append(edits, cleanupEdits...)
+
 	case mutated:
 		// Mount flags modified: full tail rewrite with merged mounts + cleaned script.
 		edits = append(edits, buildTailRewrite(p, merged)...)
@@ -205,7 +221,7 @@ func buildCacheMountEdits(p cacheMountEditParams) ([]rules.TextEdit, []cacheEnvE
 		edits = append(edits, cleanupEdits...)
 
 	case p.scriptCleaned:
-		// Fallback (e.g., heredoc): targeted cleanup unavailable, tail rewrite
+		// Fallback: targeted cleanup unavailable, tail rewrite
 		// with merged mounts (includes new) + cleaned script.
 		edits = append(edits, buildTailRewrite(p, merged)...)
 	}
@@ -236,6 +252,76 @@ func buildTailRewrite(p cacheMountEditParams, mounts []*instructions.Mount) []ru
 		Location: rules.NewRangeLocation(p.file, startLine, startCol, endLine, endCol),
 		NewText:  tailText,
 	}}
+}
+
+// buildMountFlagEdit replaces only the mount flags on the RUN line (from after
+// "RUN " to the start of the heredoc marker or script), preserving the heredoc
+// body verbatim. Used for heredoc RUNs when mounts are mutated.
+func buildMountFlagEdit(p cacheMountEditParams, mounts []*instructions.Mount) []rules.TextEdit {
+	if p.sm == nil || len(p.runLoc) == 0 {
+		return nil
+	}
+	startLine := p.runLoc[0].Start.Line
+	startCol := runKeywordEndColumn(p.runLoc, p.sm)
+
+	// Find the heredoc marker ("<<") on the first line to know where flags end.
+	line := p.sm.Line(startLine - 1)
+	heredocIdx := strings.Index(line, "<<")
+	if heredocIdx < 0 {
+		return nil
+	}
+
+	newFlags := formatRunFlags(p.run.FlagsUsed, mounts)
+	if newFlags != "" {
+		newFlags += " "
+	}
+
+	return []rules.TextEdit{{
+		Location: rules.NewRangeLocation(p.file, startLine, startCol, startLine, heredocIdx),
+		NewText:  newFlags,
+	}}
+}
+
+// computeHeredocCleanupEdits produces targeted line-deletion edits for cache
+// cleanup commands within a heredoc RUN body. Each cleanup line (e.g.,
+// "dnf clean all") is deleted as a whole source line.
+func computeHeredocCleanupEdits(
+	file string,
+	run *instructions.RunCommand,
+	runLoc []parser.Range,
+	sm *sourcemap.SourceMap,
+	cleaners map[cleanupKind]bool,
+) []rules.TextEdit {
+	if len(cleaners) == 0 || len(runLoc) == 0 || len(run.Files) == 0 || sm == nil {
+		return nil
+	}
+
+	startLine := runLoc[0].Start.Line
+	endLine := runLoc[len(runLoc)-1].End.Line
+
+	var edits []rules.TextEdit
+	// Iterate over the heredoc body lines (between the RUN header and the EOF delimiter).
+	// The first line is the RUN instruction itself; the last is the heredoc delimiter.
+	for lineIdx := startLine; lineIdx < endLine-1; lineIdx++ {
+		if lineIdx < 0 || lineIdx >= sm.LineCount() {
+			continue
+		}
+		line := sm.Line(lineIdx)
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if !isCacheCleanupCommand(trimmed, cleaners) {
+			continue
+		}
+		// Delete the entire line including its trailing newline.
+		// Line numbers are 1-based; delete from col 0 of this line to col 0 of the next.
+		edits = append(edits, rules.TextEdit{
+			Location: rules.NewRangeLocation(file, lineIdx+1, 0, lineIdx+2, 0),
+			NewText:  "",
+		})
+	}
+	return edits
 }
 
 func runKeywordEndColumn(runLoc []parser.Range, sm *sourcemap.SourceMap) int {

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -181,15 +181,15 @@ func buildCacheMountEdits(p cacheMountEditParams) ([]rules.TextEdit, []cacheEnvE
 		}
 	}
 
-	// Will a tail rewrite be emitted? If so, the mount insertion must be skipped
-	// (the tail rewrite includes mounts via formatRunFlags). Tail rewrites happen
-	// when mounts are mutated OR when cleanup falls back to a full rewrite.
-	// Heredoc RUNs never use tail rewrites: they use targeted mount + line edits.
+	// Skip the zero-width mount insertion when another edit already includes
+	// all mounts: tail rewrites (non-heredoc) use formatRunFlags with merged,
+	// and heredoc mount-flag edits (buildMountFlagEdit) also use merged.
 	needsTailRewrite := !isHeredoc && (mutated || (p.scriptCleaned && len(cleanupEdits) == 0))
+	skipMountInsert := needsTailRewrite || (isHeredoc && mutated)
 
 	// Edit 1: zero-length insertion for new mount flags right after "RUN ".
-	// Skipped when a tail rewrite will handle mounts to avoid overlapping edits.
-	if !needsTailRewrite && len(newMounts) > 0 {
+	// Skipped when another edit already covers all mounts.
+	if !skipMountInsert && len(newMounts) > 0 {
 		insertLine := runLoc[0].Start.Line
 		insertCol := runKeywordEndColumn(runLoc, p.sm)
 

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -175,7 +175,7 @@ func buildCacheMountEdits(p cacheMountEditParams) ([]rules.TextEdit, []cacheEnvE
 	var cleanupEdits []rules.TextEdit
 	if p.scriptCleaned {
 		if isHeredoc {
-			cleanupEdits = computeHeredocCleanupEdits(p.file, run, runLoc, p.sm, p.cleaners)
+			cleanupEdits = computeHeredocCleanupEdits(p.file, run, runLoc, p.sm, p.shellVariant, p.cleaners)
 		} else if !mutated {
 			cleanupEdits = computeCleanupEdits(p.file, run, runLoc, p.sm, p.shellVariant, p.cleaners)
 		}
@@ -293,14 +293,17 @@ func buildMountFlagEdit(p cacheMountEditParams, mounts []*instructions.Mount) []
 	}}
 }
 
-// computeHeredocCleanupEdits produces targeted line-deletion edits for cache
-// cleanup commands within a heredoc RUN body. Each cleanup line (e.g.,
-// "dnf clean all") is deleted as a whole source line.
+// computeHeredocCleanupEdits produces targeted edits for cache cleanup commands
+// within a heredoc RUN body. Handles three cases per line:
+//  1. Standalone cleanup (e.g., "dnf clean all") → delete the entire line.
+//  2. Chained with && (e.g., "dnf update && dnf clean all") → replace line with cleaned chain.
+//  3. No-cache flags (e.g., "pip install --no-cache-dir ...") → replace line with flags stripped.
 func computeHeredocCleanupEdits(
 	file string,
 	run *instructions.RunCommand,
 	runLoc []parser.Range,
 	sm *sourcemap.SourceMap,
+	variant shell.Variant,
 	cleaners map[cleanupKind]bool,
 ) []rules.TextEdit {
 	if len(cleaners) == 0 || len(runLoc) == 0 || len(run.Files) == 0 || sm == nil {
@@ -322,15 +325,41 @@ func computeHeredocCleanupEdits(
 		if trimmed == "" {
 			continue
 		}
-		if !isCacheCleanupCommand(trimmed, cleaners) {
+
+		// Line numbers are 1-based.
+		lineNo := lineIdx + 1
+
+		// Case 1: entire line is a cleanup command → delete line.
+		if isCacheCleanupCommand(trimmed, cleaners) {
+			edits = append(edits, rules.TextEdit{
+				Location: rules.NewRangeLocation(file, lineNo, 0, lineNo+1, 0),
+				NewText:  "",
+			})
 			continue
 		}
-		// Delete the entire line including its trailing newline.
-		// Line numbers are 1-based; delete from col 0 of this line to col 0 of the next.
-		edits = append(edits, rules.TextEdit{
-			Location: rules.NewRangeLocation(file, lineIdx+1, 0, lineIdx+2, 0),
-			NewText:  "",
-		})
+
+		// Case 2: line contains && chains with cleanup commands mixed in.
+		if strings.Contains(trimmed, "&&") {
+			updated, changed := removeCacheCleanupFromChain(trimmed, variant, cleaners)
+			if changed {
+				indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+				edits = append(edits, rules.TextEdit{
+					Location: rules.NewRangeLocation(file, lineNo, 0, lineNo+1, 0),
+					NewText:  indent + updated + "\n",
+				})
+			}
+			continue
+		}
+
+		// Case 3: no-cache flags on a single command.
+		updated, changed := stripNoCacheFlags(trimmed, variant, cleaners)
+		if changed {
+			indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+			edits = append(edits, rules.TextEdit{
+				Location: rules.NewRangeLocation(file, lineNo, 0, lineNo+1, 0),
+				NewText:  indent + updated + "\n",
+			})
+		}
 	}
 	return edits
 }

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -331,6 +331,10 @@ func runKeywordEndColumn(runLoc []parser.Range, sm *sourcemap.SourceMap) int {
 
 	if sm != nil && runLoc[0].Start.Line > 0 {
 		line := sm.Line(runLoc[0].Start.Line - 1)
+		// Search for "RUN " in the line to handle both plain RUN and ONBUILD RUN.
+		if idx := strings.Index(strings.ToUpper(line), "RUN "); idx >= 0 {
+			return idx + 4 //nolint:mnd // len("RUN ")
+		}
 		return len(leadingWhitespace(line)) + 4 //nolint:mnd // len("RUN ")
 	}
 


### PR DESCRIPTION
## Summary

- Fix `--fix` producing broken Dockerfiles for heredoc RUN instructions with cache mounts. The tail-rewrite path flattened `<<'EOF'`/`EOF` markers into plain text.
- Replace destructive tail rewrite for heredoc RUNs with targeted edits: `buildMountFlagEdit` (mount flags only) and `computeHeredocCleanupEdits` (line-based cleanup deletion).
- Add fix test case for dnf heredoc with existing cache mount and `dnf clean all`.

## Test plan

- [x] New integration fix test `prefer-package-cache-mounts-dnf-heredoc-cleanup` passes
- [x] Existing lint snapshot for heredoc case updated to reflect targeted edits
- [x] Full `TestFix` and `TestLint` integration suites pass
- [x] Unit tests for `TestPreferPackageCacheMountsRule_Check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of heredoc-based RUN commands in Dockerfiles for package cache mount optimization, including proper cleanup of cache commands within heredoc scripts.

* **Tests**
  * Added integration test coverage for heredoc-based package manager commands with cache mount detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->