### PR TITLE
feat(powershell): add progress-preference rule

### DIFF
--- a/_docs/docs.json
+++ b/_docs/docs.json
@@ -140,7 +140,8 @@
             "group": "PowerShell",
             "pages": [
               "rules/tally/powershell/error-action-preference",
-              "rules/tally/powershell/prefer-shell-instruction"
+              "rules/tally/powershell/prefer-shell-instruction",
+              "rules/tally/powershell/progress-preference"
             ]
           },
           {

--- a/_docs/rules/tally/powershell/progress-preference.mdx
+++ b/_docs/rules/tally/powershell/progress-preference.mdx
@@ -9,7 +9,7 @@ by setting `$ProgressPreference = 'SilentlyContinue'`.
 | Property | Value |
 |----------|-------|
 | Severity | Style |
-| Category | Performance |
+| Category | Style |
 | Default | Enabled |
 | Auto-fix | Yes (`--fix --fix-unsafe`) |
 

--- a/_docs/rules/tally/powershell/progress-preference.mdx
+++ b/_docs/rules/tally/powershell/progress-preference.mdx
@@ -1,0 +1,122 @@
+---
+title: "tally/powershell/progress-preference"
+description: "Suppress PowerShell progress bars before `Invoke-WebRequest` by setting `$ProgressPreference = 'SilentlyContinue'`."
+---
+
+Suppress PowerShell progress bars before `Invoke-WebRequest` (or its alias `iwr`)
+by setting `$ProgressPreference = 'SilentlyContinue'`.
+
+| Property | Value |
+|----------|-------|
+| Severity | Style |
+| Category | Performance |
+| Default | Enabled |
+| Auto-fix | Yes (`--fix --fix-unsafe`) |
+
+## Description
+
+PowerShell's `Invoke-WebRequest` renders a per-response progress bar by default.
+On Windows containers this collapses download throughput by an order of magnitude
+because the host cannot render the bar and the cmdlet stalls waiting for terminal
+updates. Microsoft's official Windows container guidance is to set
+`$ProgressPreference = 'SilentlyContinue'` before any `Invoke-WebRequest` call.
+
+The rule fires whenever a `RUN` invokes `Invoke-WebRequest` or `iwr` without a
+preceding `$ProgressPreference = 'SilentlyContinue'` assignment. Detection
+does not depend on the stage's default shell — `Invoke-WebRequest` is a
+PowerShell-unique cmdlet, so finding it is itself the shell signal. That way the
+rule catches both SHELL-based PowerShell stages and one-off `powershell -Command`
+wrappers embedded inside bash stages.
+
+## Why this matters
+
+On Windows Server Core images specifically, users have reported
+`Invoke-WebRequest` downloads taking minutes where a `curl` or the same call
+with `$ProgressPreference = 'SilentlyContinue'` takes seconds. The progress bar
+is pure noise in a non-interactive build step.
+
+## Examples
+
+### Before (violation)
+
+```dockerfile
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Invoke-WebRequest https://example.com/file.zip -OutFile /tmp/file.zip
+```
+
+### After (fixed with `--fix --fix-unsafe`)
+
+```dockerfile
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ProgressPreference = 'SilentlyContinue';"]
+RUN Invoke-WebRequest https://example.com/file.zip -OutFile /tmp/file.zip
+```
+
+### Already clean (no violation)
+
+```dockerfile
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+RUN Invoke-WebRequest https://example.com/file.zip -OutFile /tmp/file.zip
+```
+
+### Explicit wrapper (violation)
+
+```dockerfile
+FROM ubuntu:22.04
+RUN pwsh -Command "Invoke-WebRequest https://example.com/file.zip -OutFile /tmp/file.zip"
+```
+
+The fix prepends the assignment to the inner script:
+
+```dockerfile
+FROM ubuntu:22.04
+RUN pwsh -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://example.com/file.zip -OutFile /tmp/file.zip"
+```
+
+## Fix behavior
+
+The fix adapts to where the PowerShell script lives:
+
+- **`SHELL` with bare `-Command`**: appends a new array element
+  `"$ProgressPreference = 'SilentlyContinue';"` to the `SHELL` instruction.
+- **`SHELL` with an existing prelude**: appends the assignment to the existing
+  prelude string, inserting a `;` separator if missing.
+- **No `SHELL` in a PowerShell-by-default stage**: inserts a new `SHELL`
+  instruction after the `FROM`.
+- **Explicit `powershell -Command` / `pwsh -Command` wrapper**: zero-width
+  insertion at the start of the inner script.
+- **`RUN <<EOF` heredoc body** (PowerShell stages only): inserts the assignment
+  on a new line at the start of the heredoc body.
+
+The fix uses `FixSuggestion` safety — it requires `--fix-unsafe` to apply. A
+same-SHELL-scope suppression prevents duplicate SHELL edits when multiple RUNs
+in the same stage violate.
+
+## Interaction with other rules
+
+- **`tally/powershell/prefer-shell-instruction`** (priority 95): when it
+  converts repeated `powershell -Command` wrappers to a `SHELL` instruction, its
+  prelude already contains `$ProgressPreference = 'SilentlyContinue'`. The
+  combined `--fix --fix-unsafe` run lets `prefer-shell-instruction` win;
+  `progress-preference`'s edit is dropped as overlapping.
+- **`tally/powershell/error-action-preference`** (priority 96): both rules edit
+  the `SHELL` instruction with zero-width insertions before the closing `]`.
+  When both are enabled and both trigger, both apply — the resulting `SHELL`
+  carries two complementary array elements, each with its own preamble.
+- **`tally/prefer-run-heredoc`** (priority 100): structural conversion to
+  heredoc runs after the preference is set and carries it into the heredoc
+  body.
+
+## References
+
+- [`$ProgressPreference`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables#progresspreference)
+  — Microsoft Learn: controls how PowerShell renders progress reports. Default
+  is `Continue`; `SilentlyContinue` suppresses the per-response bar.
+- [`Invoke-WebRequest`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest)
+  — Microsoft Learn: cmdlet reference documenting the progress-rendering
+  behavior.
+- [Optimize Windows Dockerfiles](https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-docker/optimize-windows-dockerfile)
+  — Microsoft Learn: Windows-container-specific Dockerfile guidance, including
+  the `$ProgressPreference` recommendation.

--- a/design-docs/PROPOSED-RULES-TRACKER.md
+++ b/design-docs/PROPOSED-RULES-TRACKER.md
@@ -1,0 +1,135 @@
+# Proposed Rules Tracker
+
+Rules described in design docs but **not yet implemented**.
+Cross-referenced against the 52 rules currently in `internal/rules/tally/` and `RULES.md`.
+
+> Last updated: 2026-04-03
+
+---
+
+## GPU Container Rules (`tally/gpu/*`)
+
+Source: [32-gpu-container-rules.md](32-gpu-container-rules.md)
+
+| Rule ID | Severity | Description | Notes |
+|---------|----------|-------------|-------|
+| `tally/gpu/prefer-uv-over-conda` | Info | Suggest uv over conda for GPU Python deps | |
+| `tally/gpu/require-torch-cuda-arch-list` | Info | Warn when CUDA extensions built without `TORCH_CUDA_ARCH_LIST` | |
+| `tally/gpu/hardcoded-cuda-path` | Info | Detect hardcoded `/usr/local/cuda-X.Y` paths (use `/usr/local/cuda`) | |
+| `tally/gpu/ld-library-path-overwrite` | Warning | Detect `LD_LIBRARY_PATH` overwrite without preserving existing value | |
+| `tally/gpu/deprecated-cuda-image` | Warning | Flag EOL CUDA image versions | Needs resolver for EOL data |
+| `tally/gpu/cuda-image-upgrade` | Info | Suggest patched CUDA image versions | Needs resolver for version data |
+| `tally/gpu/model-download-in-build` | Info | Warn about downloading large model artifacts in RUN | |
+
+**Already implemented (6):** `prefer-runtime-final-stage`, `no-redundant-cuda-install`, `no-container-runtime-in-image`, `no-buildtime-gpu-queries`,
+`no-hardcoded-visible-devices`, `prefer-minimal-driver-capabilities`
+
+---
+
+## STOPSIGNAL Rules
+
+Source: [33-stopsignal-rules.md](33-stopsignal-rules.md)
+
+| Rule ID | Severity | Description | Notes |
+|---------|----------|-------------|-------|
+| `tally/no-shell-wrapper-for-stopsignal` | Warning | Detect shell/opaque wrapper hiding PID 1 when STOPSIGNAL is set | |
+| `tally/prefer-nginx-sigquit` | Info | Recommend SIGQUIT for nginx/openresty images | |
+| `tally/prefer-php-fpm-sigquit` | Info | Recommend SIGQUIT for php-fpm images | |
+| `tally/prefer-postgres-sigint` | Info | Recommend SIGINT for postgres images | |
+| `tally/prefer-httpd-sigwinch` | Info | Recommend SIGWINCH for Apache httpd images | |
+
+**Already implemented (3):** `no-ungraceful-stopsignal`, `prefer-canonical-stopsignal`, `prefer-systemd-sigrtmin-plus-3`
+
+---
+
+## PHP Container Rules (`tally/php/*`)
+
+Source: [35-php-container-rules.md](35-php-container-rules.md)
+
+| Rule ID | Severity | Description | Notes |
+|---------|----------|-------------|-------|
+| `tally/php/composer-optimize-autoloader` | Warning | Detect production `composer install` without autoloader optimization | |
+| `tally/php/prefer-composer-manifest-bind-mounts` | Info | Recommend BuildKit bind mounts for composer.json/lock over COPY | |
+| `tally/php/remove-build-deps-after-extension-build` | Warning | Warn on leftover build deps after `docker-php-ext-install`/`pecl install` | |
+| `tally/php/composer-no-interaction-in-build` | Info | Detect `composer install` without `--no-interaction` | |
+| `tally/php/prefer-composer-stage` | Info | Suggest `composer:*` image instead of curl-installing composer | |
+| `tally/php/enable-opcache-in-production` | Info | Suggest enabling OPcache in production PHP runtimes | |
+| `tally/php/prefer-non-root-runtime` | Info | Suggest running as non-root (www-data) in production | |
+
+**Already implemented (1):** `composer-no-dev-in-production`
+
+---
+
+## Windows Container Rules (`tally/windows/*`)
+
+Source: [27-windows-container-rules.md](27-windows-container-rules.md)
+
+| Rule ID | Severity | Description | Notes |
+|---------|----------|-------------|-------|
+| `tally/windows/cleanup-in-same-layer` | Warning | Detect file cleanup in separate layer from download | |
+| `tally/windows/prefer-nanoserver` | Info | Recommend nanoserver over servercore for minimal runtimes | |
+
+**Already implemented (3):** `no-stopsignal`, `no-run-mounts`, `no-chown-flag`
+
+---
+
+## PowerShell Rules (`tally/powershell/*`)
+
+Source: [27-windows-container-rules.md](27-windows-container-rules.md)
+
+_All rules proposed in the design doc are implemented._
+
+**Already implemented (3):** `prefer-shell-instruction`, `error-action-preference`, `progress-preference`
+
+---
+
+## USER & Privilege Rules
+
+Source: [34-user-instructions.md](34-user-instructions.md)
+
+| Rule ID | Severity | Description | Notes |
+|---------|----------|-------------|-------|
+| `tally/user-explicit-group-drops-supplementary-groups` | Suggestion | `USER name:group` drops supplementary groups accidentally | |
+| `tally/workdir-created-under-wrong-user` | Suggestion | WORKDIR created as root then repaired with chown | |
+
+**Already implemented (4):** `stateful-root-runtime`, `user-created-but-never-used`, `copy-after-user-without-chown`,
+`world-writable-state-path-workaround`
+
+---
+
+## BuildKit Phase 2 Rules
+
+Source: [10-buildkit-phase2-path-forward.md](10-buildkit-phase2-path-forward.md),
+[buildkit-phase2-rules-research.md](buildkit-phase2-rules-research.md)
+
+| Rule ID | Severity | Description | Notes |
+|---------|----------|-------------|-------|
+| WorkdirRelativePath | Warning | Relative WORKDIR without prior absolute WORKDIR | No `tally/` prefix assigned yet |
+| SecretsUsedInArgOrEnv | Warning | Pattern match for secret tokens in ARG/ENV keys | No `tally/` prefix assigned yet |
+| RedundantTargetPlatform | Info | Unnecessary `$TARGETPLATFORM` usage | No `tally/` prefix assigned yet |
+
+---
+
+## ShellCheck Native Porting
+
+Source: [28-shellcheck-go-reimplementation-bridge-sc1040.md](28-shellcheck-go-reimplementation-bridge-sc1040.md)
+
+| Rule ID | Severity | Description | Notes |
+|---------|----------|-------------|-------|
+| `shellcheck/SC1040` | Warning | `<<-` end token can only be indented with tabs | Pilot for native Go reimplementation |
+
+---
+
+## Summary
+
+| Category | Proposed | Implemented | Remaining |
+|----------|----------|-------------|-----------|
+| GPU | 14 | 6 | **8** |
+| STOPSIGNAL | 8 | 3 | **5** |
+| PHP | 9 | 1 | **8** |
+| Windows | 6 | 3 | **3** |
+| PowerShell | 3 | 3 | **0** |
+| USER / Privilege | 7 | 4 | **3** |
+| BuildKit Phase 2 | 3 | 0 | **3** |
+| ShellCheck Native | 1 | 0 | **1** |
+| **Total** | **51** | **19** | **32** |

--- a/internal/integration/__snapshots__/TestFixPowerShellPreferShellInstruction_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixPowerShellPreferShellInstruction_1.snap.Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/powershell:ubuntu-22.04
 
-SHELL ["pwsh","-NoLogo","-NoProfile","-Command","$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-NoLogo", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
 RUN Install-Module PSReadLine -Force
 ENV POWERSHELL_TELEMETRY_OPTOUT=1
 RUN Invoke-WebRequest https://example.com/tools.zip -OutFile /tmp/tools.zip

--- a/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.Dockerfile
@@ -4,7 +4,7 @@ FROM teeks99/msvc-win:14.0
   # [tally] settings to opt out from telemetry
   ENV POWERSHELL_TELEMETRY_OPTOUT=1
 
-SHELL ["powershell", "-command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+SHELL ["powershell", "-command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ProgressPreference = 'SilentlyContinue';"]
 
 # Install Chocolatey
 RUN <<EOF

--- a/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.md
+++ b/internal/integration/__snapshots__/TestFixRealWorldBoostMSVCWindowsContainer_1.snap.md
@@ -1,9 +1,9 @@
 note: 4 slow check(s) skipped (image not found)
-Fixed 12 issues
+Fixed 13 issues
 Skipped 1 fixes
 note: 1 AI fix(es) failed (see details below)
 note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registered: ai-autofix
-**5 issues** in `<stdin>`
+**6 issues** in `<stdin>`
 
 | Line | Issue |
 |------|-------|
@@ -12,4 +12,5 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 13 | 💅 expected blank line between COPY and RUN |
 | 13 | 💅 consecutive RUN instructions can be combined using heredoc syntax |
+| 24 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
 

--- a/internal/integration/__snapshots__/TestFixRealWorldJaracoWindows_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorldJaracoWindows_1.snap.Dockerfile
@@ -10,7 +10,7 @@ ENV POWERSHELL_TELEMETRY_OPTOUT=1
 # Download the Build Tools bootstrapper.
 ADD https://aka.ms/vs/16/release/vs_buildtools.exe vs_buildtools.exe
 
-SHELL ["powershell","-Command","$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install chocolatey
 RUN <<EOF

--- a/internal/integration/__snapshots__/TestFixRealWorldMetalama_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorldMetalama_1.snap.Dockerfile
@@ -8,7 +8,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025
 ENV POWERSHELL_TELEMETRY_OPTOUT=1
 
 # The initial shell is Windows PowerShell (use full path to avoid HCS issues)
-SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;"]
+SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ProgressPreference = 'SilentlyContinue';"]
 
 # Prepare environment
 ENV PSExecutionPolicyPreference=Bypass

--- a/internal/integration/__snapshots__/TestFixTelemetryOptOutCombined_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixTelemetryOptOutCombined_1.snap.Dockerfile
@@ -39,7 +39,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS win
 # [tally] settings to opt out from telemetry
 ENV POWERSHELL_TELEMETRY_OPTOUT=1 VCPKG_DISABLE_METRICS=1
 
-	SHELL ["powershell","-Command","$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+	SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
 
 	RUN <<-EOF
 		$ErrorActionPreference = 'Stop'

--- a/internal/integration/__snapshots__/TestFixWindowsContainer_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixWindowsContainer_1.snap.Dockerfile
@@ -6,7 +6,7 @@ ENV POWERSHELL_TELEMETRY_OPTOUT=1
 # Install Chocolatey
 RUN @powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:ChocolateyUseWindowsCompression='false'; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
 
-SHELL ["powershell","-Command","$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
 
 # Install build tools
 RUN <<EOF

--- a/internal/integration/__snapshots__/TestFixWindowsContainer_1.snap.md
+++ b/internal/integration/__snapshots__/TestFixWindowsContainer_1.snap.md
@@ -1,8 +1,8 @@
 Fixed 5 issues
-Skipped 1 fixes
+Skipped 2 fixes
 note: 1 AI fix(es) failed (see details below)
 note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registered: ai-autofix
-**4 issues** in `<stdin>`
+**5 issues** in `<stdin>`
 
 | Line | Issue |
 |------|-------|
@@ -10,4 +10,5 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 4 | 💅 consecutive RUN instructions can be combined using heredoc syntax |
 | 17 | 💅 expected blank line between WORKDIR and COPY |
+| 22 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
 

--- a/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-cross-prefer-shell-instruction_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-error-action-preference-cross-prefer-shell-instruction_1.snap.Dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/powershell:ubuntu-22.04
-SHELL ["pwsh","-Command","$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
 RUN Install-Module PSReadLine -Force
 RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip

--- a/internal/integration/__snapshots__/TestFix_powershell-progress-preference-cross-error-action-preference_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-progress-preference-cross-error-action-preference_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true;", "$ProgressPreference = 'SilentlyContinue';"]
+RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip; Write-Host done

--- a/internal/integration/__snapshots__/TestFix_powershell-progress-preference-cross-prefer-shell-instruction_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-progress-preference-cross-prefer-shell-instruction_1.snap.Dockerfile
@@ -1,4 +1,4 @@
 FROM mcr.microsoft.com/powershell:ubuntu-22.04
-SHELL ["pwsh","-Command","$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
 RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip
 RUN Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip

--- a/internal/integration/__snapshots__/TestFix_powershell-progress-preference-cross-prefer-shell-instruction_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-progress-preference-cross-prefer-shell-instruction_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh","-Command","$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';"]
+RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip
+RUN Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip

--- a/internal/integration/__snapshots__/TestFix_powershell-progress-preference-explicit-wrapper_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-progress-preference-explicit-wrapper_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu:22.04
+RUN pwsh -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://example.com/c.zip -OutFile /tmp/c.zip"

--- a/internal/integration/__snapshots__/TestFix_powershell-progress-preference-missing-shell_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-progress-preference-missing-shell_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ProgressPreference = 'SilentlyContinue';"]
+RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip

--- a/internal/integration/__snapshots__/TestFix_powershell-progress-preference-no-iwr-no-fix_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-progress-preference-no-iwr-no-fix_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force

--- a/internal/integration/__snapshots__/TestFix_powershell-progress-preference-shell-has-partial_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-progress-preference-shell-has-partial_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+RUN Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip

--- a/internal/integration/__snapshots__/TestFix_powershell-progress-preference-windows-backtick_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_powershell-progress-preference-windows-backtick_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN powershell -Command `
+    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://example.com/setup.exe -OutFile C:\setup.exe

--- a/internal/integration/__snapshots__/TestLint_powershell-progress-preference_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_powershell-progress-preference_1.snap.json
@@ -1,0 +1,198 @@
+{
+  "files": [
+    {
+      "file": "testdata/powershell-progress-preference/Dockerfile",
+      "violations": [
+        {
+          "detail": "PowerShell renders a per-response progress bar for Invoke-WebRequest by default. On Windows containers this collapses download throughput by an order of magnitude. Set $ProgressPreference = 'SilentlyContinue' before the call.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/powershell/progress-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 9
+            },
+            "file": "testdata/powershell-progress-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 9
+            }
+          },
+          "message": "PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue'",
+          "rule": "tally/powershell/progress-preference",
+          "severity": "style",
+          "sourceCode": "RUN Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip",
+          "suggestedFix": {
+            "description": "Add $ProgressPreference = 'SilentlyContinue' to SHELL instruction",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 25,
+                    "line": 8
+                  },
+                  "file": "testdata/powershell-progress-preference/Dockerfile",
+                  "start": {
+                    "column": 25,
+                    "line": 8
+                  }
+                },
+                "newText": ", \"$ProgressPreference = 'SilentlyContinue';\""
+              }
+            ],
+            "priority": 97,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "PowerShell renders a per-response progress bar for Invoke-WebRequest by default. On Windows containers this collapses download throughput by an order of magnitude. Set $ProgressPreference = 'SilentlyContinue' before the call.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/powershell/progress-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 10
+            },
+            "file": "testdata/powershell-progress-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 10
+            }
+          },
+          "message": "PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue'",
+          "rule": "tally/powershell/progress-preference",
+          "severity": "style",
+          "sourceCode": "RUN iwr https://example.com/c.zip -OutFile /tmp/c.zip"
+        },
+        {
+          "detail": "PowerShell renders a per-response progress bar for Invoke-WebRequest by default. On Windows containers this collapses download throughput by an order of magnitude. Set $ProgressPreference = 'SilentlyContinue' before the call.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/powershell/progress-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 15
+            },
+            "file": "testdata/powershell-progress-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 15
+            }
+          },
+          "message": "PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue'",
+          "rule": "tally/powershell/progress-preference",
+          "severity": "style",
+          "sourceCode": "RUN Invoke-WebRequest https://example.com/d.zip -OutFile /tmp/d.zip",
+          "suggestedFix": {
+            "description": "Add $ProgressPreference = 'SilentlyContinue' to SHELL instruction",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 60,
+                    "line": 14
+                  },
+                  "file": "testdata/powershell-progress-preference/Dockerfile",
+                  "start": {
+                    "column": 60,
+                    "line": 14
+                  }
+                },
+                "newText": " $ProgressPreference = 'SilentlyContinue';"
+              }
+            ],
+            "priority": 97,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "PowerShell renders a per-response progress bar for Invoke-WebRequest by default. On Windows containers this collapses download throughput by an order of magnitude. Set $ProgressPreference = 'SilentlyContinue' before the call.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/powershell/progress-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 19
+            },
+            "file": "testdata/powershell-progress-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 19
+            }
+          },
+          "message": "PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue'",
+          "rule": "tally/powershell/progress-preference",
+          "severity": "style",
+          "sourceCode": "RUN pwsh -Command \"Invoke-WebRequest https://example.com/e.zip -OutFile /tmp/e.zip\"",
+          "suggestedFix": {
+            "description": "Add $ProgressPreference = 'SilentlyContinue' to wrapper script",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 19
+                  },
+                  "file": "testdata/powershell-progress-preference/Dockerfile",
+                  "start": {
+                    "column": 19,
+                    "line": 19
+                  }
+                },
+                "newText": "$ProgressPreference = 'SilentlyContinue'; "
+              }
+            ],
+            "priority": 97,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "PowerShell renders a per-response progress bar for Invoke-WebRequest by default. On Windows containers this collapses download throughput by an order of magnitude. Set $ProgressPreference = 'SilentlyContinue' before the call.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/powershell/progress-preference/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 29
+            },
+            "file": "testdata/powershell-progress-preference/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 29
+            }
+          },
+          "message": "PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue'",
+          "rule": "tally/powershell/progress-preference",
+          "severity": "style",
+          "sourceCode": "RUN powershell -Command \"Invoke-WebRequest https://example.com/setup.exe -OutFile C:\\\\setup.exe\"",
+          "suggestedFix": {
+            "description": "Add $ProgressPreference = 'SilentlyContinue' to wrapper script",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 25,
+                    "line": 29
+                  },
+                  "file": "testdata/powershell-progress-preference/Dockerfile",
+                  "start": {
+                    "column": 25,
+                    "line": 29
+                  }
+                },
+                "newText": "$ProgressPreference = 'SilentlyContinue'; "
+              }
+            ],
+            "priority": 97,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 5,
+    "total": 5,
+    "warnings": 0
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_prefer-shell-instruction-cross-rules_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-shell-instruction-cross-rules_1.snap.json
@@ -36,7 +36,7 @@
                     "line": 3
                   }
                 },
-                "newText": "SHELL [\"pwsh\",\"-NoLogo\",\"-NoProfile\",\"-Command\",\"$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';\"]\n"
+                "newText": "SHELL [\"pwsh\", \"-NoLogo\", \"-NoProfile\", \"-Command\", \"$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';\"]\n"
               },
               {
                 "location": {

--- a/internal/integration/__snapshots__/TestLint_prefer-shell-instruction_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-shell-instruction_1.snap.json
@@ -36,7 +36,7 @@
                     "line": 3
                   }
                 },
-                "newText": "SHELL [\"pwsh\",\"-NoLogo\",\"-NoProfile\",\"-Command\",\"$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';\"]\n"
+                "newText": "SHELL [\"pwsh\", \"-NoLogo\", \"-NoProfile\", \"-Command\", \"$ErrorActionPreference = 'Stop'; $PSNativeCommandUseErrorActionPreference = $true; $ProgressPreference = 'SilentlyContinue';\"]\n"
               },
               {
                 "location": {

--- a/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "files_scanned": 1,
-  "rules_enabled": 97,
+  "rules_enabled": 98,
   "summary": {
     "errors": 0,
     "files": 0,

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1896,6 +1896,106 @@ severity = "warning"
 			wantApplied: 1, // only prefer-shell-instruction applies
 		},
 
+		// PowerShell progress-preference: SHELL missing $ProgressPreference
+		// (Shape A — last arg is bare "-Command").
+		{
+			name: "powershell-progress-preference-missing-shell",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"SHELL [\"pwsh\", \"-Command\"]\n" +
+				"RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/progress-preference")...),
+			wantApplied: 1,
+		},
+		// PowerShell progress-preference: SHELL has partial prelude
+		// (Shape B — last arg already carries a trailing-`;` preamble).
+		{
+			name: "powershell-progress-preference-shell-has-partial",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"SHELL [\"pwsh\", \"-Command\", \"$ErrorActionPreference = 'Stop';\"]\n" +
+				"RUN Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/progress-preference")...),
+			wantApplied: 1,
+		},
+		// PowerShell progress-preference: RUN without IWR — no fix.
+		{
+			name: "powershell-progress-preference-no-iwr-no-fix",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"SHELL [\"pwsh\", \"-Command\"]\n" +
+				"RUN Install-Module PSReadLine -Force\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/progress-preference")...),
+			wantApplied: 0,
+		},
+		// PowerShell progress-preference: explicit pwsh -Command wrapper
+		// (Shape D — inner-script zero-width insertion) from a bash stage.
+		{
+			name: "powershell-progress-preference-explicit-wrapper",
+			input: "FROM ubuntu:22.04\n" +
+				"RUN pwsh -Command \"Invoke-WebRequest https://example.com/c.zip -OutFile /tmp/c.zip\"\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/progress-preference")...),
+			wantApplied: 1,
+		},
+		// PowerShell progress-preference: backtick-continued powershell wrapper
+		// in a Windows servercore stage — exercises backtick continuation path.
+		{
+			name: "powershell-progress-preference-windows-backtick",
+			input: "# escape=`\n" +
+				"FROM mcr.microsoft.com/windows/servercore:ltsc2022\n" +
+				"RUN powershell -Command `\n" +
+				"    Invoke-WebRequest -Uri https://example.com/setup.exe " +
+				"-OutFile C:\\setup.exe\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/powershell/progress-preference")...),
+			wantApplied: 1,
+		},
+
+		// Cross-rule: progress-preference + prefer-shell-instruction both
+		// enabled. prefer-shell-instruction (priority 95) wins because its
+		// SHELL insertion carries the full prelude (including
+		// $ProgressPreference). progress-preference's SHELL edit is dropped
+		// by conflict resolution.
+		{
+			name: "powershell-progress-preference-cross-prefer-shell-instruction",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"RUN pwsh -Command Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip\n" +
+				"RUN pwsh -Command Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules(
+					"tally/powershell/progress-preference",
+					"tally/powershell/prefer-shell-instruction",
+				)...),
+			wantApplied: 1, // only prefer-shell-instruction applies
+		},
+
+		// Cross-rule: progress-preference + error-action-preference both
+		// enabled on the same SHELL line. Both fixes are zero-width
+		// insertions before the closing `]`, so they stack rather than
+		// conflict — both apply and the SHELL ends up with two array
+		// elements carrying complementary preludes. The result is verbose
+		// but correct; see snapshot.
+		{
+			name: "powershell-progress-preference-cross-error-action-preference",
+			input: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				"SHELL [\"pwsh\", \"-Command\"]\n" +
+				"RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip; Write-Host done\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules(
+					"tally/powershell/progress-preference",
+					"tally/powershell/error-action-preference",
+				)...),
+			wantApplied: 2, // both rules' zero-width SHELL-line insertions apply
+		},
+
 		// Prefer canonical STOPSIGNAL: missing SIG prefix → SIGTERM (FixSafe)
 		{
 			name:  "prefer-canonical-stopsignal-prefix",

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -256,6 +256,13 @@ func lintCases(t *testing.T) []lintCase {
 			args:     append([]string{"--format", "json"}, mustSelectRules("tally/powershell/error-action-preference")...),
 			wantExit: 1,
 		},
+		// PowerShell: progress-preference
+		{
+			name:     "powershell-progress-preference",
+			dir:      "powershell-progress-preference",
+			args:     append([]string{"--format", "json"}, mustSelectRules("tally/powershell/progress-preference")...),
+			wantExit: 1,
+		},
 		{
 			name:     "php-composer-no-dev-in-production",
 			dir:      "php-composer-no-dev-in-production",

--- a/internal/integration/testdata/powershell-progress-preference/Dockerfile
+++ b/internal/integration/testdata/powershell-progress-preference/Dockerfile
@@ -1,0 +1,29 @@
+# Stage 1: SHELL prelude already sets $ProgressPreference — no violation expected
+FROM mcr.microsoft.com/powershell:ubuntu-22.04 AS clean
+SHELL ["pwsh", "-Command", "$ProgressPreference = 'SilentlyContinue';"]
+RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip
+
+# Stage 2: SHELL without prelude — each IWR RUN should trigger
+FROM mcr.microsoft.com/powershell:ubuntu-22.04 AS missing-shell
+SHELL ["pwsh", "-Command"]
+RUN Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip
+RUN iwr https://example.com/c.zip -OutFile /tmp/c.zip
+
+# Stage 3: SHELL has Stop but no ProgressPreference
+FROM mcr.microsoft.com/powershell:ubuntu-22.04 AS partial-shell
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
+RUN Invoke-WebRequest https://example.com/d.zip -OutFile /tmp/d.zip
+
+# Stage 4: Explicit wrapper from a non-PowerShell shell (Linux bash)
+FROM ubuntu:22.04 AS explicit-wrapper
+RUN pwsh -Command "Invoke-WebRequest https://example.com/e.zip -OutFile /tmp/e.zip"
+
+# Stage 5: RUN without Invoke-WebRequest — no violation
+FROM mcr.microsoft.com/powershell:ubuntu-22.04 AS no-iwr
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force
+
+# Stage 6: Windows servercore with powershell wrapper and backtick continuation
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS windows-backtick
+RUN powershell -Command "Invoke-WebRequest https://example.com/setup.exe -OutFile C:\\setup.exe"

--- a/internal/rules/tally/powershell/__snapshots__/TestProgressPreferenceRule_Metadata_1.snap.json
+++ b/internal/rules/tally/powershell/__snapshots__/TestProgressPreferenceRule_Metadata_1.snap.json
@@ -1,5 +1,5 @@
 {
- "Category": "performance",
+ "Category": "style",
  "Code": "tally/powershell/progress-preference",
  "DefaultSeverity": "style",
  "Description": "PowerShell RUN using Invoke-WebRequest should set $ProgressPreference = 'SilentlyContinue'",

--- a/internal/rules/tally/powershell/__snapshots__/TestProgressPreferenceRule_Metadata_1.snap.json
+++ b/internal/rules/tally/powershell/__snapshots__/TestProgressPreferenceRule_Metadata_1.snap.json
@@ -1,0 +1,10 @@
+{
+ "Category": "performance",
+ "Code": "tally/powershell/progress-preference",
+ "DefaultSeverity": "style",
+ "Description": "PowerShell RUN using Invoke-WebRequest should set $ProgressPreference = 'SilentlyContinue'",
+ "DocURL": "https://tally.wharflab.com/rules/tally/powershell/progress-preference/",
+ "FixPriority": 97,
+ "IsExperimental": false,
+ "Name": "Suppress PowerShell progress bars for web downloads"
+}

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -437,6 +437,14 @@ func (r *ErrorActionPreferenceRule) buildShellModifyFixFromCmd(
 		return nil
 	}
 
+	// Bail out on multi-line SHELL instructions (backslash/backtick
+	// continuations). The bracket/quote search below only scans the first
+	// physical line and would produce an invalid edit. Multi-line SHELL is
+	// rare; we report without a fix in that case.
+	if isMultiLineInstruction(sm, shellCmd.Location()[0]) {
+		return nil
+	}
+
 	sourceLine := sm.Line(shellLine - 1)
 	if sourceLine == "" {
 		return nil

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -526,7 +526,10 @@ func (r *ErrorActionPreferenceRule) buildShellInsertFix(
 	executable := shellExecutableForStage(info)
 	preludeToAdd := buildPreludeString(needStop, needNative)
 
-	shellInstruction := `SHELL ["` + executable + `", "-Command", "` + preludeToAdd + `"]`
+	shellArray := formatShellArray([]string{executable, "-Command", preludeToAdd})
+	if shellArray == "" {
+		return nil
+	}
 
 	indent := ""
 	if sm != nil && fromEndLine > 0 && fromEndLine <= sm.LineCount() {
@@ -540,7 +543,7 @@ func (r *ErrorActionPreferenceRule) buildShellInsertFix(
 		Edits: []rules.TextEdit{
 			{
 				Location: rules.NewRangeLocation(file, insertLine, 0, insertLine, 0),
-				NewText:  indent + shellInstruction + "\n",
+				NewText:  indent + "SHELL " + shellArray + "\n",
 			},
 		},
 	}

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -283,40 +283,12 @@ func (r *ErrorActionPreferenceRule) buildWrapperFix(
 	needStop bool,
 	needNative bool,
 ) *rules.SuggestedFix {
-	if p.sm == nil || len(run.Location()) == 0 {
+	insertLine, insertCol, ok := wrapperInsertionPoint(p.sm, run, invocation)
+	if !ok {
 		return nil
 	}
-
 	startLine := run.Location()[0].Start.Line
-	endLine := run.Location()[len(run.Location())-1].End.Line
-
-	// Use Snippet to get the raw source (0-based line args).
-	source := p.sm.Snippet(startLine-1, endLine-1)
-	if source == "" {
-		return nil
-	}
-
-	// Anchor the search past the executable name to avoid matching tokens
-	// in the "RUN powershell" prefix itself.
-	exeLower := strings.ToLower(invocation.executable)
-	anchorIdx := strings.Index(strings.ToLower(source), exeLower)
-	if anchorIdx < 0 {
-		return nil
-	}
-	searchStart := anchorIdx + len(exeLower)
-
-	firstToken := firstNonWhitespaceWord(invocation.script)
-	if firstToken == "" {
-		return nil
-	}
-	relIdx := strings.Index(source[searchStart:], firstToken)
-	if relIdx < 0 {
-		return nil
-	}
-	insertByte := searchStart + relIdx
-
 	prelude := buildPreludeString(needStop, needNative) + " "
-	insertLine, insertCol := sourcemap.ByteToLineCol(source, insertByte)
 
 	return &rules.SuggestedFix{
 		Description: "Add PowerShell error-handling preferences to wrapper script",

--- a/internal/rules/tally/powershell/error_action_preference.go
+++ b/internal/rules/tally/powershell/error_action_preference.go
@@ -261,7 +261,7 @@ func (r *ErrorActionPreferenceRule) checkExplicitWrapper(
 		WithDetail(detail)
 	v.StageIndex = p.stageIdx
 
-	if fix := r.buildWrapperFix(p, run, script, invocation, !scriptHasStop, !scriptHasNative); fix != nil {
+	if fix := r.buildWrapperFix(p, run, invocation, !scriptHasStop, !scriptHasNative); fix != nil {
 		v = v.WithSuggestedFix(fix)
 	}
 
@@ -278,7 +278,6 @@ func (r *ErrorActionPreferenceRule) checkExplicitWrapper(
 func (r *ErrorActionPreferenceRule) buildWrapperFix(
 	p checkParams,
 	run *instructions.RunCommand,
-	_ string,
 	invocation explicitPowerShellInvocation,
 	needStop bool,
 	needNative bool,

--- a/internal/rules/tally/powershell/prefer_shell_instruction.go
+++ b/internal/rules/tally/powershell/prefer_shell_instruction.go
@@ -1,7 +1,6 @@
 package powershell
 
 import (
-	jsonv2 "encoding/json/v2"
 	"regexp"
 	"slices"
 	"strconv"
@@ -301,8 +300,8 @@ func buildSuggestedFix(
 	shellArgs = append(shellArgs, first.invocation.prefixArgs...)
 	shellArgs = append(shellArgs, "-Command", powerShellPrelude)
 
-	shellJSON, err := jsonv2.Marshal(shellArgs)
-	if err != nil {
+	shellArray := formatShellArray(shellArgs)
+	if shellArray == "" {
 		return nil
 	}
 
@@ -323,7 +322,7 @@ func buildSuggestedFix(
 	edits := make([]rules.TextEdit, 0, len(runEdits)+1)
 	edits = append(edits, rules.TextEdit{
 		Location: rules.NewRangeLocation(file, startLine, 0, startLine, 0),
-		NewText:  indent + "SHELL " + string(shellJSON) + "\n",
+		NewText:  indent + "SHELL " + shellArray + "\n",
 	})
 	edits = append(edits, runEdits...)
 
@@ -1084,8 +1083,8 @@ func buildShellInsertionEdit(
 		return rules.TextEdit{}, false
 	}
 
-	shellJSON, err := jsonv2.Marshal(shellCmd)
-	if err != nil {
+	shellArray := formatShellArray(shellCmd)
+	if shellArray == "" {
 		return rules.TextEdit{}, false
 	}
 
@@ -1098,7 +1097,7 @@ func buildShellInsertionEdit(
 
 	return rules.TextEdit{
 		Location: rules.NewRangeLocation(file, startLine, 0, startLine, 0),
-		NewText:  indent + "SHELL " + string(shellJSON) + "\n",
+		NewText:  indent + "SHELL " + shellArray + "\n",
 	}, true
 }
 

--- a/internal/rules/tally/powershell/prefer_shell_instruction_test.go
+++ b/internal/rules/tally/powershell/prefer_shell_instruction_test.go
@@ -31,7 +31,7 @@ func testPowerShellShellLine(executable string, args ...string) string {
 		parts = append(parts, `"`+arg+`"`)
 	}
 	parts = append(parts, `"-Command"`, `"`+testPowerShellPrelude+`"`)
-	return "SHELL [" + strings.Join(parts, ",") + "]"
+	return "SHELL [" + strings.Join(parts, ", ") + "]"
 }
 
 func TestPreferShellInstructionRule_Metadata(t *testing.T) {
@@ -359,7 +359,7 @@ RUN apk add --no-cache curl
 ` + testPwshShell + `
 RUN Write-Host hi
 RUN Write-Host bye
-SHELL ["/bin/sh","-c"]
+SHELL ["/bin/sh", "-c"]
 RUN apk add --no-cache curl
 `
 	if got != want {
@@ -397,7 +397,7 @@ RUN pwsh -Command Write-Host bye
 	want := `FROM alpine
 ` + testPwshShell + `
 RUN Write-Host hi
-SHELL ["/bin/sh","-c"]
+SHELL ["/bin/sh", "-c"]
 CMD echo hi
 RUN pwsh -Command Write-Host bye
 `

--- a/internal/rules/tally/powershell/progress_preference.go
+++ b/internal/rules/tally/powershell/progress_preference.go
@@ -282,6 +282,16 @@ func shellArgsHaveProgressPreference(shellCmd []string) bool {
 // active SHELL instruction. The edit is a zero-width insertion positioned
 // either before the closing `]` (when the last arg is bare "-Command") or
 // before the last `"` (when the last arg already carries a prelude).
+//
+// When this rule fires alongside tally/powershell/error-action-preference on
+// the same SHELL line, both rules emit zero-width insertions before the
+// closing `]`. The conflict resolver stacks them rather than picking a
+// winner, so the final SHELL carries two trailing array elements (one per
+// rule) rather than a single consolidated -Command string. That is
+// semantically equivalent under pwsh -Command semantics — multiple trailing
+// string arguments are space-joined before parsing — but visually verbose.
+// tally/powershell/prefer-shell-instruction (priority 95) side-steps this by
+// building the entire SHELL in one edit with the full prelude inlined.
 func buildShellLineFix(
 	file string,
 	sm *sourcemap.SourceMap,

--- a/internal/rules/tally/powershell/progress_preference.go
+++ b/internal/rules/tally/powershell/progress_preference.go
@@ -296,6 +296,15 @@ func buildShellLineFix(
 		return nil
 	}
 
+	// Bail out on multi-line SHELL instructions (backslash/backtick
+	// continuations). The bracket/quote search below only scans the first
+	// physical line, so it can land inside a comment or earlier token and
+	// produce an invalid edit. A multi-line SHELL is rare in practice; we
+	// just report the violation without a fix.
+	if isMultiLineInstruction(sm, shellCmd.Location()[0]) {
+		return nil
+	}
+
 	sourceLine := sm.Line(shellLine - 1)
 	if sourceLine == "" {
 		return nil

--- a/internal/rules/tally/powershell/progress_preference.go
+++ b/internal/rules/tally/powershell/progress_preference.go
@@ -100,8 +100,10 @@ func (r *ProgressPreferenceRule) checkStage(
 		}
 
 		// Suppress duplicate SHELL-level fixes within the same SHELL scope.
-		// Wrapper-body and heredoc-body fixes are per-RUN and never suppressed.
-		if v.SuggestedFix != nil && isStageShellFix(p.activeShellInstr, v.SuggestedFix, p.file) {
+		// Wrapper-body and heredoc-body fixes are per-RUN and never suppressed;
+		// only the Path 3 (variant.IsPowerShell()) violationForPowerShellRun
+		// path emits SHELL-modify / SHELL-insert edits that could overlap.
+		if v.SuggestedFix != nil && isStageLevelPowerShellFix(p, run) {
 			if stageFixEmitted {
 				v.SuggestedFix = nil
 			} else {
@@ -472,19 +474,29 @@ func buildHeredocBodyFix(
 	}
 }
 
-// isStageShellFix reports whether the fix modifies the active SHELL line,
-// so that callers can suppress duplicate SHELL edits across multiple RUNs
-// in the same SHELL scope.
-func isStageShellFix(activeShellInstr *instructions.ShellCommand, fix *rules.SuggestedFix, file string) bool {
-	if activeShellInstr == nil || fix == nil || len(fix.Edits) != 1 {
+// isStageLevelPowerShellFix reports whether the given RUN would receive a
+// stage-level SHELL fix (modify existing SHELL, or insert a new SHELL after
+// FROM). Those fixes target the same region across every RUN in the same
+// SHELL scope, so only the first should carry the edit — subsequent
+// violations in the scope report without a fix to avoid overlapping edits.
+//
+// The predicate mirrors the Path-3 branch in checkRun: active shell is
+// PowerShell and the RUN doesn't route through the wrapper or heredoc paths
+// (which produce per-RUN, non-overlapping edits).
+func isStageLevelPowerShellFix(p progressCheckParams, run *instructions.RunCommand) bool {
+	if len(run.Files) > 0 && run.Files[0].Data != "" {
+		// Heredoc fix targets the body of this specific RUN — per-RUN,
+		// never overlaps another RUN's fix.
 		return false
 	}
-	if len(activeShellInstr.Location()) == 0 {
-		return false
+	variant := shellutil.VariantFromShellCmd(p.activeShellCmd)
+	if p.info != nil && len(run.Location()) > 0 {
+		variant = p.info.ShellVariantAtLine(run.Location()[0].Start.Line)
 	}
-	shellLine := activeShellInstr.Location()[0].Start.Line
-	edit := fix.Edits[0]
-	return edit.Location.File == file && edit.Location.Start.Line == shellLine
+	// Only the PowerShell-variant path emits SHELL-modify or SHELL-insert
+	// edits. Wrapper fixes (non-PowerShell variant with explicit
+	// powershell/pwsh -Command) target the inner script of a specific RUN.
+	return variant.IsPowerShell()
 }
 
 func init() {

--- a/internal/rules/tally/powershell/progress_preference.go
+++ b/internal/rules/tally/powershell/progress_preference.go
@@ -1,0 +1,470 @@
+package powershell
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	shellutil "github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+// ProgressPreferenceRuleCode is the full rule code.
+const ProgressPreferenceRuleCode = rules.TallyRulePrefix + "powershell/progress-preference"
+
+const progressPreferenceAssignment = "$ProgressPreference = 'SilentlyContinue';"
+
+// ProgressPreferenceRule warns when PowerShell RUN instructions invoke
+// Invoke-WebRequest (or its alias iwr) without setting
+// $ProgressPreference = 'SilentlyContinue'. The per-response progress bars
+// tank build throughput on Windows containers.
+type ProgressPreferenceRule struct{}
+
+// NewProgressPreferenceRule creates a new rule instance.
+func NewProgressPreferenceRule() *ProgressPreferenceRule {
+	return &ProgressPreferenceRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *ProgressPreferenceRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            ProgressPreferenceRuleCode,
+		Name:            "Suppress PowerShell progress bars for web downloads",
+		Description:     "PowerShell RUN using Invoke-WebRequest should set $ProgressPreference = 'SilentlyContinue'",
+		DocURL:          rules.TallyDocURL(ProgressPreferenceRuleCode),
+		DefaultSeverity: rules.SeverityStyle,
+		Category:        "performance",
+		FixPriority:     97, //nolint:mnd // After error-action-preference (96), before prefer-run-heredoc (100).
+	}
+}
+
+// Check runs the rule.
+func (r *ProgressPreferenceRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	sm := input.SourceMap()
+
+	violations := make([]rules.Violation, 0, len(input.Stages))
+	for stageIdx, stage := range input.Stages {
+		violations = append(violations, r.checkStage(input, sm, stageIdx, stage, meta)...)
+	}
+	return violations
+}
+
+// progressCheckParams bundles per-RUN inputs shared across the Path 1/2/3 helpers.
+type progressCheckParams struct {
+	file             string
+	sm               *sourcemap.SourceMap
+	meta             rules.RuleMetadata
+	stageIdx         int
+	info             *semantic.StageInfo
+	activeShellCmd   []string
+	activeShellInstr *instructions.ShellCommand
+}
+
+func (r *ProgressPreferenceRule) checkStage(
+	input rules.LintInput,
+	sm *sourcemap.SourceMap,
+	stageIdx int,
+	stage instructions.Stage,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	p := progressCheckParams{
+		file:           input.File,
+		sm:             sm,
+		meta:           meta,
+		stageIdx:       stageIdx,
+		info:           stageInfoForIndex(input.Semantic, stageIdx),
+		activeShellCmd: initialStageShellCmd(input.Semantic, stageIdx),
+	}
+	stageFixEmitted := false
+
+	violations := make([]rules.Violation, 0, len(stage.Commands))
+	for _, cmd := range stage.Commands {
+		if sc, ok := cmd.(*instructions.ShellCommand); ok && len(sc.Shell) > 0 {
+			p.activeShellCmd = sc.Shell
+			p.activeShellInstr = sc
+			stageFixEmitted = false
+			continue
+		}
+
+		run, ok := cmd.(*instructions.RunCommand)
+		if !ok || !run.PrependShell || len(run.CmdLine) == 0 {
+			continue
+		}
+
+		v := r.checkRun(p, run)
+		if v == nil {
+			continue
+		}
+
+		// Suppress duplicate SHELL-level fixes within the same SHELL scope.
+		// Wrapper-body and heredoc-body fixes are per-RUN and never suppressed.
+		if v.SuggestedFix != nil && isStageShellFix(p.activeShellInstr, v.SuggestedFix, p.file) {
+			if stageFixEmitted {
+				v.SuggestedFix = nil
+			} else {
+				stageFixEmitted = true
+			}
+		}
+		violations = append(violations, *v)
+	}
+	return violations
+}
+
+func (r *ProgressPreferenceRule) checkRun(p progressCheckParams, run *instructions.RunCommand) *rules.Violation {
+	// Determine the effective variant at this RUN line so we can route the fix.
+	variant := shellutil.VariantFromShellCmd(p.activeShellCmd)
+	if p.info != nil && len(run.Location()) > 0 {
+		variant = p.info.ShellVariantAtLine(run.Location()[0].Start.Line)
+	}
+
+	// Path 1: heredoc body. Detection and fix both operate on the body.
+	if len(run.Files) > 0 && run.Files[0].Data != "" {
+		body := run.Files[0].Data
+		if !scriptUsesInvokeWebRequest(body) {
+			return nil
+		}
+		if progressPreferenceSet(body) || shellArgsHaveProgressPreference(p.activeShellCmd) {
+			return nil
+		}
+		return r.violationForHeredoc(p, run, variant)
+	}
+
+	script := run.CmdLine[0]
+
+	// Path 2: explicit powershell/pwsh -Command wrapper inside a non-PowerShell shell.
+	if !variant.IsPowerShell() {
+		invocation, ok := parseExplicitPowerShellInvocation(script)
+		if !ok {
+			return nil
+		}
+		if !scriptUsesInvokeWebRequest(invocation.script) {
+			return nil
+		}
+		if progressPreferenceSet(invocation.script) {
+			return nil
+		}
+		return r.violationForWrapper(p, run, script, invocation)
+	}
+
+	// Path 3: stage shell is PowerShell. SHELL + script both contribute to the prelude.
+	if !scriptUsesInvokeWebRequest(script) {
+		return nil
+	}
+	if shellArgsHaveProgressPreference(p.activeShellCmd) || progressPreferenceSet(script) {
+		return nil
+	}
+	return r.violationForPowerShellRun(p, run)
+}
+
+// violationForPowerShellRun handles a RUN whose active shell is PowerShell.
+// The fix modifies an existing SHELL instruction (if any) or inserts a new one.
+func (r *ProgressPreferenceRule) violationForPowerShellRun(p progressCheckParams, run *instructions.RunCommand) *rules.Violation {
+	loc := rules.NewLocationFromRanges(p.file, run.Location())
+	if loc.IsFileLevel() {
+		return nil
+	}
+
+	v := newProgressPreferenceViolation(loc, p.meta, p.stageIdx)
+
+	var fix *rules.SuggestedFix
+	if p.activeShellInstr != nil {
+		fix = buildShellLineFix(p.file, p.sm, p.activeShellInstr, p.meta.FixPriority)
+	} else {
+		fix = buildShellInsertFix(p.file, p.sm, p.info, p.meta.FixPriority)
+	}
+	if fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+	return &v
+}
+
+// violationForWrapper handles an explicit powershell/pwsh -Command wrapper
+// inside a non-PowerShell stage. The fix is a zero-width insertion at the
+// start of the inner script.
+func (r *ProgressPreferenceRule) violationForWrapper(
+	p progressCheckParams,
+	run *instructions.RunCommand,
+	script string,
+	invocation explicitPowerShellInvocation,
+) *rules.Violation {
+	loc := rules.NewLocationFromRanges(p.file, run.Location())
+	if loc.IsFileLevel() {
+		return nil
+	}
+
+	v := newProgressPreferenceViolation(loc, p.meta, p.stageIdx)
+	if fix := buildWrapperFix(p.file, p.sm, run, script, invocation, p.meta.FixPriority); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+	return &v
+}
+
+// violationForHeredoc handles a RUN heredoc body containing Invoke-WebRequest.
+// The fix inserts the assignment at the start of the heredoc body. Only
+// emitted when the stage's active variant is PowerShell; otherwise we warn
+// without a fix since injecting PowerShell syntax into e.g. a bash heredoc
+// would change behavior.
+func (r *ProgressPreferenceRule) violationForHeredoc(
+	p progressCheckParams,
+	run *instructions.RunCommand,
+	variant shellutil.Variant,
+) *rules.Violation {
+	loc := rules.NewLocationFromRanges(p.file, run.Location())
+	if loc.IsFileLevel() {
+		return nil
+	}
+
+	v := newProgressPreferenceViolation(loc, p.meta, p.stageIdx)
+	if variant.IsPowerShell() {
+		if fix := buildHeredocBodyFix(p.file, p.sm, run, p.meta.FixPriority); fix != nil {
+			v = v.WithSuggestedFix(fix)
+		}
+	}
+	return &v
+}
+
+func newProgressPreferenceViolation(loc rules.Location, meta rules.RuleMetadata, stageIdx int) rules.Violation {
+	msg := "PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue'"
+	detail := "PowerShell renders a per-response progress bar for Invoke-WebRequest by default. " +
+		"On Windows containers this collapses download throughput by an order of magnitude. " +
+		"Set $ProgressPreference = 'SilentlyContinue' before the call."
+	v := rules.NewViolation(loc, meta.Code, msg, meta.DefaultSeverity).
+		WithDocURL(meta.DocURL).
+		WithDetail(detail)
+	v.StageIndex = stageIdx
+	return v
+}
+
+// scriptUsesInvokeWebRequest reports whether the script contains an
+// Invoke-WebRequest or iwr command per the PowerShell tree-sitter parser.
+func scriptUsesInvokeWebRequest(script string) bool {
+	return len(shellutil.FindCommands(script, shellutil.VariantPowerShell, "invoke-webrequest", "iwr")) > 0
+}
+
+// progressPreferenceSet walks the leading PowerShell assignments in a script
+// and returns true if any one of them sets $ProgressPreference to a value
+// that contains "silentlycontinue" (case-insensitive, quotes stripped).
+// The walk stops at the first non-assignment so preferences set AFTER the
+// IWR call don't count — the risky command already ran before they applied.
+func progressPreferenceSet(script string) bool {
+	for _, stmt := range shellutil.ExtractChainedCommands(script, shellutil.VariantPowerShell) {
+		trimmed := strings.TrimSpace(stmt)
+		if trimmed == "" {
+			continue
+		}
+		name, value, ok := shellutil.PowerShellAssignment(trimmed)
+		if !ok {
+			return false
+		}
+		if !strings.EqualFold(name, "$ProgressPreference") {
+			continue
+		}
+		if strings.EqualFold(shellutil.DropQuotes(value), "SilentlyContinue") {
+			return true
+		}
+	}
+	return false
+}
+
+// shellArgsHaveProgressPreference checks whether the last SHELL arg sets
+// $ProgressPreference = 'SilentlyContinue' in its prelude.
+func shellArgsHaveProgressPreference(shellCmd []string) bool {
+	if len(shellCmd) <= 1 {
+		return false
+	}
+	return progressPreferenceSet(shellCmd[len(shellCmd)-1])
+}
+
+// buildShellLineFix inserts $ProgressPreference = 'SilentlyContinue' into the
+// active SHELL instruction. The edit is a zero-width insertion positioned
+// either before the closing `]` (when the last arg is bare "-Command") or
+// before the last `"` (when the last arg already carries a prelude).
+func buildShellLineFix(
+	file string,
+	sm *sourcemap.SourceMap,
+	shellCmd *instructions.ShellCommand,
+	priority int,
+) *rules.SuggestedFix {
+	if sm == nil || len(shellCmd.Location()) == 0 {
+		return nil
+	}
+	shellLine := shellCmd.Location()[0].Start.Line
+	if shellLine <= 0 {
+		return nil
+	}
+
+	sourceLine := sm.Line(shellLine - 1)
+	if sourceLine == "" {
+		return nil
+	}
+
+	existing := extractShellLastArg(sourceLine)
+	if strings.EqualFold(strings.TrimSpace(existing), "-Command") {
+		closeBracket := strings.LastIndex(sourceLine, "]")
+		if closeBracket < 0 {
+			return nil
+		}
+		return &rules.SuggestedFix{
+			Description: "Add $ProgressPreference = 'SilentlyContinue' to SHELL instruction",
+			Safety:      rules.FixSuggestion,
+			Priority:    priority,
+			Edits: []rules.TextEdit{
+				{
+					Location: rules.NewRangeLocation(
+						file, shellLine, closeBracket, shellLine, closeBracket,
+					),
+					NewText: `, "` + progressPreferenceAssignment + `"`,
+				},
+			},
+		}
+	}
+
+	lastQuote := strings.LastIndex(sourceLine, `"`)
+	if lastQuote < 0 {
+		return nil
+	}
+	sep := " "
+	if !strings.HasSuffix(strings.TrimSpace(existing), ";") {
+		sep = "; "
+	}
+	return &rules.SuggestedFix{
+		Description: "Add $ProgressPreference = 'SilentlyContinue' to SHELL instruction",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		Edits: []rules.TextEdit{
+			{
+				Location: rules.NewRangeLocation(
+					file, shellLine, lastQuote, shellLine, lastQuote,
+				),
+				NewText: sep + progressPreferenceAssignment,
+			},
+		},
+	}
+}
+
+// buildShellInsertFix emits a new SHELL instruction carrying the preference
+// after the FROM line. Used when a PowerShell-by-default stage has no
+// SHELL instruction preceding the RUN.
+func buildShellInsertFix(
+	file string,
+	sm *sourcemap.SourceMap,
+	info *semantic.StageInfo,
+	priority int,
+) *rules.SuggestedFix {
+	if info == nil || info.Stage == nil || len(info.Stage.Location) == 0 {
+		return nil
+	}
+
+	fromEndLine := info.Stage.Location[len(info.Stage.Location)-1].End.Line
+	insertLine := fromEndLine + 1
+
+	executable := shellExecutableForStage(info)
+
+	indent := ""
+	if sm != nil && fromEndLine > 0 && fromEndLine <= sm.LineCount() {
+		indent = leadingIndentForLine(sm.Line(fromEndLine - 1))
+	}
+
+	shellInstruction := `SHELL ["` + executable + `", "-Command", "` + progressPreferenceAssignment + `"]`
+	return &rules.SuggestedFix{
+		Description: "Insert a PowerShell SHELL instruction with $ProgressPreference = 'SilentlyContinue'",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		Edits: []rules.TextEdit{
+			{
+				Location: rules.NewRangeLocation(file, insertLine, 0, insertLine, 0),
+				NewText:  indent + shellInstruction + "\n",
+			},
+		},
+	}
+}
+
+// buildWrapperFix inserts the assignment at the start of the inner script
+// of an explicit powershell/pwsh -Command wrapper. Zero-width insertion.
+func buildWrapperFix(
+	file string,
+	sm *sourcemap.SourceMap,
+	run *instructions.RunCommand,
+	_ string,
+	invocation explicitPowerShellInvocation,
+	priority int,
+) *rules.SuggestedFix {
+	insertLine, insertCol, ok := wrapperInsertionPoint(sm, run, invocation)
+	if !ok {
+		return nil
+	}
+	startLine := run.Location()[0].Start.Line
+
+	return &rules.SuggestedFix{
+		Description: "Add $ProgressPreference = 'SilentlyContinue' to wrapper script",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		Edits: []rules.TextEdit{
+			{
+				Location: rules.NewRangeLocation(
+					file,
+					startLine+insertLine, insertCol,
+					startLine+insertLine, insertCol,
+				),
+				NewText: progressPreferenceAssignment + " ",
+			},
+		},
+	}
+}
+
+// buildHeredocBodyFix inserts the assignment on its own line at the start of
+// the heredoc body. The heredoc body begins on the line after the `<<EOF`
+// marker, so we anchor the edit at column 0 of run.Files[0] start line.
+func buildHeredocBodyFix(
+	file string,
+	sm *sourcemap.SourceMap,
+	run *instructions.RunCommand,
+	priority int,
+) *rules.SuggestedFix {
+	if sm == nil || len(run.Files) == 0 || len(run.Location()) == 0 {
+		return nil
+	}
+
+	// BuildKit does not expose the heredoc body's line range directly on
+	// run.Files. The body starts on the line after the RUN's first location
+	// range end. This holds for single-line heredoc preambles like
+	// `RUN <<EOF`, which is the common shape.
+	bodyStartLine := run.Location()[0].End.Line + 1
+	if bodyStartLine <= 0 || bodyStartLine > sm.LineCount() {
+		return nil
+	}
+
+	return &rules.SuggestedFix{
+		Description: "Add $ProgressPreference = 'SilentlyContinue' to heredoc body",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		Edits: []rules.TextEdit{
+			{
+				Location: rules.NewRangeLocation(file, bodyStartLine, 0, bodyStartLine, 0),
+				NewText:  progressPreferenceAssignment + "\n",
+			},
+		},
+	}
+}
+
+// isStageShellFix reports whether the fix modifies the active SHELL line,
+// so that callers can suppress duplicate SHELL edits across multiple RUNs
+// in the same SHELL scope.
+func isStageShellFix(activeShellInstr *instructions.ShellCommand, fix *rules.SuggestedFix, file string) bool {
+	if activeShellInstr == nil || fix == nil || len(fix.Edits) != 1 {
+		return false
+	}
+	if len(activeShellInstr.Location()) == 0 {
+		return false
+	}
+	shellLine := activeShellInstr.Location()[0].Start.Line
+	edit := fix.Edits[0]
+	return edit.Location.File == file && edit.Location.Start.Line == shellLine
+}
+
+func init() {
+	rules.Register(NewProgressPreferenceRule())
+}

--- a/internal/rules/tally/powershell/progress_preference.go
+++ b/internal/rules/tally/powershell/progress_preference.go
@@ -148,7 +148,7 @@ func (r *ProgressPreferenceRule) checkRun(p progressCheckParams, run *instructio
 		if progressPreferenceSet(invocation.script) {
 			return nil
 		}
-		return r.violationForWrapper(p, run, script, invocation)
+		return r.violationForWrapper(p, run, invocation)
 	}
 
 	// Path 3: stage shell is PowerShell. SHELL + script both contribute to the prelude.
@@ -189,7 +189,6 @@ func (r *ProgressPreferenceRule) violationForPowerShellRun(p progressCheckParams
 func (r *ProgressPreferenceRule) violationForWrapper(
 	p progressCheckParams,
 	run *instructions.RunCommand,
-	script string,
 	invocation explicitPowerShellInvocation,
 ) *rules.Violation {
 	loc := rules.NewLocationFromRanges(p.file, run.Location())
@@ -198,7 +197,7 @@ func (r *ProgressPreferenceRule) violationForWrapper(
 	}
 
 	v := newProgressPreferenceViolation(loc, p.meta, p.stageIdx)
-	if fix := buildWrapperFix(p.file, p.sm, run, script, invocation, p.meta.FixPriority); fix != nil {
+	if fix := buildWrapperFix(p.file, p.sm, run, invocation, p.meta.FixPriority); fix != nil {
 		v = v.WithSuggestedFix(fix)
 	}
 	return &v
@@ -412,7 +411,6 @@ func buildWrapperFix(
 	file string,
 	sm *sourcemap.SourceMap,
 	run *instructions.RunCommand,
-	_ string,
 	invocation explicitPowerShellInvocation,
 	priority int,
 ) *rules.SuggestedFix {

--- a/internal/rules/tally/powershell/progress_preference.go
+++ b/internal/rules/tally/powershell/progress_preference.go
@@ -387,7 +387,10 @@ func buildShellInsertFix(
 		indent = leadingIndentForLine(sm.Line(fromEndLine - 1))
 	}
 
-	shellInstruction := `SHELL ["` + executable + `", "-Command", "` + progressPreferenceAssignment + `"]`
+	shellArray := formatShellArray([]string{executable, "-Command", progressPreferenceAssignment})
+	if shellArray == "" {
+		return nil
+	}
 	return &rules.SuggestedFix{
 		Description: "Insert a PowerShell SHELL instruction with $ProgressPreference = 'SilentlyContinue'",
 		Safety:      rules.FixSuggestion,
@@ -395,7 +398,7 @@ func buildShellInsertFix(
 		Edits: []rules.TextEdit{
 			{
 				Location: rules.NewRangeLocation(file, insertLine, 0, insertLine, 0),
-				NewText:  indent + shellInstruction + "\n",
+				NewText:  indent + "SHELL " + shellArray + "\n",
 			},
 		},
 	}

--- a/internal/rules/tally/powershell/progress_preference.go
+++ b/internal/rules/tally/powershell/progress_preference.go
@@ -35,7 +35,7 @@ func (r *ProgressPreferenceRule) Metadata() rules.RuleMetadata {
 		Description:     "PowerShell RUN using Invoke-WebRequest should set $ProgressPreference = 'SilentlyContinue'",
 		DocURL:          rules.TallyDocURL(ProgressPreferenceRuleCode),
 		DefaultSeverity: rules.SeverityStyle,
-		Category:        "performance",
+		Category:        "style",
 		FixPriority:     97, //nolint:mnd // After error-action-preference (96), before prefer-run-heredoc (100).
 	}
 }

--- a/internal/rules/tally/powershell/progress_preference_test.go
+++ b/internal/rules/tally/powershell/progress_preference_test.go
@@ -1,0 +1,277 @@
+package powershell
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestProgressPreferenceRule_Metadata(t *testing.T) {
+	t.Parallel()
+	snaps.MatchStandaloneJSON(t, NewProgressPreferenceRule().Metadata())
+}
+
+func TestProgressPreferenceRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewProgressPreferenceRule(), []testutil.RuleTestCase{
+		// === No violations ===
+		{
+			Name: "RUN without Invoke-WebRequest",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Install-Module PSReadLine -Force
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "SHELL prelude already sets $ProgressPreference",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ProgressPreference = 'SilentlyContinue';"]
+RUN Invoke-WebRequest https://example.com/file.zip -OutFile /tmp/file.zip
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "script prelude sets $ProgressPreference before IWR",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://example.com/file.zip -OutFile /tmp/file.zip
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "case-insensitive preference value",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN $ProgressPreference = 'silentlycontinue'; Invoke-WebRequest https://example.com -OutFile /tmp/f.zip
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bash stage without PowerShell wrapper",
+			Content: `FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y curl
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "SHELL prelude with full prefer-shell-instruction prelude",
+			Content: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				`SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; ` +
+				`$PSNativeCommandUseErrorActionPreference = $true; ` +
+				`$ProgressPreference = 'SilentlyContinue';"]` + "\n" +
+				"RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip\n",
+			WantViolations: 0,
+		},
+		{
+			Name: "heredoc body already sets preference",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN <<EOF
+$ProgressPreference = 'SilentlyContinue'
+Invoke-WebRequest https://example.com -OutFile /tmp/f.zip
+EOF
+`,
+			WantViolations: 0,
+		},
+
+		// === Violations ===
+		{
+			Name: "plain IWR in PowerShell SHELL stage",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Invoke-WebRequest https://example.com/file.zip -OutFile /tmp/file.zip
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "iwr alias in PowerShell SHELL stage",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN iwr https://example.com/file.zip -OutFile /tmp/file.zip
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "assignment after command is not a valid prelude",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip; $ProgressPreference = 'SilentlyContinue'
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "wrong preference value still triggers",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN $ProgressPreference = 'Continue'; Invoke-WebRequest https://example.com -OutFile /tmp/f.zip
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "explicit powershell -Command wrapper inside bash stage",
+			Content: `FROM ubuntu:22.04
+RUN pwsh -Command "Invoke-WebRequest https://example.com -OutFile /tmp/f.zip"
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "windows servercore with plain Invoke-WebRequest",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN powershell -Command "Invoke-WebRequest https://example.com/setup.exe -OutFile C:\setup.exe"
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "multiple RUNs in same PowerShell SHELL scope each report",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip
+RUN Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip
+`,
+			WantViolations: 2,
+		},
+		{
+			Name: "heredoc body missing preference",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command"]
+RUN <<EOF
+Invoke-WebRequest https://example.com -OutFile /tmp/f.zip
+EOF
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "SHELL has partial prelude (Stop) but missing Progress",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
+RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip
+`,
+			WantViolations: 1,
+		},
+		{
+			// Stage defaults to PowerShell via image but has no SHELL — Shape C.
+			Name: "PowerShell stage without SHELL instruction",
+			Content: `FROM mcr.microsoft.com/powershell:ubuntu-22.04
+RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip
+`,
+			WantViolations: 1,
+		},
+	})
+}
+
+func TestProgressPreferenceRule_OverlapWithPreferShellInstruction(t *testing.T) {
+	t.Parallel()
+
+	// When prefer-shell-instruction has applied its fix, the SHELL carries
+	// the full prelude including $ProgressPreference = 'SilentlyContinue'.
+	// progress-preference must not fire in that case.
+	testutil.RunRuleTests(t, NewProgressPreferenceRule(), []testutil.RuleTestCase{
+		{
+			Name: "SHELL with full prefer-shell-instruction prelude",
+			Content: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				`SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; ` +
+				`$PSNativeCommandUseErrorActionPreference = $true; ` +
+				`$ProgressPreference = 'SilentlyContinue';"]` + "\n" +
+				"RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip\n",
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestProgressPreferenceRule_OverlapWithErrorActionPreference(t *testing.T) {
+	t.Parallel()
+
+	// The two rules fire on orthogonal preferences. When the SHELL has
+	// Stop + Native but no Progress, only progress-preference triggers.
+	testutil.RunRuleTests(t, NewProgressPreferenceRule(), []testutil.RuleTestCase{
+		{
+			Name: "SHELL has error-action-preference prelude only",
+			Content: "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+				`SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; ` +
+				`$PSNativeCommandUseErrorActionPreference = $true;"]` + "\n" +
+				"RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip\n",
+			WantViolations: 1,
+		},
+	})
+}
+
+func TestProgressPreferenceSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		script string
+		want   bool
+	}{
+		{name: "empty script", script: "", want: false},
+		{
+			name:   "silent continue single-quoted",
+			script: "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://example.com",
+			want:   true,
+		},
+		{
+			name:   "silent continue double-quoted",
+			script: `$ProgressPreference = "SilentlyContinue"; Invoke-WebRequest https://example.com`,
+			want:   true,
+		},
+		{
+			name:   "case insensitive variable name",
+			script: "$progresspreference = 'SilentlyContinue'; Invoke-WebRequest https://example.com",
+			want:   true,
+		},
+		{
+			name:   "wrong value",
+			script: "$ProgressPreference = 'Continue'; Invoke-WebRequest https://example.com",
+			want:   false,
+		},
+		{
+			name:   "assignment after command is not a prelude",
+			script: "Invoke-WebRequest https://example.com; $ProgressPreference = 'SilentlyContinue'",
+			want:   false,
+		},
+		{
+			name:   "non-assignment stops walk, but earlier set counts",
+			script: "$ProgressPreference = 'SilentlyContinue'; Write-Host hi; $ProgressPreference = 'Continue'",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := progressPreferenceSet(tt.script); got != tt.want {
+				t.Errorf("progressPreferenceSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScriptUsesInvokeWebRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		script string
+		want   bool
+	}{
+		{name: "empty", script: "", want: false},
+		{name: "Invoke-WebRequest", script: "Invoke-WebRequest https://example.com", want: true},
+		{name: "iwr alias", script: "iwr https://example.com", want: true},
+		{name: "lowercase invoke-webrequest", script: "invoke-webrequest https://example.com", want: true},
+		{name: "unrelated cmdlet", script: "Install-Module PSReadLine", want: false},
+		{name: "iwr as substring only", script: "New-IwrWrapper", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := scriptUsesInvokeWebRequest(tt.script); got != tt.want {
+				t.Errorf("scriptUsesInvokeWebRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rules/tally/powershell/progress_preference_test.go
+++ b/internal/rules/tally/powershell/progress_preference_test.go
@@ -185,6 +185,34 @@ func TestProgressPreferenceRule_MultiLineShellNoFix(t *testing.T) {
 	}
 }
 
+func TestProgressPreferenceRule_NoShellMultipleRunsSingleInsert(t *testing.T) {
+	t.Parallel()
+
+	// PowerShell-by-default stage (no SHELL instruction) with multiple IWR
+	// RUNs. Each RUN triggers a violation, but only the FIRST carries a
+	// SuggestedFix; the rest are suppressed so we don't emit overlapping
+	// SHELL-insert edits all pointing at FROM+1.
+	content := "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+		"RUN Invoke-WebRequest https://example.com/a.zip -OutFile /tmp/a.zip\n" +
+		"RUN Invoke-WebRequest https://example.com/b.zip -OutFile /tmp/b.zip\n"
+
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewProgressPreferenceRule().Check(input)
+	if len(violations) != 2 {
+		t.Fatalf("got %d violations, want 2", len(violations))
+	}
+
+	fixed := 0
+	for _, v := range violations {
+		if v.SuggestedFix != nil {
+			fixed++
+		}
+	}
+	if fixed != 1 {
+		t.Errorf("expected exactly 1 SuggestedFix across %d violations, got %d", len(violations), fixed)
+	}
+}
+
 func TestProgressPreferenceRule_OverlapWithPreferShellInstruction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/powershell/progress_preference_test.go
+++ b/internal/rules/tally/powershell/progress_preference_test.go
@@ -163,6 +163,28 @@ RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip
 	})
 }
 
+func TestProgressPreferenceRule_MultiLineShellNoFix(t *testing.T) {
+	t.Parallel()
+
+	// A SHELL instruction spanning multiple physical lines via backslash
+	// continuation. buildShellLineFix bails out because its bracket/quote
+	// search only reads the first line and can produce invalid edits. The
+	// violation is still reported, but with no SuggestedFix attached.
+	content := "FROM mcr.microsoft.com/powershell:ubuntu-22.04\n" +
+		"SHELL [\\\n" +
+		"    \"pwsh\", \"-Command\"]\n" +
+		"RUN Invoke-WebRequest https://example.com -OutFile /tmp/f.zip\n"
+
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewProgressPreferenceRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Errorf("expected no SuggestedFix on multi-line SHELL, got %+v", violations[0].SuggestedFix)
+	}
+}
+
 func TestProgressPreferenceRule_OverlapWithPreferShellInstruction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/powershell/wrapper_anchor.go
+++ b/internal/rules/tally/powershell/wrapper_anchor.go
@@ -93,8 +93,13 @@ func wrapperInsertionPoint(
 		return 0, 0, false
 	}
 
+	// Use a single lower-cased view of the source for both anchor lookups.
+	// PowerShell identifiers are case-insensitive and tree-sitter may
+	// normalize casing differently from the raw source, so the executable
+	// anchor and the inner-script first-token anchor must agree.
+	sourceLower := strings.ToLower(source)
 	exeLower := strings.ToLower(invocation.executable)
-	anchorIdx := strings.Index(strings.ToLower(source), exeLower)
+	anchorIdx := strings.Index(sourceLower, exeLower)
 	if anchorIdx < 0 {
 		return 0, 0, false
 	}
@@ -104,7 +109,7 @@ func wrapperInsertionPoint(
 	if firstToken == "" {
 		return 0, 0, false
 	}
-	relIdx := strings.Index(source[searchStart:], firstToken)
+	relIdx := strings.Index(sourceLower[searchStart:], strings.ToLower(firstToken))
 	if relIdx < 0 {
 		return 0, 0, false
 	}

--- a/internal/rules/tally/powershell/wrapper_anchor.go
+++ b/internal/rules/tally/powershell/wrapper_anchor.go
@@ -1,6 +1,7 @@
 package powershell
 
 import (
+	jsonv2 "encoding/json/v2"
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
@@ -8,6 +9,45 @@ import (
 
 	"github.com/wharflab/tally/internal/sourcemap"
 )
+
+// formatShellArray renders a SHELL instruction array argument in the
+// canonical spaced form: `["a", "b", "c"]`. Shared by all fix emitters in
+// the powershell package so generated SHELL lines have consistent spacing
+// regardless of which rule authored them.
+//
+// Returns "" on marshal failure, which callers should treat as "skip fix".
+func formatShellArray(args []string) string {
+	// jsonv2.Marshal emits `["a","b","c"]` (no spaces). Splice a space after
+	// every top-level `,` that is not inside a quoted string to get the
+	// `["a", "b", "c"]` form used throughout the codebase.
+	raw, err := jsonv2.Marshal(args)
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(raw) + len(args))
+	inQuote := false
+	escape := false
+	for _, c := range string(raw) {
+		b.WriteRune(c)
+		if escape {
+			escape = false
+			continue
+		}
+		if c == '\\' {
+			escape = true
+			continue
+		}
+		if c == '"' {
+			inQuote = !inQuote
+			continue
+		}
+		if c == ',' && !inQuote {
+			b.WriteByte(' ')
+		}
+	}
+	return b.String()
+}
 
 // isMultiLineInstruction reports whether the given source range spans more
 // than one physical line. Used by SHELL-line fixes that scan a single line

--- a/internal/rules/tally/powershell/wrapper_anchor.go
+++ b/internal/rules/tally/powershell/wrapper_anchor.go
@@ -4,9 +4,28 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/wharflab/tally/internal/sourcemap"
 )
+
+// isMultiLineInstruction reports whether the given source range spans more
+// than one physical line. Used by SHELL-line fixes that scan a single line
+// for brackets/quotes and need to bail out on continuation-split instructions
+// (backslash or backtick) to avoid producing invalid edit locations.
+//
+// Falls back to sm.ResolveEndLine when the parser-reported end line matches
+// the start line, which covers continuation cases where the parser collapses
+// the range (common for RUN; rare but possible for SHELL).
+func isMultiLineInstruction(sm *sourcemap.SourceMap, r parser.Range) bool {
+	if r.End.Line > r.Start.Line {
+		return true
+	}
+	if sm == nil {
+		return false
+	}
+	return sm.ResolveEndLine(r.End.Line) > r.Start.Line
+}
 
 // wrapperInsertionPoint locates the (line, column) offset inside a RUN's
 // source region where the inner script of an explicit powershell/pwsh

--- a/internal/rules/tally/powershell/wrapper_anchor.go
+++ b/internal/rules/tally/powershell/wrapper_anchor.go
@@ -1,0 +1,56 @@
+package powershell
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+// wrapperInsertionPoint locates the (line, column) offset inside a RUN's
+// source region where the inner script of an explicit powershell/pwsh
+// -Command wrapper begins. line is a 0-based offset from the RUN's first
+// location line; col is 0-based. The search is anchored past the executable
+// token so we never match the "RUN powershell" prefix.
+//
+// Shared by tally/powershell/error-action-preference and
+// tally/powershell/progress-preference, which both inject preamble text at
+// this anchor with a zero-width insertion.
+func wrapperInsertionPoint(
+	sm *sourcemap.SourceMap,
+	run *instructions.RunCommand,
+	invocation explicitPowerShellInvocation,
+) (line, col int, ok bool) {
+	if sm == nil || len(run.Location()) == 0 {
+		return 0, 0, false
+	}
+
+	startLine := run.Location()[0].Start.Line
+	endLine := run.Location()[len(run.Location())-1].End.Line
+
+	source := sm.Snippet(startLine-1, endLine-1)
+	if source == "" {
+		return 0, 0, false
+	}
+
+	exeLower := strings.ToLower(invocation.executable)
+	anchorIdx := strings.Index(strings.ToLower(source), exeLower)
+	if anchorIdx < 0 {
+		return 0, 0, false
+	}
+	searchStart := anchorIdx + len(exeLower)
+
+	firstToken := firstNonWhitespaceWord(invocation.script)
+	if firstToken == "" {
+		return 0, 0, false
+	}
+	relIdx := strings.Index(source[searchStart:], firstToken)
+	if relIdx < 0 {
+		return 0, 0, false
+	}
+	insertByte := searchStart + relIdx
+
+	line, col = sourcemap.ByteToLineCol(source, insertByte)
+	return line, col, true
+}


### PR DESCRIPTION
## Summary

- New `tally/powershell/progress-preference` rule (design-docs/27) warns when `Invoke-WebRequest` / `iwr` runs without `$ProgressPreference = 'SilentlyContinue'` — Windows containers stall massively on the per-response progress bar.
- Detection walks every RUN with no stage gate, since `Invoke-WebRequest` parsed via tree-sitter is itself the shell signal; fix shape is chosen from the effective shell context (five shapes: SHELL append, SHELL insert, wrapper-body prepend, heredoc-body prepend, existing-prelude append).
- Extracts shared `wrapperInsertionPoint` helper so `error-action-preference` no longer duplicates the inner-script anchor logic (fixes CPD finding introduced by the new rule).

## Test plan

- [x] `go test ./internal/rules/tally/powershell/...` (unit + overlap tests, file coverage ≥85%)
- [x] `go test ./internal/integration/...` (new `TestLint_powershell-progress-preference` + 7 `TestFix_powershell-progress-preference-*` snapshots, plus updated real-world Windows snapshots)
- [x] `make test` (6319 tests pass)
- [x] `make lint` (0 issues)
- [x] `make cpd` (clean)
- [x] `cd _docs && npx mint validate` (docs build)
- [x] Docs page added at `_docs/rules/tally/powershell/progress-preference.mdx` + `_docs/docs.json` navigation + `design-docs/PROPOSED-RULES-TRACKER.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PowerShell lint rule that detects Invoke-WebRequest usage without suppressed progress output and offers automated fixes.

* **Documentation**
  * Added user-facing docs for the new rule with examples and fix behavior.
  * Added a Proposed Rules Tracker design document.

* **Tests**
  * Added integration and unit tests covering many Dockerfile shapes, fix behaviors, and rule interactions.

* **Snapshots / Examples**
  * Added and updated Dockerfile snapshots and test snapshots to reflect the new rule and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->