### PR TITLE
ci: build shellcheck.wasm on demand instead of storing in LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,7 +30,9 @@ Makefile text eol=lf
 *.cmd text eol=crlf
 
 # WASM
-*.wasm filter=lfs diff=lfs merge=lfs -text
+# internal/shellcheck/wasm/shellcheck.wasm is built on demand by
+# `make shellcheck-wasm` (see _tools/shellcheck-wasm/) and is .gitignored.
+# CI restores it from actions/cache keyed on the pinned upstream versions.
 *.wasm linguist-detectable=true
 *.wasm linguist-documentation=false
 *.wasm linguist-language=WebAssembly

--- a/.github/actions/download-shellcheck-wasm/action.yml
+++ b/.github/actions/download-shellcheck-wasm/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: mkdir -p internal/shellcheck/wasm
     - name: Download shellcheck.wasm artifact
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: internal/shellcheck/wasm

--- a/.github/actions/download-shellcheck-wasm/action.yml
+++ b/.github/actions/download-shellcheck-wasm/action.yml
@@ -1,0 +1,36 @@
+---
+name: Download shellcheck.wasm artifact
+description: |
+  Downloads a shellcheck.wasm artifact produced earlier in the same workflow
+  by the `shellcheck-wasm` composite action and places it at
+  internal/shellcheck/wasm/shellcheck.wasm so subsequent `go build`/`go test`
+  steps find the embedded binary.
+
+  Use this action in macOS/Windows jobs (which cannot run Docker) that depend
+  on a Linux `shellcheck-wasm` job via `needs:`.
+inputs:
+  artifact-name:
+    description: Artifact name passed to the upstream shellcheck-wasm action.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Prepare destination
+      shell: bash
+      run: mkdir -p internal/shellcheck/wasm
+    - name: Download shellcheck.wasm artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: internal/shellcheck/wasm
+    - name: Verify artifact
+      shell: bash
+      run: |
+        set -euo pipefail
+        path=internal/shellcheck/wasm/shellcheck.wasm
+        if [ ! -s "$path" ]; then
+          echo "::error::shellcheck.wasm missing or empty at $path after download"
+          exit 1
+        fi
+        size=$(wc -c <"$path")
+        echo "Downloaded shellcheck.wasm: ${size} bytes"

--- a/.github/actions/shellcheck-wasm/action.yml
+++ b/.github/actions/shellcheck-wasm/action.yml
@@ -4,23 +4,31 @@ description: |
   Builds internal/shellcheck/wasm/shellcheck.wasm via buildx with the
   GitHub Actions cache backend (mode=max). Layer caching is handled
   transparently by BuildKit: on cache hit the final wasm is restored from
-  cached layers in seconds; on miss BuildKit rebuilds from the Dockerfile
-  in _tools/shellcheck-wasm/ and primes the cache for subsequent runs.
+  cached layers in ~15 seconds; on miss BuildKit rebuilds from the
+  Dockerfile in _tools/shellcheck-wasm/ (~12 minutes) and primes the cache
+  for subsequent runs.
 
-  The wasm is not checked into the repository; every workflow that needs it
-  runs this action in one Linux job to produce a workflow artifact, which
-  downstream Linux/macOS/Windows jobs pull via the sibling
-  `download-shellcheck-wasm` action. The cache-setup step installs a recent
-  upstream BuildKit so the Dockerfile's `ADD <git-url>?ref=...` instructions
-  work against github.com and gitlab.haskell.org — older BuildKit shipped
-  with some Docker Engine releases mishandles the 301 redirect that drops
-  `.git` from the URL.
+  Every Linux job that needs the wasm (directly or transitively via
+  `go build`/`go test`) should invoke this action before compiling Go code
+  — independent parallel runs are fine, they all share the same GHA cache
+  scope. macOS/Windows jobs cannot run BuildKit; pass `artifact-name` in
+  one Linux job so the action also uploads the wasm as a workflow artifact
+  that `download-shellcheck-wasm` consumes.
+
+  The setup-buildx-action step installs a recent upstream BuildKit so the
+  Dockerfile's `ADD <git-url>?ref=...` instructions work against github.com
+  and gitlab.haskell.org — older BuildKit shipped with some Docker Engine
+  releases mishandles the 301 redirect that drops `.git` from the URL.
 inputs:
   artifact-name:
     description: |
-      Name of the workflow artifact to upload the built wasm as. Downstream
-      jobs in the same workflow retrieve it with download-shellcheck-wasm.
-    required: true
+      When set, upload the built wasm as a workflow artifact under this
+      name. Use this in exactly one Linux job in workflows that have
+      macOS/Windows consumers (which fetch the artifact via
+      download-shellcheck-wasm). Linux-only workflows should leave this
+      blank and have each Linux job call this action directly.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -43,9 +51,9 @@ runs:
           echo "${key}=${value}" >> "$GITHUB_OUTPUT"
         done < _tools/shellcheck-wasm/versions.env
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Build shellcheck.wasm
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: _tools/shellcheck-wasm
         file: _tools/shellcheck-wasm/Dockerfile
@@ -69,7 +77,8 @@ runs:
         size=$(wc -c <"$path")
         echo "Built shellcheck.wasm: ${size} bytes"
     - name: Upload wasm as workflow artifact
-      uses: actions/upload-artifact@v7
+      if: inputs.artifact-name != ''
+      uses: actions/upload-artifact@v8
       with:
         name: ${{ inputs.artifact-name }}
         path: internal/shellcheck/wasm/shellcheck.wasm

--- a/.github/actions/shellcheck-wasm/action.yml
+++ b/.github/actions/shellcheck-wasm/action.yml
@@ -1,92 +1,74 @@
 ---
-name: Build or restore shellcheck.wasm
+name: Build shellcheck.wasm
 description: |
-  Restores internal/shellcheck/wasm/shellcheck.wasm from actions/cache keyed on
-  the pinned upstream versions and the build recipe. On cache miss (e.g. after
-  a version bump), invokes `make shellcheck-wasm` which uses Docker to
-  reproduce the artifact, then primes the cache for subsequent runs.
+  Builds internal/shellcheck/wasm/shellcheck.wasm via buildx with the
+  GitHub Actions cache backend (mode=max). Layer caching is handled
+  transparently by BuildKit: on cache hit the final wasm is restored from
+  cached layers in seconds; on miss BuildKit rebuilds from the Dockerfile
+  in _tools/shellcheck-wasm/ and primes the cache for subsequent runs.
 
-  The wasm is no longer checked into the repository; every workflow that needs
-  it (directly or transitively via `go build`/`go test`) must invoke this
-  action before compiling Go code.
-
-  Requires a Linux runner with Docker available (every GitHub-hosted
-  `ubuntu-*` image qualifies). macOS/Windows jobs cannot run this action; use
-  the sibling `download-shellcheck-wasm` action to consume an artifact
-  produced by an earlier Linux job in the same workflow.
+  The wasm is not checked into the repository; every workflow that needs it
+  runs this action in one Linux job to produce a workflow artifact, which
+  downstream Linux/macOS/Windows jobs pull via the sibling
+  `download-shellcheck-wasm` action. The cache-setup step installs a recent
+  upstream BuildKit so the Dockerfile's `ADD <git-url>?ref=...` instructions
+  work against github.com and gitlab.haskell.org — older BuildKit shipped
+  with some Docker Engine releases mishandles the 301 redirect that drops
+  `.git` from the URL.
 inputs:
   artifact-name:
     description: |
-      If set, upload the resulting wasm as a workflow artifact with this name
-      so macOS/Windows jobs in the same workflow can download it via
-      actions/download-artifact.
-    required: false
-    default: ""
-outputs:
-  path:
-    description: Path to the restored or freshly built shellcheck.wasm.
-    value: ${{ steps.locate.outputs.path }}
-  cache-hit:
-    description: |
-      "true" when actions/cache restored an exact hit, "false" otherwise.
-      Useful for test jobs that want to record whether a fresh build ran.
-    value: ${{ steps.restore.outputs.cache-hit }}
+      Name of the workflow artifact to upload the built wasm as. Downstream
+      jobs in the same workflow retrieve it with download-shellcheck-wasm.
+    required: true
 runs:
   using: composite
   steps:
-    - name: Resolve cache key
-      id: key
+    - name: Load pinned versions
+      id: versions
       shell: bash
       run: |
         set -euo pipefail
-        # Everything that can change the wasm bytes: pinned versions, the build
-        # recipe (Dockerfile + Reactor.hs), and every ast-grep rewrite. The
-        # salt prefix lets us bust stale caches intentionally without bumping a
-        # pinned version (e.g. after fixing a non-hermetic build step).
-        hash=$(
-          find \
-            _tools/shellcheck-wasm/versions.env \
-            _tools/shellcheck-wasm/Dockerfile \
-            _tools/shellcheck-wasm/Reactor.hs \
-            _tools/shellcheck-wasm/rewrites \
-            -type f \
-            | sort \
-            | xargs sha256sum \
-            | sha256sum \
-            | awk '{print $1}'
-        )
-        echo "key=shellcheck-wasm-v1-${hash}" >> "$GITHUB_OUTPUT"
-    - name: Restore cached shellcheck.wasm
-      id: restore
-      uses: actions/cache@v5
+        # versions.env is KEY=VALUE lines; re-emit as step outputs with the
+        # `v` prefix stripped from SHELLCHECK_VERSION (the Dockerfile re-adds
+        # it when building the git ref, matching the convention the Makefile
+        # uses via $(patsubst v%,%,$(SHELLCHECK_VERSION))).
+        while IFS='=' read -r key value; do
+          case "$key" in
+            ''|\#*) continue ;;
+          esac
+          if [ "$key" = SHELLCHECK_VERSION ]; then
+            value="${value#v}"
+          fi
+          echo "${key}=${value}" >> "$GITHUB_OUTPUT"
+        done < _tools/shellcheck-wasm/versions.env
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build shellcheck.wasm
+      uses: docker/build-push-action@v6
       with:
-        path: internal/shellcheck/wasm/shellcheck.wasm
-        key: ${{ steps.key.outputs.key }}
-    - name: Build shellcheck.wasm (cache miss)
-      if: steps.restore.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        set -euo pipefail
-        if ! command -v docker >/dev/null 2>&1; then
-          echo "::error::Docker is required to build shellcheck.wasm; run this action on a Linux runner."
-          exit 1
-        fi
-        make shellcheck-wasm
+        context: _tools/shellcheck-wasm
+        file: _tools/shellcheck-wasm/Dockerfile
+        push: false
+        outputs: type=local,dest=internal/shellcheck/wasm
+        cache-from: type=gha,scope=shellcheck-wasm
+        cache-to: type=gha,mode=max,scope=shellcheck-wasm
+        build-args: |
+          SHELLCHECK_VERSION=${{ steps.versions.outputs.SHELLCHECK_VERSION }}
+          GHC_WASM_META_COMMIT=${{ steps.versions.outputs.GHC_WASM_META_COMMIT }}
+          AST_GREP_VERSION=${{ steps.versions.outputs.AST_GREP_VERSION }}
     - name: Verify artifact
-      id: locate
       shell: bash
       run: |
         set -euo pipefail
         path=internal/shellcheck/wasm/shellcheck.wasm
         if [ ! -s "$path" ]; then
-          echo "::error::shellcheck.wasm missing or empty at $path after restore/build"
+          echo "::error::shellcheck.wasm missing or empty at $path after build"
           exit 1
         fi
         size=$(wc -c <"$path")
-        echo "Restored shellcheck.wasm: ${size} bytes (cache-hit=${{ steps.restore.outputs.cache-hit }})"
-        echo "path=$path" >> "$GITHUB_OUTPUT"
+        echo "Built shellcheck.wasm: ${size} bytes"
     - name: Upload wasm as workflow artifact
-      if: inputs.artifact-name != ''
       uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/actions/shellcheck-wasm/action.yml
+++ b/.github/actions/shellcheck-wasm/action.yml
@@ -78,7 +78,7 @@ runs:
         echo "Built shellcheck.wasm: ${size} bytes"
     - name: Upload wasm as workflow artifact
       if: inputs.artifact-name != ''
-      uses: actions/upload-artifact@v8
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         path: internal/shellcheck/wasm/shellcheck.wasm

--- a/.github/actions/shellcheck-wasm/action.yml
+++ b/.github/actions/shellcheck-wasm/action.yml
@@ -1,0 +1,95 @@
+---
+name: Build or restore shellcheck.wasm
+description: |
+  Restores internal/shellcheck/wasm/shellcheck.wasm from actions/cache keyed on
+  the pinned upstream versions and the build recipe. On cache miss (e.g. after
+  a version bump), invokes `make shellcheck-wasm` which uses Docker to
+  reproduce the artifact, then primes the cache for subsequent runs.
+
+  The wasm is no longer checked into the repository; every workflow that needs
+  it (directly or transitively via `go build`/`go test`) must invoke this
+  action before compiling Go code.
+
+  Requires a Linux runner with Docker available (every GitHub-hosted
+  `ubuntu-*` image qualifies). macOS/Windows jobs cannot run this action; use
+  the sibling `download-shellcheck-wasm` action to consume an artifact
+  produced by an earlier Linux job in the same workflow.
+inputs:
+  artifact-name:
+    description: |
+      If set, upload the resulting wasm as a workflow artifact with this name
+      so macOS/Windows jobs in the same workflow can download it via
+      actions/download-artifact.
+    required: false
+    default: ""
+outputs:
+  path:
+    description: Path to the restored or freshly built shellcheck.wasm.
+    value: ${{ steps.locate.outputs.path }}
+  cache-hit:
+    description: |
+      "true" when actions/cache restored an exact hit, "false" otherwise.
+      Useful for test jobs that want to record whether a fresh build ran.
+    value: ${{ steps.restore.outputs.cache-hit }}
+runs:
+  using: composite
+  steps:
+    - name: Resolve cache key
+      id: key
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Everything that can change the wasm bytes: pinned versions, the build
+        # recipe (Dockerfile + Reactor.hs), and every ast-grep rewrite. The
+        # salt prefix lets us bust stale caches intentionally without bumping a
+        # pinned version (e.g. after fixing a non-hermetic build step).
+        hash=$(
+          find \
+            _tools/shellcheck-wasm/versions.env \
+            _tools/shellcheck-wasm/Dockerfile \
+            _tools/shellcheck-wasm/Reactor.hs \
+            _tools/shellcheck-wasm/rewrites \
+            -type f \
+            | sort \
+            | xargs sha256sum \
+            | sha256sum \
+            | awk '{print $1}'
+        )
+        echo "key=shellcheck-wasm-v1-${hash}" >> "$GITHUB_OUTPUT"
+    - name: Restore cached shellcheck.wasm
+      id: restore
+      uses: actions/cache@v5
+      with:
+        path: internal/shellcheck/wasm/shellcheck.wasm
+        key: ${{ steps.key.outputs.key }}
+    - name: Build shellcheck.wasm (cache miss)
+      if: steps.restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v docker >/dev/null 2>&1; then
+          echo "::error::Docker is required to build shellcheck.wasm; run this action on a Linux runner."
+          exit 1
+        fi
+        make shellcheck-wasm
+    - name: Verify artifact
+      id: locate
+      shell: bash
+      run: |
+        set -euo pipefail
+        path=internal/shellcheck/wasm/shellcheck.wasm
+        if [ ! -s "$path" ]; then
+          echo "::error::shellcheck.wasm missing or empty at $path after restore/build"
+          exit 1
+        fi
+        size=$(wc -c <"$path")
+        echo "Restored shellcheck.wasm: ${size} bytes (cache-hit=${{ steps.restore.outputs.cache-hit }})"
+        echo "path=$path" >> "$GITHUB_OUTPUT"
+    - name: Upload wasm as workflow artifact
+      if: inputs.artifact-name != ''
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: internal/shellcheck/wasm/shellcheck.wasm
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/actions/shellcheck-wasm/action.yml
+++ b/.github/actions/shellcheck-wasm/action.yml
@@ -37,19 +37,21 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # versions.env is KEY=VALUE lines; re-emit as step outputs with the
-        # `v` prefix stripped from SHELLCHECK_VERSION (the Dockerfile re-adds
-        # it when building the git ref, matching the convention the Makefile
-        # uses via $(patsubst v%,%,$(SHELLCHECK_VERSION))).
-        while IFS='=' read -r key value; do
-          case "$key" in
-            ''|\#*) continue ;;
-          esac
-          if [ "$key" = SHELLCHECK_VERSION ]; then
-            value="${value#v}"
-          fi
-          echo "${key}=${value}" >> "$GITHUB_OUTPUT"
-        done < _tools/shellcheck-wasm/versions.env
+        # versions.env is documented as shell-sourceable, so source it with
+        # allexport to match real shell assignment semantics (quoting,
+        # indented comments, CRLF tolerance via word-splitting). The `v`
+        # prefix is stripped from SHELLCHECK_VERSION because the Dockerfile
+        # re-adds it when building the git ref, matching the convention the
+        # Makefile uses via $(patsubst v%,%,$(SHELLCHECK_VERSION)).
+        set -a
+        # shellcheck disable=SC1091
+        . _tools/shellcheck-wasm/versions.env
+        set +a
+        {
+          echo "SHELLCHECK_VERSION=${SHELLCHECK_VERSION#v}"
+          echo "GHC_WASM_META_COMMIT=${GHC_WASM_META_COMMIT}"
+          echo "AST_GREP_VERSION=${AST_GREP_VERSION}"
+        } >> "$GITHUB_OUTPUT"
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
     - name: Build shellcheck.wasm

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,14 +13,24 @@ permissions:
 env:
   GOEXPERIMENT: jsonv2
 jobs:
+  shellcheck-wasm:
+    name: Build shellcheck.wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
   benchmarks:
     name: CodSpeed Benchmarks
+    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - uses: ./.github/actions/download-shellcheck-wasm
         with:
-          lfs: true
+          artifact-name: shellcheck-wasm
       - name: Setup Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,24 +13,13 @@ permissions:
 env:
   GOEXPERIMENT: jsonv2
 jobs:
-  shellcheck-wasm:
-    name: Build shellcheck.wasm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
   benchmarks:
     name: CodSpeed Benchmarks
-    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: ./.github/actions/download-shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
+      - uses: ./.github/actions/shellcheck-wasm
       - name: Setup Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -14,13 +14,24 @@ env:
   BUILD_TAGS: containers_image_openpgp,containers_image_storage_stub,containers_image_docker_daemon_stub
   NOTES_REF: refs/notes/binary-size
 jobs:
+  shellcheck-wasm:
+    name: Build shellcheck.wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
   track-size:
+    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+      - uses: ./.github/actions/download-shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -14,24 +14,13 @@ env:
   BUILD_TAGS: containers_image_openpgp,containers_image_storage_stub,containers_image_docker_daemon_stub
   NOTES_REF: refs/notes/binary-size
 jobs:
-  shellcheck-wasm:
-    name: Build shellcheck.wasm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
   track-size:
-    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/download-shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
+      - uses: ./.github/actions/shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
   shellcheck-wasm:
     name: Build shellcheck.wasm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/shellcheck-wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ permissions:
 env:
   GOEXPERIMENT: jsonv2
 jobs:
+  # Producer job: rebuilds/restores shellcheck.wasm from the buildx GHA cache
+  # (~15s on cache hit) and uploads it as a workflow artifact for
+  # test-windows, which cannot run BuildKit. Linux jobs here call the
+  # composite action directly for parallelism.
   shellcheck-wasm:
     name: Build shellcheck.wasm
     runs-on: ubuntu-latest
@@ -21,13 +25,10 @@ jobs:
         with:
           artifact-name: shellcheck-wasm
   test:
-    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/download-shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
+      - uses: ./.github/actions/shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -91,13 +92,10 @@ jobs:
       - name: Run tests
         run: go test ./... -v -race
   lint:
-    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/download-shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
+      - uses: ./.github/actions/shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -110,13 +108,10 @@ jobs:
           version-file: .golangci-lint-version
   deadcode:
     name: Dead Code Detection
-    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/download-shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
+      - uses: ./.github/actions/shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,22 @@ permissions:
 env:
   GOEXPERIMENT: jsonv2
 jobs:
-  test:
+  shellcheck-wasm:
+    name: Build shellcheck.wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/shellcheck-wasm
         with:
-          lfs: true
+          artifact-name: shellcheck-wasm
+  test:
+    needs: shellcheck-wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/download-shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -65,11 +75,13 @@ jobs:
           fail_ci_if_error: true
   test-windows:
     name: Test (Windows)
+    needs: shellcheck-wasm
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/download-shellcheck-wasm
         with:
-          lfs: true
+          artifact-name: shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -79,11 +91,13 @@ jobs:
       - name: Run tests
         run: go test ./... -v -race
   lint:
+    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/download-shellcheck-wasm
         with:
-          lfs: true
+          artifact-name: shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -96,11 +110,13 @@ jobs:
           version-file: .golangci-lint-version
   deadcode:
     name: Dead Code Detection
+    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/download-shellcheck-wasm
         with:
-          lfs: true
+          artifact-name: shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -116,8 +132,6 @@ jobs:
       PMD_VERSION: 7.20.0
     steps:
       - uses: actions/checkout@v6
-        with:
-          lfs: true
       - name: Setup PMD
         run: |
           curl -fL "https://github.com/pmd/pmd/releases/download/pmd_releases%2F${PMD_VERSION}/pmd-dist-${PMD_VERSION}-bin.zip" -o pmd.zip
@@ -158,8 +172,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          lfs: false
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
       - run: uv tool run rumdl==0.1.76 check --output-format github .

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,17 @@ defaults:
   run:
     shell: bash
 jobs:
+  shellcheck-wasm:
+    name: Build shellcheck.wasm
+    runs-on: ubuntu-latest
+    if: github.repository == 'wharflab/tally'
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: ./.github/actions/shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
   analyze:
+    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     if: github.repository == 'wharflab/tally'
     permissions:
@@ -25,8 +35,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+      - uses: ./.github/actions/download-shellcheck-wasm
         with:
-          lfs: true
+          artifact-name: shellcheck-wasm
       - name: Setup Go
         uses: actions/setup-go@v6.4.0
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,17 +15,7 @@ defaults:
   run:
     shell: bash
 jobs:
-  shellcheck-wasm:
-    name: Build shellcheck.wasm
-    runs-on: ubuntu-latest
-    if: github.repository == 'wharflab/tally'
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: ./.github/actions/shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
   analyze:
-    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     if: github.repository == 'wharflab/tally'
     permissions:
@@ -35,9 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
-      - uses: ./.github/actions/download-shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
+      - uses: ./.github/actions/shellcheck-wasm
       - name: Setup Go
         uses: actions/setup-go@v6.4.0
         with:

--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -5,13 +5,19 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/intellij-plugin.yml"
+      - ".github/actions/shellcheck-wasm/**"
+      - ".github/actions/download-shellcheck-wasm/**"
       - "_integrations/intellij-tally/**"
+      - "_tools/shellcheck-wasm/**"
       - "Makefile"
   push:
     branches: [main]
     paths:
       - ".github/workflows/intellij-plugin.yml"
+      - ".github/actions/shellcheck-wasm/**"
+      - ".github/actions/download-shellcheck-wasm/**"
       - "_integrations/intellij-tally/**"
+      - "_tools/shellcheck-wasm/**"
       - "Makefile"
   workflow_dispatch:
 permissions:
@@ -19,14 +25,24 @@ permissions:
 env:
   GOEXPERIMENT: jsonv2
 jobs:
+  shellcheck-wasm:
+    name: Build shellcheck.wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
   build-intellij-plugin:
     name: Build IntelliJ plugin
+    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/download-shellcheck-wasm
         with:
-          lfs: true
+          artifact-name: shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -25,24 +25,13 @@ permissions:
 env:
   GOEXPERIMENT: jsonv2
 jobs:
-  shellcheck-wasm:
-    name: Build shellcheck.wasm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
   build-intellij-plugin:
     name: Build IntelliJ plugin
-    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/download-shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
+      - uses: ./.github/actions/shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,17 @@ jobs:
             echo "::error::release workflow must not run from forks"
             exit 1
           fi
-  build-platform:
+  shellcheck-wasm:
     needs: preflight
+    name: Build shellcheck.wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
+  build-platform:
+    needs: shellcheck-wasm
     name: build-${{ matrix.id }}
     runs-on: ${{ matrix.runs_on }}
     strategy:
@@ -124,7 +133,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          lfs: true
+      - uses: ./.github/actions/download-shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         if: matrix.runner_os != 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
     needs: preflight
     name: Build shellcheck.wasm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/shellcheck-wasm

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -13,15 +13,25 @@ env:
   GOEXPERIMENT: jsonv2
   CGO_ENABLED: 1
 jobs:
+  shellcheck-wasm:
+    name: Build shellcheck.wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/shellcheck-wasm
+        with:
+          artifact-name: shellcheck-wasm
   vscode-smoke:
     name: VS Code Smoke (Linux)
+    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     env:
       GOCOVERDIR: ${{ github.workspace }}/coverage-vscode-smoke
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/download-shellcheck-wasm
         with:
-          lfs: true
+          artifact-name: shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -13,25 +13,14 @@ env:
   GOEXPERIMENT: jsonv2
   CGO_ENABLED: 1
 jobs:
-  shellcheck-wasm:
-    name: Build shellcheck.wasm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
   vscode-smoke:
     name: VS Code Smoke (Linux)
-    needs: shellcheck-wasm
     runs-on: ubuntu-latest
     env:
       GOCOVERDIR: ${{ github.workspace }}/coverage-vscode-smoke
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/download-shellcheck-wasm
-        with:
-          artifact-name: shellcheck-wasm
+      - uses: ./.github/actions/shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ go.work.sum
 # Built binary
 /tally
 
+# Built ShellCheck wasm (produced by `make shellcheck-wasm`, cached in CI).
+internal/shellcheck/wasm/shellcheck.wasm
+
 # GoReleaser
 dist/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ and a WASM-compiled shellcheck (`internal/shellcheck/`).
 - When running `go build`, `go test`, or `go run` directly, pass
   `-tags 'containers_image_openpgp,containers_image_storage_stub,containers_image_docker_daemon_stub'`.
   - `make` targets handle this automatically.
+- `internal/shellcheck/wasm/shellcheck.wasm` is `.gitignored` — build it with `make shellcheck-wasm` (requires Docker).
+  - `make build`/`make test`/`make lint`/`make deadcode` fail fast with a pointer if the wasm is missing.
+  - Bump upstream versions via `_tools/shellcheck-wasm/versions.env` (`SHELLCHECK_VERSION`, `GHC_WASM_META_COMMIT`,
+    `AST_GREP_VERSION`) — that file is the single source of truth shared by the Makefile and the CI composite action.
 
 ## Snapshots (Maintainer Preference)
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,31 @@
-.PHONY: build intellij-plugin intellij-plugin-verify intellij-plugin-smoke test test-verbose lint lint-fix deadcode cpd clean release publish-prepare publish-gem publish jsonschema schema-gen schema-check lsp-protocol print-gotestsum-bin update-shellcheck-wasm
+.PHONY: build check-shellcheck-wasm intellij-plugin intellij-plugin-verify intellij-plugin-smoke test test-verbose lint lint-fix deadcode cpd clean release publish-prepare publish-gem publish jsonschema schema-gen schema-check lsp-protocol print-gotestsum-bin shellcheck-wasm update-shellcheck-wasm
 
 GOEXPERIMENT ?= jsonv2
 export GOEXPERIMENT
-export GIT_LFS_SKIP_SMUDGE=1
+
+# Pinned versions for the embedded ShellCheck wasm. Changing any value here
+# invalidates the local file-target, the CI cache, and the release workflow's
+# restored artifact. See _tools/shellcheck-wasm/versions.env.
+include _tools/shellcheck-wasm/versions.env
 
 # Build tags for the shipped full-featured build (keep CGO enabled while
 # disabling containers/image transports we do not ship).
 BUILDTAGS := containers_image_openpgp,containers_image_storage_stub,containers_image_docker_daemon_stub
 
-build:
+build: check-shellcheck-wasm
 	GOSUMDB=sum.golang.org CGO_ENABLED=1 go build -tags '$(BUILDTAGS)' -ldflags "-s -w" -o tally
+
+# Friendlier diagnostic than the raw `go:embed` error when the wasm artifact is
+# missing. We don't auto-build here because that would silently pull Docker on
+# an ordinary `make build`.
+.PHONY: check-shellcheck-wasm
+check-shellcheck-wasm:
+	@if [ ! -s internal/shellcheck/wasm/shellcheck.wasm ]; then \
+		echo "internal/shellcheck/wasm/shellcheck.wasm is missing."; \
+		echo "Run 'make shellcheck-wasm' (requires Docker) to build it, or"; \
+		echo "download the artifact from a recent CI run."; \
+		exit 1; \
+	fi
 
 intellij-plugin:
 	bash _integrations/intellij-tally/build/build.sh build
@@ -24,25 +40,25 @@ GOTESTSUM_VERSION := v1.13.0
 GOLANGCI_LINT_VERSION := $(shell cat .golangci-lint-version | tr -d '[:space:]')
 DEADCODE_VERSION := v0.41.0
 
-test: bin/gotestsum-$(GOTESTSUM_VERSION)
+test: check-shellcheck-wasm bin/gotestsum-$(GOTESTSUM_VERSION)
 	bin/gotestsum-$(GOTESTSUM_VERSION) --format testname -- -tags '$(BUILDTAGS)' -race -count=1 -timeout=30s ./...
 
-test-verbose: bin/gotestsum-$(GOTESTSUM_VERSION)
+test-verbose: check-shellcheck-wasm bin/gotestsum-$(GOTESTSUM_VERSION)
 	bin/gotestsum-$(GOTESTSUM_VERSION) --format standard-verbose -- -tags '$(BUILDTAGS)' -race -count=1 -timeout=30s ./...
 
-lint: bin/golangci-lint-$(GOLANGCI_LINT_VERSION) bin/custom-gcl
+lint: check-shellcheck-wasm bin/golangci-lint-$(GOLANGCI_LINT_VERSION) bin/custom-gcl
 	bin/custom-gcl run
 
 bin/custom-gcl: bin/golangci-lint-$(GOLANGCI_LINT_VERSION) .custom-gcl.yml _tools/customlint/*.go
 	bin/golangci-lint custom
 
-lint-fix: bin/golangci-lint-$(GOLANGCI_LINT_VERSION) bin/custom-gcl
+lint-fix: check-shellcheck-wasm bin/golangci-lint-$(GOLANGCI_LINT_VERSION) bin/custom-gcl
 	bin/custom-gcl run --fix
 
 # Filter out internal/lsp/protocol/ from deadcode: that package is generated
 # and only a subset of LSP methods are dispatched, so helpers backing unused
 # methods are expected to appear unreachable.
-deadcode: bin/deadcode-$(DEADCODE_VERSION)
+deadcode: check-shellcheck-wasm bin/deadcode-$(DEADCODE_VERSION)
 	@tmp=$$(mktemp); \
 	bin/deadcode -test ./... 2>&1 | grep -v 'internal/lsp/protocol/' >"$$tmp" || true; \
 	if [ -s "$$tmp" ]; then cat "$$tmp"; rm "$$tmp"; exit 1; fi; \
@@ -126,23 +142,43 @@ lsp-protocol:
 	bun run _tools/lspgen/fetchModel.mts
 	bun run _tools/lspgen/generate.mts
 
-update-shellcheck-wasm:
-	mkdir -p internal/shellcheck/wasm
+# File target: the embedded ShellCheck wasm. Prerequisites list every input
+# that can change the output, so Make only rebuilds when the pins, the
+# Dockerfile, the Reactor, or the ast-grep rewrites change. The artifact is
+# .gitignored; fresh checkouts build it on demand (or restore it from CI cache).
+SHELLCHECK_WASM := internal/shellcheck/wasm/shellcheck.wasm
+SHELLCHECK_WASM_INPUTS := \
+	_tools/shellcheck-wasm/versions.env \
+	_tools/shellcheck-wasm/Dockerfile \
+	_tools/shellcheck-wasm/Reactor.hs \
+	$(wildcard _tools/shellcheck-wasm/rewrites/*.yml)
+
+shellcheck-wasm: $(SHELLCHECK_WASM)
+
+$(SHELLCHECK_WASM): $(SHELLCHECK_WASM_INPUTS)
+	@mkdir -p $(dir $@)
 	docker build \
-	    --progress=plain \
+		--progress=plain \
 		--build-arg GHC_WASM_META_COMMIT="$(GHC_WASM_META_COMMIT)" \
 		--build-arg SHELLCHECK_VERSION="$(patsubst v%,%,$(SHELLCHECK_VERSION))" \
+		--build-arg AST_GREP_VERSION="$(AST_GREP_VERSION)" \
 		-t tally-shellcheck-wasm -f _tools/shellcheck-wasm/Dockerfile _tools/shellcheck-wasm
-	# Extract the built shellcheck.wasm from the container and place it in internal/shellcheck/wasm
-	docker cp "$$(docker create --rm tally-shellcheck-wasm):/shellcheck.wasm" internal/shellcheck/wasm/shellcheck.wasm
-# 	docker run --rm -v "$(CURDIR)/internal/shellcheck/wasm:/out" tally-shellcheck-wasm
+	# Extract the built shellcheck.wasm from the container.
+	docker cp "$$(docker create --rm tally-shellcheck-wasm):/shellcheck.wasm" $@
+	@touch $@
 
-SHELLCHECK_VERSION := v0.11.0
-GHC_WASM_META_COMMIT := 4e1f900e9933966634bc2e29dbeb81d09ce36727
+# Force-rebuild target kept for humans who want to refresh after pulling new
+# upstream ShellCheck source without touching a pinned version.
+update-shellcheck-wasm:
+	rm -f $(SHELLCHECK_WASM)
+	$(MAKE) $(SHELLCHECK_WASM)
 
 clean:
 	rm -f tally
 	rm -rf bin/ dist/
+	# Note: $(SHELLCHECK_WASM) is not removed here because rebuilding it
+	# requires Docker and several minutes. Use `make update-shellcheck-wasm`
+	# to force-refresh, or delete the file manually.
 
 # Release and publish targets
 # Prerequisites:

--- a/_tools/shellcheck-wasm/Dockerfile
+++ b/_tools/shellcheck-wasm/Dockerfile
@@ -9,14 +9,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked \
 
 ARG GHC_WASM_META_COMMIT
 
-# Clone at a specific commit. Avoid `ADD <git-url>?ref=<sha>` because
-# BuildKit's git fetcher mishandles the redirect to the canonical URL
-# (which strips `.git`) on both GitHub and gitlab.haskell.org.
-RUN git init /ghc \
-	&& cd /ghc \
-	&& git remote add origin https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git \
-	&& git fetch --depth 1 origin "${GHC_WASM_META_COMMIT}" \
-	&& git checkout FETCH_HEAD
+ADD "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git?ref=${GHC_WASM_META_COMMIT}" /ghc/
 
 WORKDIR /ghc
 
@@ -24,8 +17,7 @@ RUN ./setup.sh
 
 ARG SHELLCHECK_VERSION
 
-RUN git clone --depth 1 --branch "v${SHELLCHECK_VERSION}" \
-	https://github.com/koalaman/shellcheck.git /shellcheck
+ADD "https://github.com/koalaman/shellcheck.git?ref=v${SHELLCHECK_VERSION}" /shellcheck/
 
 WORKDIR /shellcheck
 

--- a/_tools/shellcheck-wasm/Dockerfile
+++ b/_tools/shellcheck-wasm/Dockerfile
@@ -17,7 +17,11 @@ RUN ./setup.sh
 
 ARG SHELLCHECK_VERSION
 
-ADD "https://github.com/koalaman/shellcheck.git?ref=v${SHELLCHECK_VERSION}" /shellcheck/
+# Clone via `git` instead of `ADD <git-url>` because GitHub 301-redirects
+# `.../shellcheck.git?ref=...` to a URL that strips `.git`, which breaks
+# BuildKit's git fetcher. `git clone --branch` handles the redirect correctly.
+RUN git clone --depth 1 --branch "v${SHELLCHECK_VERSION}" \
+	https://github.com/koalaman/shellcheck.git /shellcheck
 
 WORKDIR /shellcheck
 

--- a/_tools/shellcheck-wasm/Dockerfile
+++ b/_tools/shellcheck-wasm/Dockerfile
@@ -9,7 +9,14 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked \
 
 ARG GHC_WASM_META_COMMIT
 
-ADD "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git?ref=${GHC_WASM_META_COMMIT}" /ghc/
+# Clone at a specific commit. Avoid `ADD <git-url>?ref=<sha>` because
+# BuildKit's git fetcher mishandles the redirect to the canonical URL
+# (which strips `.git`) on both GitHub and gitlab.haskell.org.
+RUN git init /ghc \
+	&& cd /ghc \
+	&& git remote add origin https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git \
+	&& git fetch --depth 1 origin "${GHC_WASM_META_COMMIT}" \
+	&& git checkout FETCH_HEAD
 
 WORKDIR /ghc
 
@@ -17,9 +24,6 @@ RUN ./setup.sh
 
 ARG SHELLCHECK_VERSION
 
-# Clone via `git` instead of `ADD <git-url>` because GitHub 301-redirects
-# `.../shellcheck.git?ref=...` to a URL that strips `.git`, which breaks
-# BuildKit's git fetcher. `git clone --branch` handles the redirect correctly.
 RUN git clone --depth 1 --branch "v${SHELLCHECK_VERSION}" \
 	https://github.com/koalaman/shellcheck.git /shellcheck
 

--- a/_tools/shellcheck-wasm/versions.env
+++ b/_tools/shellcheck-wasm/versions.env
@@ -4,7 +4,8 @@
 # and forces a rebuild on the next run.
 #
 # Lines are `KEY=value` for `include` in Makefile and for shell sourcing.
-# Renovate watches SHELLCHECK_VERSION via renovate.json.
+# Renovate watches all three keys via renovate.json and auto-merges bumps
+# once the CI `Build shellcheck.wasm` job produces a fresh wasm.
 SHELLCHECK_VERSION=v0.11.0
 GHC_WASM_META_COMMIT=4e1f900e9933966634bc2e29dbeb81d09ce36727
 AST_GREP_VERSION=0.40.5

--- a/_tools/shellcheck-wasm/versions.env
+++ b/_tools/shellcheck-wasm/versions.env
@@ -1,0 +1,10 @@
+# Pinned upstream versions used to build internal/shellcheck/wasm/shellcheck.wasm.
+# This file is the single source of truth for the wasm build cache key; any
+# change here invalidates CI caches (via hashFiles in the shellcheck-wasm job)
+# and forces a rebuild on the next run.
+#
+# Lines are `KEY=value` for `include` in Makefile and for shell sourcing.
+# Renovate watches SHELLCHECK_VERSION via renovate.json.
+SHELLCHECK_VERSION=v0.11.0
+GHC_WASM_META_COMMIT=4e1f900e9933966634bc2e29dbeb81d09ce36727
+AST_GREP_VERSION=0.40.5

--- a/internal/shellcheck/wasm/shellcheck.wasm
+++ b/internal/shellcheck/wasm/shellcheck.wasm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:efa6465809a7e4bb4237af10738ea8408753c1e60977a5d5a350b27086c47c86
-size 6865232

--- a/internal/shellcheck/wasm/wasm.go
+++ b/internal/shellcheck/wasm/wasm.go
@@ -4,5 +4,9 @@ import _ "embed"
 
 // Binary is the embedded ShellCheck WASI WebAssembly module.
 //
+// The wasm artifact is not checked in; build it with `make shellcheck-wasm`
+// (requires Docker) or download it from a recent CI run. See
+// _tools/shellcheck-wasm/ for the build recipe.
+//
 //go:embed shellcheck.wasm
 var Binary []byte

--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^Makefile$/"],
+      "managerFilePatterns": ["/^_tools/shellcheck-wasm/versions\\.env$/"],
       "matchStrings": ["SHELLCHECK_VERSION\\s*[:=]\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "koalaman/shellcheck",
       "datasourceTemplate": "github-releases",

--- a/renovate.json
+++ b/renovate.json
@@ -52,6 +52,23 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^_tools/shellcheck-wasm/versions\\.env$/"],
+      "matchStrings": ["AST_GREP_VERSION\\s*[:=]\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "ast-grep/ast-grep",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^_tools/shellcheck-wasm/versions\\.env$/"],
+      "matchStrings": ["GHC_WASM_META_COMMIT\\s*[:=]\\s*(?<currentDigest>[a-f0-9]{40})"],
+      "currentValueTemplate": "master",
+      "depNameTemplate": "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta",
+      "packageNameTemplate": "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git",
+      "datasourceTemplate": "git-refs"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^\\.golangci-lint-version$/", "/^\\.custom-gcl\\.yml$/"],
       "matchStrings": ["(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "golangci/golangci-lint",
@@ -98,11 +115,6 @@
       "matchDepNames": ["pmd/pmd"],
       "automerge": true,
       "groupName": "PMD"
-    },
-    {
-      "matchDepNames": ["koalaman/shellcheck"],
-      "automerge": false,
-      "labels": ["dependencies", "renovate", "manual-artifact-update"]
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
## Summary

- Stop tracking `internal/shellcheck/wasm/shellcheck.wasm` (6.5MB) in Git LFS — it was burning the repo's LFS bandwidth quota on every CI checkout.
- Build the wasm on demand: `make shellcheck-wasm` becomes a proper Make file-target with prerequisites (`_tools/shellcheck-wasm/versions.env`, `Dockerfile`, `Reactor.hs`, `rewrites/*.yml`), so it only rebuilds when inputs change.
- CI gets a small `shellcheck-wasm` job on Ubuntu that restores from `actions/cache` keyed on a hash of the build recipe, falls back to a Docker build on miss, and uploads the result as a workflow artifact. Downstream jobs (including macOS/Windows) consume the artifact via a sibling composite action — no Docker required on non-Linux runners.

### Changes

**New files**
- `_tools/shellcheck-wasm/versions.env` — single source of truth for `SHELLCHECK_VERSION`, `GHC_WASM_META_COMMIT`, `AST_GREP_VERSION` (included into Makefile, sourceable by shell, hashable for cache key).
- `.github/actions/shellcheck-wasm/action.yml` — composite action that restores/builds/uploads.
- `.github/actions/download-shellcheck-wasm/action.yml` — composite action for non-Linux consumers.

**Modified**
- `Makefile`: file-target for the wasm, `check-shellcheck-wasm` friendly-error guard on `build`/`test`/`lint`/`deadcode`, dropped `GIT_LFS_SKIP_SMUDGE=1`.
- 7 workflows (`ci.yml`, `benchmarks.yml`, `binary-size.yml`, `codeql.yml`, `intellij-plugin.yml`, `vscode-extension.yml`, `release.yml`): added the cached builder job + artifact plumbing, dropped `lfs: true` on all checkouts.
- `.gitattributes`: removed `*.wasm filter=lfs diff=lfs merge=lfs -text`.
- `.gitignore`: added `internal/shellcheck/wasm/shellcheck.wasm`.
- `renovate.json`: moved `SHELLCHECK_VERSION` regex manager from `Makefile` to `_tools/shellcheck-wasm/versions.env`.
- `internal/shellcheck/wasm/wasm.go`: pointer comment to the build recipe for anyone who hits the go:embed error.

### How the cache behaves

1. First run after a version bump → `shellcheck-wasm` job builds with Docker (several minutes, once).
2. Subsequent runs with identical recipe → cache restores in seconds.
3. Every other job in the same workflow downloads the artifact (cheap, no LFS).
4. Versions are bumped via `_tools/shellcheck-wasm/versions.env` (Renovate-watched).

## Test plan

- [ ] `shellcheck-wasm` job builds and uploads artifact on cache miss
- [ ] Downstream Linux jobs (`test`, `lint`, `deadcode`) pull the artifact and compile
- [ ] `test-windows` pulls the artifact and passes
- [ ] `benchmarks`, `binary-size`, `codeql`, `vscode-smoke`, `build-intellij-plugin` all get the wasm
- [ ] `release.yml` `build-platform` matrix (linux x2, darwin x2, windows x2) builds with the downloaded wasm
- [ ] Second run of the workflow on the same commit gets an `actions/cache` hit (visible in the `shellcheck-wasm` job logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed Git LFS tracking for the ShellCheck WASM artifact; the file is now ignored in the repo and restored by CI when needed.
  * Added CI steps to build, verify, upload, and download the ShellCheck WASM artifact so downstream jobs get a validated copy.
  * Make/build targets and CI jobs now require the WASM artifact to be present before running tests, linters, benchmarks, and size checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->