### PR TITLE
fix(shellcheck): detect RUN heredoc opener after continuation-wrapped flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ shellcheck-wasm: $(SHELLCHECK_WASM)
 
 $(SHELLCHECK_WASM): $(SHELLCHECK_WASM_INPUTS)
 	@mkdir -p $(dir $@)
-	docker build \
+	docker buildx build \
 		--progress=plain \
 		--build-arg GHC_WASM_META_COMMIT="$(GHC_WASM_META_COMMIT)" \
 		--build-arg SHELLCHECK_VERSION="$(patsubst v%,%,$(SHELLCHECK_VERSION))" \

--- a/_tools/shellcheck-wasm/Dockerfile
+++ b/_tools/shellcheck-wasm/Dockerfile
@@ -2,6 +2,15 @@ FROM dhi.io/debian-base:trixie-dev AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# [tally] curl configuration for improved robustness
+ENV CURL_HOME=/etc/curl
+COPY --chmod=0644 <<EOF ${CURL_HOME}/.curlrc
+--retry-connrefused
+--connect-timeout 15
+--retry 5
+--max-time 300
+EOF
+
 RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked \
 	--mount=type=cache,target=/var/lib/apt,id=aptlib,sharing=locked \
 	apt-get update \
@@ -25,7 +34,9 @@ COPY Reactor.hs /shellcheck/Reactor.hs
 
 ARG AST_GREP_VERSION=0.40.5
 
-RUN --mount=type=bind,source=rewrites,target=/rewrites,readonly <<EOF
+RUN --mount=type=cache,target=/root/.npm,id=npm \
+	--mount=type=bind,source=rewrites,target=/rewrites,readonly \
+	<<EOF
 set -e
 ./striptests
 . ~/.ghc-wasm/env

--- a/internal/highlight/extract/script.go
+++ b/internal/highlight/extract/script.go
@@ -109,12 +109,12 @@ func extractRunLikeScript(
 	end = max(end, start)
 
 	if len(node.Heredocs) > 0 {
-		if overrideShell, bodyOnly := heredocBodyScriptMode(
+		if overrideShell, openerOffset, bodyOnly := heredocBodyScriptMode(
 			linesForSpan(sm, start, end),
 			escapeToken,
 			blankLeadingFlags,
 		); bodyOnly {
-			bodyStart := start + 1
+			bodyStart := start + openerOffset + 1
 			bodyEnd := end - 1
 			if bodyEnd < bodyStart {
 				return Mapping{}, false
@@ -140,43 +140,60 @@ func extractRunLikeScript(
 	}, true
 }
 
+// heredocBodyScriptMode reports whether lines represent a heredoc whose body is
+// a shell script (as opposed to a data payload fed to a command via stdin). It
+// returns the optional shell override (e.g. "bash" from `RUN <<EOF bash`) and
+// the 0-based line index within lines at which the `<<TAG` opener appears, so
+// the caller can compute the body's start line even when flags span multiple
+// continuation lines before the opener.
 func heredocBodyScriptMode(
 	lines []string,
 	escapeToken rune,
 	blankLeadingFlags func(lines []string, escapeToken rune) []string,
-) (string, bool) {
+) (string, int, bool) {
 	if len(lines) == 0 {
-		return "", false
+		return "", 0, false
 	}
 
 	blanked := blankLeadingFlags(lines, escapeToken)
-	header := firstNonEmptyLine(blanked)
+	headerIdx, header := firstHeaderLine(blanked, escapeToken)
 	if header == "" {
-		return "", false
+		return "", 0, false
 	}
 
 	rest, ok := heredocCommandRemainder(header)
 	if !ok {
-		return "", false
+		return "", 0, false
 	}
 	if rest == "" {
-		return "", true
+		return "", headerIdx, true
 	}
 
 	shellName, ok := heredocShellOverride(rest)
 	if !ok {
-		return "", false
+		return "", 0, false
 	}
-	return shellName, true
+	return shellName, headerIdx, true
 }
 
-func firstNonEmptyLine(lines []string) string {
-	for _, line := range lines {
-		if strings.TrimSpace(line) != "" {
-			return line
+// firstHeaderLine returns the index and content of the first line that carries
+// meaningful (non-continuation-only) content. Lines that contain only leading
+// whitespace plus a trailing line-continuation are skipped, so callers can
+// locate the instruction/heredoc header even when flags span several physical
+// lines joined by the Dockerfile escape token.
+func firstHeaderLine(lines []string, escapeToken rune) (int, string) {
+	escape := string(escapeToken)
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
 		}
+		if trimmed == escape {
+			continue
+		}
+		return i, line
 	}
-	return ""
+	return 0, ""
 }
 
 func heredocCommandRemainder(line string) (string, bool) {

--- a/internal/highlight/extract/script.go
+++ b/internal/highlight/extract/script.go
@@ -180,7 +180,9 @@ func heredocBodyScriptMode(
 // meaningful (non-continuation-only) content. Lines that contain only leading
 // whitespace plus a trailing line-continuation are skipped, so callers can
 // locate the instruction/heredoc header even when flags span several physical
-// lines joined by the Dockerfile escape token.
+// lines joined by the Dockerfile escape token. A line is treated as
+// "continuation-only" whenever stripping its trailing escape token leaves
+// nothing but whitespace — independent of how flag-blanking padded the line.
 func firstHeaderLine(lines []string, escapeToken rune) (int, string) {
 	escape := string(escapeToken)
 	for i, line := range lines {
@@ -188,7 +190,7 @@ func firstHeaderLine(lines []string, escapeToken rune) (int, string) {
 		if trimmed == "" {
 			continue
 		}
-		if trimmed == escape {
+		if prefix, ok := strings.CutSuffix(trimmed, escape); ok && strings.TrimSpace(prefix) == "" {
 			continue
 		}
 		return i, line

--- a/internal/highlight/extract/script_test.go
+++ b/internal/highlight/extract/script_test.go
@@ -74,6 +74,54 @@ EOF
 	}
 }
 
+func TestExtractRunScript_FlagsAcrossContinuationBeforeHeredoc(t *testing.T) {
+	t.Parallel()
+
+	mapping := extractRunScriptForTest(t, `FROM alpine
+RUN --mount=type=cache,target=/root/.cache,id=cache \
+	--mount=type=bind,source=payload,target=/payload,readonly \
+	<<EOF
+set -e
+echo hi
+EOF
+`)
+
+	if !mapping.IsHeredoc {
+		t.Fatalf("expected heredoc body mapping when flags span continuation lines, got Script=%q", mapping.Script)
+	}
+	if mapping.Script != "set -e\necho hi" {
+		t.Fatalf("expected body-only script, got %q", mapping.Script)
+	}
+	// Opener appears on line 4 of the Dockerfile, so the body starts on line 5.
+	if mapping.OriginStartLine != 5 {
+		t.Fatalf("expected body origin line 5, got %d", mapping.OriginStartLine)
+	}
+}
+
+func TestExtractRunScript_FlagsAcrossContinuationWithShellOverride(t *testing.T) {
+	t.Parallel()
+
+	mapping := extractRunScriptForTest(t, `FROM alpine
+RUN --mount=type=cache,target=/root/.cache,id=cache \
+	<<EOF bash
+echo hi
+EOF
+`)
+
+	if !mapping.IsHeredoc {
+		t.Fatalf("expected heredoc body mapping, got Script=%q", mapping.Script)
+	}
+	if mapping.ShellNameOverride != "bash" {
+		t.Fatalf("expected shell override bash, got %q", mapping.ShellNameOverride)
+	}
+	if mapping.Script != "echo hi" {
+		t.Fatalf("expected body-only script, got %q", mapping.Script)
+	}
+	if mapping.OriginStartLine != 4 {
+		t.Fatalf("expected body origin line 4, got %d", mapping.OriginStartLine)
+	}
+}
+
 func extractRunScriptForTest(t *testing.T, content string) Mapping {
 	t.Helper()
 

--- a/internal/highlight/extract/script_test.go
+++ b/internal/highlight/extract/script_test.go
@@ -122,6 +122,37 @@ EOF
 	}
 }
 
+func TestExtractRunScript_FilePayloadWithFlagsAcrossContinuation(t *testing.T) {
+	t.Parallel()
+
+	mapping := extractRunScriptForTest(t, `FROM alpine
+RUN --mount=type=cache,target=/root/.cache,id=cache \
+	--mount=type=bind,source=etc,target=/etc,readonly \
+	<<EOF cat > /etc/app.conf
+enable-rpc=true
+EOF
+`)
+
+	if mapping.IsHeredoc {
+		t.Fatalf(
+			"expected file-payload heredoc to remain non-heredoc data even when flags span continuation lines, got Script=%q",
+			mapping.Script,
+		)
+	}
+	if strings.Contains(mapping.Script, ">>>") {
+		t.Fatalf("unexpected marker content in script %q", mapping.Script)
+	}
+	if !strings.Contains(mapping.Script, "<<EOF cat > /etc/app.conf") {
+		t.Fatalf("expected heredoc command to be preserved in script, got %q", mapping.Script)
+	}
+	if !strings.Contains(mapping.Script, "enable-rpc=true") {
+		t.Fatalf("expected payload lines to remain in script, got %q", mapping.Script)
+	}
+	if mapping.OriginStartLine != 2 {
+		t.Fatalf("expected command origin line 2, got %d", mapping.OriginStartLine)
+	}
+}
+
 func extractRunScriptForTest(t *testing.T, content string) Mapping {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Fix heredoc-body extraction when `RUN --mount=...` flags span multiple continuation lines before `<<TAG`. Previously the opener detection used `firstNonEmptyLine`, which picked up lines containing only `\` continuations and bailed out — so the whole multi-line span (flags, continuations, `<<EOF`, body, and `EOF`) was fed verbatim to shellcheck, producing false positives.
- Refresh `_tools/shellcheck-wasm/Dockerfile` to exercise the patterns this fix handles: a `COPY --chmod=0644 <<EOF ${CURL_HOME}/.curlrc` heredoc, plus a `RUN --mount=type=cache,...` / `--mount=type=bind,...` / `<<EOF` block split across three continuation lines.
- Switch `make shellcheck-wasm` to `docker buildx build` so the mount flags resolve on all supported BuildKit versions.

## Root cause

`heredocBodyScriptMode` called `firstNonEmptyLine(blanked)` to locate the opener after flag-blanking. Flag-blanking preserves trailing `\` characters on each continuation line, so when flags wrap across lines the "first non-empty" line was just `\` — heredoc detection failed. The caller then fed the full span to shellcheck and flagged:

- **shellcheck/SC2188** at `<<EOF` (seen as a redirection with no command)
- **shellcheck/SC2154** on `$r` and `$rule_id` (loop variables defined inside the body appeared inside opaque heredoc context to shellcheck)
- Wrong columns because the script handed to shellcheck started several columns left of the real body lines.

## Fix

Replaced `firstNonEmptyLine` with `firstHeaderLine`, which skips blank lines and lines that contain only the escape token, and returns the opener's 0-based line offset within the span. The caller now computes `bodyStart := start + openerOffset + 1`, so the body origin line is correct even when the `<<TAG` opener lives several continuation lines past the instruction start.

## Test plan

- [x] `go test ./internal/highlight/extract/...` — added two new tests covering multi-line flags before a plain heredoc and before an explicit-shell heredoc
- [x] `go test ./internal/rules/shellcheck/... ./internal/integration/...` — no regressions
- [x] `./tally lint _tools/shellcheck-wasm/Dockerfile` — SC2188 / SC2154 false positives are gone
- [ ] CI: verify `make shellcheck-wasm` still builds with `docker buildx build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heredoc parsing when flags span multiple continued lines in Dockerfile RUN commands.

* **Build & Infrastructure**
  * Switched container image builds to buildx for more reliable builds.
  * Added curl retry/timeouts and npm cache to improve build robustness.

* **Tests**
  * Added tests covering heredoc extraction with continuation-wrapped flags and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->