### PR TITLE
fix(lsp): semantic tokens for RUN heredoc continuation and markers

### DIFF
--- a/internal/highlight/dockerfile/tokenize.go
+++ b/internal/highlight/dockerfile/tokenize.go
@@ -77,6 +77,11 @@ func tokenizeNode(
 		tokens = append(tokens, numberTokens(text, lineIdx)...)
 		tokens = append(tokens, heredocTokens(text, lineIdx)...)
 	}
+
+	if len(node.Heredocs) > 0 {
+		opener := heredocOpenerLine(sm, startLine, endLine, escapeToken)
+		tokens = append(tokens, heredocTerminatorTokens(sm, node, opener, endLine)...)
+	}
 	return tokens
 }
 
@@ -410,10 +415,50 @@ func heredocTokens(line string, lineNum int) []core.Token {
 				Line:     lineNum,
 				StartCol: nameStartCol,
 				EndCol:   nameEndCol,
-				Type:     core.TokenString,
+				Type:     core.TokenKeyword,
 				Priority: 24,
 			},
 		)
+	}
+	return out
+}
+
+// heredocTerminatorTokens emits keyword tokens for each physical line within
+// the instruction's span that matches one of the node's heredoc terminator
+// names, so themes can style the closing tag the same as the opener tag.
+// Chomp heredocs (`<<-TAG`) allow the terminator to be preceded by leading
+// tabs, which are stripped before matching. The quoting style of the opener
+// (`<<'EOF'`, `<<"EOF"`) does not appear in the terminator line.
+func heredocTerminatorTokens(sm *sourcemap.SourceMap, node *parser.Node, openerLine, end int) []core.Token {
+	if len(node.Heredocs) == 0 {
+		return nil
+	}
+	limit := min(end, sm.LineCount())
+	hdIdx := 0
+	var out []core.Token
+	for line := openerLine + 1; line <= limit && hdIdx < len(node.Heredocs); line++ {
+		raw := sm.Line(line - 1)
+		candidate := strings.TrimRight(raw, " \t\r")
+		if node.Heredocs[hdIdx].Chomp {
+			candidate = strings.TrimLeft(candidate, "\t")
+		}
+		if candidate != node.Heredocs[hdIdx].Name {
+			continue
+		}
+		start := strings.Index(raw, candidate)
+		if start < 0 {
+			hdIdx++
+			continue
+		}
+		startCol, endCol := core.RuneColsForByteRange(raw, start, start+len(candidate))
+		out = append(out, core.Token{
+			Line:     line - 1,
+			StartCol: startCol,
+			EndCol:   endCol,
+			Type:     core.TokenKeyword,
+			Priority: 24,
+		})
+		hdIdx++
 	}
 	return out
 }

--- a/internal/highlight/dockerfile/tokenize.go
+++ b/internal/highlight/dockerfile/tokenize.go
@@ -532,12 +532,32 @@ func heredocBodyLines(sm *sourcemap.SourceMap, root *parser.Node, escapeToken ru
 			continue
 		}
 		end := sm.ResolveEndLineWithEscape(node.EndLine, escapeToken)
-		for line := node.StartLine; line <= end; line++ {
-			if line == node.StartLine || line == end {
-				continue
-			}
+		opener := heredocOpenerLine(sm, node.StartLine, end, escapeToken)
+		for line := opener + 1; line < end; line++ {
 			out[line-1] = true
 		}
 	}
 	return out
+}
+
+// heredocOpenerLine returns the 1-based physical line within [startLine, end]
+// that carries the `<<TAG` opener. BuildKit reports node.StartLine as the line
+// containing the instruction keyword (e.g. RUN), but the opener may sit on a
+// later physical line when flags span backslash-continued lines. Everything
+// between the opener line and the terminator (node.EndLine) is the heredoc
+// body; earlier continuation lines still carry Dockerfile flag/argument
+// tokens and must not be treated as body.
+func heredocOpenerLine(sm *sourcemap.SourceMap, startLine, end int, escapeToken rune) int {
+	limit := min(end, sm.LineCount())
+	escape := string(escapeToken)
+	for line := startLine; line <= limit; line++ {
+		trimmed := strings.TrimRight(sm.Line(line-1), " \t")
+		if trimmed == "" {
+			continue
+		}
+		if !strings.HasSuffix(trimmed, escape) {
+			return line
+		}
+	}
+	return startLine
 }

--- a/internal/highlight/dockerfile/tokenize_test.go
+++ b/internal/highlight/dockerfile/tokenize_test.go
@@ -65,6 +65,68 @@ func TestQuotedTokens_RespectEscapeDirective(t *testing.T) {
 	assertTokenText(t, line, tokens[0], "\"say `\"hello`\"\"")
 }
 
+func TestTokenize_HeredocMarkersAreKeywords(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(strings.Join([]string{
+		"FROM alpine",
+		"RUN <<EOF",
+		"echo hi",
+		"EOF",
+		"COPY <<-CHOMP /tmp/out",
+		"\tinline",
+		"\tCHOMP",
+		"",
+	}, "\n"))
+
+	sm := sourcemap.New(source)
+	result, err := parser.Parse(bytes.NewReader(source))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	tokens := Tokenize(sm, result.AST, '\\')
+
+	// Opener tag `EOF` should be a keyword token so VS Code's fallback maps
+	// it to keyword.control.heredoc-token.shell.dockerfile.
+	assertHasLineTokenType(t, string(source), tokens, 1, core.TokenKeyword, "EOF")
+
+	// Terminator `EOF` on its own line must also be a keyword token.
+	assertHasLineTokenType(t, string(source), tokens, 3, core.TokenKeyword, "EOF")
+
+	// Chomp terminator (`<<-TAG`) has leading tabs stripped before matching.
+	assertHasLineTokenType(t, string(source), tokens, 6, core.TokenKeyword, "CHOMP")
+}
+
+func assertHasLineTokenType(
+	t *testing.T,
+	source string,
+	tokens []core.Token,
+	wantLine int,
+	wantType core.TokenType,
+	wantText string,
+) {
+	t.Helper()
+
+	lines := strings.Split(source, "\n")
+	for _, tok := range tokens {
+		if tok.Line != wantLine || tok.Type != wantType {
+			continue
+		}
+		if tok.Line < 0 || tok.Line >= len(lines) {
+			continue
+		}
+		runes := []rune(lines[tok.Line])
+		if tok.StartCol < 0 || tok.EndCol < tok.StartCol || tok.EndCol > len(runes) {
+			continue
+		}
+		if got := string(runes[tok.StartCol:tok.EndCol]); got == wantText {
+			return
+		}
+	}
+	t.Fatalf("missing token line=%d type=%s text=%q in %+v", wantLine, wantType, wantText, tokens)
+}
+
 func TestTokenize_WindowsPaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/highlight/highlight_test.go
+++ b/internal/highlight/highlight_test.go
@@ -1,6 +1,8 @@
 package highlight
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -102,6 +104,107 @@ func TestAnalyze_PowerShellLineContinuationTokenization(t *testing.T) {
 	assertHasLineToken(t, source, line4, core.TokenParameter, "-ItemType")
 	assertHasLineToken(t, source, line4, core.TokenParameter, "-Path")
 	assertHasLineToken(t, source, line4, core.TokenParameter, "-Force")
+}
+
+// TestAnalyze_RunHeredocWithMultiLineMounts reproduces the semantic-token gap
+// seen in _tools/shellcheck-wasm/Dockerfile: when a RUN instruction has
+// multiple --mount flags spread across backslash-continuation lines before a
+// heredoc opener, the continuation lines before the opener must still receive
+// flag/keyword tokens. They were previously being treated as heredoc body.
+func TestAnalyze_RunHeredocWithMultiLineMounts(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(strings.Join([]string{
+		"ARG AST_GREP_VERSION=0.40.5",
+		"FROM alpine",
+		"RUN --mount=type=cache,target=/root/.npm,id=npm \\",
+		"\t--mount=type=bind,source=rewrites,target=/rewrites,readonly \\",
+		"\t<<EOF",
+		"set -e",
+		"./striptests",
+		"EOF",
+		"",
+	}, "\n"))
+
+	doc := Analyze("Dockerfile", source)
+	if doc == nil {
+		t.Fatal("Analyze() returned nil")
+	}
+
+	// First RUN flag line (line 2, the startLine of the instruction).
+	line2 := doc.LineTokens(2)
+	assertHasLineToken(t, source, line2, core.TokenKeyword, "RUN")
+	assertHasLineToken(t, source, line2, core.TokenParameter, "--mount")
+
+	// Continuation line that carries the second --mount flag must still be
+	// tokenized — previously it was swallowed by the heredoc-body exclusion.
+	line3 := doc.LineTokens(3)
+	assertHasLineToken(t, source, line3, core.TokenParameter, "--mount")
+	assertHasLineToken(t, source, line3, core.TokenProperty, "type")
+	assertHasLineToken(t, source, line3, core.TokenString, "bind")
+
+	// Heredoc opener line still gets `<<` and tag tokens.
+	line4 := doc.LineTokens(4)
+	assertHasLineToken(t, source, line4, core.TokenOperator, "<<")
+	assertHasLineToken(t, source, line4, core.TokenString, "EOF")
+}
+
+// TestAnalyze_ShellcheckWasmDockerfile exercises the semantic tokenizer on the
+// real Dockerfile from _tools/shellcheck-wasm/ to make sure the in-repo file
+// behaves the same as the synthetic test above. This is the file whose LSP
+// coloring the maintainer inspected by eye.
+func TestAnalyze_ShellcheckWasmDockerfile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "_tools", "shellcheck-wasm", "Dockerfile")
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	doc := Analyze(path, source)
+	if doc == nil {
+		t.Fatal("Analyze() returned nil")
+	}
+
+	lines := strings.Split(string(source), "\n")
+
+	// Line indices are 0-based. The file has:
+	//   line 36 (1-based 37): RUN --mount=type=cache,...
+	//   line 37 (1-based 38): \t--mount=type=bind,source=rewrites,target=/rewrites,readonly \
+	//   line 38 (1-based 39): \t<<EOF
+	// Verify the offsets to guard against the file drifting.
+	requireLinePrefix(t, lines, 36, "RUN --mount=type=cache")
+	requireLinePrefix(t, lines, 37, "\t--mount=type=bind,source=rewrites")
+	requireLinePrefix(t, lines, 38, "\t<<EOF")
+
+	runLine := doc.LineTokens(36)
+	assertHasLineToken(t, source, runLine, core.TokenKeyword, "RUN")
+	assertHasLineToken(t, source, runLine, core.TokenParameter, "--mount")
+
+	// The second --mount flag sits on a continuation line between the RUN
+	// startLine and the heredoc opener. The LSP must emit flag/kv tokens for
+	// it; previously it was excluded as heredoc body.
+	secondMount := doc.LineTokens(37)
+	assertHasLineToken(t, source, secondMount, core.TokenParameter, "--mount")
+	assertHasLineToken(t, source, secondMount, core.TokenProperty, "type")
+	assertHasLineToken(t, source, secondMount, core.TokenString, "bind")
+	assertHasLineToken(t, source, secondMount, core.TokenProperty, "source")
+	assertHasLineToken(t, source, secondMount, core.TokenString, "rewrites")
+
+	openerLine := doc.LineTokens(38)
+	assertHasLineToken(t, source, openerLine, core.TokenOperator, "<<")
+	assertHasLineToken(t, source, openerLine, core.TokenString, "EOF")
+}
+
+func requireLinePrefix(t *testing.T, lines []string, line int, prefix string) {
+	t.Helper()
+	if line < 0 || line >= len(lines) {
+		t.Fatalf("line %d out of range (have %d lines)", line, len(lines))
+	}
+	if !strings.HasPrefix(lines[line], prefix) {
+		t.Fatalf("line %d prefix mismatch: got %q want prefix %q", line, lines[line], prefix)
+	}
 }
 
 func assertNoLineToken(t *testing.T, source []byte, tokens []core.Token, wantType core.TokenType, wantText string) {

--- a/internal/highlight/highlight_test.go
+++ b/internal/highlight/highlight_test.go
@@ -143,10 +143,18 @@ func TestAnalyze_RunHeredocWithMultiLineMounts(t *testing.T) {
 	assertHasLineToken(t, source, line3, core.TokenProperty, "type")
 	assertHasLineToken(t, source, line3, core.TokenString, "bind")
 
-	// Heredoc opener line still gets `<<` and tag tokens.
+	// Heredoc opener line still gets `<<` and tag tokens. The tag is emitted
+	// as a keyword so VS Code's fallback maps it to the grammar's
+	// keyword.control.heredoc-token.shell.dockerfile scope.
 	line4 := doc.LineTokens(4)
 	assertHasLineToken(t, source, line4, core.TokenOperator, "<<")
-	assertHasLineToken(t, source, line4, core.TokenString, "EOF")
+	assertHasLineToken(t, source, line4, core.TokenKeyword, "EOF")
+
+	// Closing terminator line emits a matching keyword token for the tag so
+	// the grammar's heredoc-token scope theming applies there too. Source
+	// layout: line 7 is the `EOF` terminator.
+	line7 := doc.LineTokens(7)
+	assertHasLineToken(t, source, line7, core.TokenKeyword, "EOF")
 }
 
 // TestAnalyze_ShellcheckWasmDockerfile exercises the semantic tokenizer on the
@@ -194,7 +202,14 @@ func TestAnalyze_ShellcheckWasmDockerfile(t *testing.T) {
 
 	openerLine := doc.LineTokens(38)
 	assertHasLineToken(t, source, openerLine, core.TokenOperator, "<<")
-	assertHasLineToken(t, source, openerLine, core.TokenString, "EOF")
+	assertHasLineToken(t, source, openerLine, core.TokenKeyword, "EOF")
+
+	// The matching terminator line (105, 0-based) reads `EOF` on its own.
+	// Verify we emit a keyword token there too so the grammar's closing tag
+	// styling still applies under semantic highlighting.
+	requireLinePrefix(t, lines, 105, "EOF")
+	terminatorLine := doc.LineTokens(105)
+	assertHasLineToken(t, source, terminatorLine, core.TokenKeyword, "EOF")
 }
 
 func requireLinePrefix(t *testing.T, lines []string, line int, prefix string) {


### PR DESCRIPTION
## Summary

Two related fixes to the LSP semantic token emitter so a RUN heredoc renders the same under semantic highlighting as it does with Better Dockerfile Syntax's TextMate grammar alone.

### 1. Tokenize continuation lines before the heredoc opener

`heredocBodyLines` treated every physical line strictly between `node.StartLine` and the terminator as body, so when a `RUN`'s `--mount` flags spanned backslash-continuation lines before the `<<TAG` opener, those continuation lines (and the opener itself) got **zero** semantic tokens. Fix: walk forward from `StartLine`, skip continuation-wrapped lines, treat only the range `(opener, end)` as body.

Reproduces on `_tools/shellcheck-wasm/Dockerfile` — `RUN` on line 37 spans a second `--mount` on line 38 plus the `<<EOF` opener on line 39. Before: 0 tokens on lines 38 and 39. After: full flag/kv tokenization on line 38 and `<<`/`EOF` on line 39.

### 2. Emit heredoc tag tokens as keywords at opener and terminator

Better Dockerfile Syntax scopes both the opener tag and the closing terminator as `keyword.control.heredoc-token.shell.dockerfile`. Tally was emitting the opener tag as `TokenString` and nothing at all for the terminator line, so semantic highlighting overwrote the grammar's coloring for the opener while letting the grammar keep ownership of the terminator — inconsistent. Fix: emit `TokenKeyword` for the opener tag (the `keyword` fallback already points to the grammar's heredoc-token scope) and emit a matching `TokenKeyword` for each node's terminator line. Honors `<<-TAG` chomp form by stripping leading tabs before matching.

## Test plan

- [x] `TestAnalyze_RunHeredocWithMultiLineMounts` — synthetic fixture: asserts the second `--mount` receives flag/property/string tokens, the `<<EOF` line gets operator + keyword tokens, and the closing `EOF` line gets a keyword token.
- [x] `TestAnalyze_ShellcheckWasmDockerfile` — reads the real `_tools/shellcheck-wasm/Dockerfile` and asserts tokens on lines 36–38 plus the matching terminator on line 105.
- [x] `TestTokenize_HeredocMarkersAreKeywords` — covers plain and chomp (`<<-TAG`) heredoc terminators.
- [x] `go test ./internal/highlight/... ./internal/lspserver/... ./internal/dockerfile/... ./internal/integration/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)