### PR TITLE
feat(fix): add test-friendly ApplyFix/ApplyEdits wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ skip-blank-lines = true
   [`design-docs/16-integration-tests-refactor-and-placement.md` §8](design-docs/16-integration-tests-refactor-and-placement.md#8-decision-tree-where-should-this-test-go)
 - Update snapshots when intentional output changes:
   - `UPDATE_SNAPS=true go test ./internal/integration/...`
+- In rule/resolver tests, round-trip a fix back to source with `fix.ApplyFix(src, v.SuggestedFix)` or `fix.ApplyEdits(src, edits)` — handles
+  edit ordering so you don't need a manual reverse-order `ApplyEdit` loop.
 
 ## Commit & Pull Request Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ and a WASM-compiled shellcheck (`internal/shellcheck/`).
   - If a fix needs external data, implement a resolver (`fix.FixResolver`) instead of doing IO/network in the rule.
   - PREFER narrow edits over whole-region replacement (e.g. delete one package token, not the whole install line).
   - Async resolvers run AFTER sync fixes; always scan the post-sync content before emitting edits — don't trust the original state.
+  - In tests, apply a fix's edits back to source with `fix.ApplyFix(src, v.SuggestedFix)` (or `fix.ApplyEdits(src, edits)`) — don't hand-roll a
+    reverse-order `ApplyEdit` loop.
   - tally assumes PowerShell 7+ in Windows containers, so `curl`/`wget` resolve to the binaries (no PS 5.1 alias gotcha).
 
 ## Docs & Schema

--- a/internal/fix/dl4001_cleanup_resolver_test.go
+++ b/internal/fix/dl4001_cleanup_resolver_test.go
@@ -2,7 +2,6 @@ package fix
 
 import (
 	"context"
-	"slices"
 	"strings"
 	"testing"
 
@@ -326,12 +325,8 @@ func TestDL4001CleanupResolver_DropsInstallSubcommandInChain(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 
-	// Apply edits via the production ApplyEdit helper (back-to-front so
-	// earlier offsets are not invalidated by later deletes).
-	got := []byte(dockerfile)
-	for _, edit := range slices.Backward(edits) {
-		got = ApplyEdit(got, edit)
-	}
+	// Apply edits via the production helper.
+	got := ApplyEdits([]byte(dockerfile), edits)
 	if strings.Contains(string(got), "apt-get install") {
 		t.Fatalf("apt-get install should have been removed:\n%s", got)
 	}

--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -3,9 +3,46 @@
 package fix
 
 import (
+	"cmp"
+	"slices"
+
 	"github.com/wharflab/tally/internal/config"
 	"github.com/wharflab/tally/internal/rules"
 )
+
+// ApplyEdits applies a set of text edits to src and returns the result.
+// Edits are sorted by descending position (later edits first) so earlier
+// offsets are not invalidated, matching the ordering used by the production
+// fixer for a single fix. Input src is not modified.
+//
+// Intended for tests that want to round-trip a rule's SuggestedFix.Edits
+// back through the source without reimplementing the reverse-order loop.
+func ApplyEdits(src []byte, edits []rules.TextEdit) []byte {
+	if len(edits) == 0 {
+		return src
+	}
+	ordered := slices.Clone(edits)
+	slices.SortStableFunc(ordered, func(a, b rules.TextEdit) int {
+		if c := cmp.Compare(b.Location.Start.Line, a.Location.Start.Line); c != 0 {
+			return c
+		}
+		return cmp.Compare(b.Location.Start.Column, a.Location.Start.Column)
+	})
+	out := src
+	for _, e := range ordered {
+		out = ApplyEdit(out, e)
+	}
+	return out
+}
+
+// ApplyFix applies a SuggestedFix's edits to src and returns the result.
+// Returns src unchanged when fix is nil or has no edits.
+func ApplyFix(src []byte, fix *rules.SuggestedFix) []byte {
+	if fix == nil {
+		return src
+	}
+	return ApplyEdits(src, fix.Edits)
+}
 
 // Re-export FixSafety from rules package for convenience.
 // This allows fix package users to use fix.FixSafe instead of rules.FixSafe.

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -1,6 +1,7 @@
 package fix
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/wharflab/tally/internal/rules"
@@ -76,4 +77,84 @@ func TestFixSafety_ReExport(t *testing.T) {
 	if FixUnsafe != rules.FixUnsafe {
 		t.Errorf("FixUnsafe = %v, want %v", FixUnsafe, rules.FixUnsafe)
 	}
+}
+
+func TestApplyEdits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty edits returns src", func(t *testing.T) {
+		t.Parallel()
+		src := []byte("FROM alpine\n")
+		got := ApplyEdits(src, nil)
+		if !bytes.Equal(got, src) {
+			t.Errorf("ApplyEdits(nil) = %q, want %q", got, src)
+		}
+	})
+
+	t.Run("ascending-order edits applied correctly", func(t *testing.T) {
+		t.Parallel()
+		// Two same-line edits given in ascending order: ApplyEdits must
+		// reverse them so the first edit's position is not invalidated.
+		src := []byte("RUN apt install curl wget\n")
+		edits := []rules.TextEdit{
+			{Location: rules.NewRangeLocation("Dockerfile", 1, 4, 1, 7), NewText: "apt-get"},
+			{Location: rules.NewRangeLocation("Dockerfile", 1, 21, 1, 25), NewText: "htop"},
+		}
+		want := "RUN apt-get install curl htop\n"
+		if got := ApplyEdits(src, edits); string(got) != want {
+			t.Errorf("ApplyEdits() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("multi-line descending order", func(t *testing.T) {
+		t.Parallel()
+		src := []byte("FROM alpine\nRUN foo\nRUN bar\n")
+		edits := []rules.TextEdit{
+			{Location: rules.NewRangeLocation("Dockerfile", 2, 4, 2, 7), NewText: "FOO"},
+			{Location: rules.NewRangeLocation("Dockerfile", 3, 4, 3, 7), NewText: "BAR"},
+		}
+		want := "FROM alpine\nRUN FOO\nRUN BAR\n"
+		if got := ApplyEdits(src, edits); string(got) != want {
+			t.Errorf("ApplyEdits() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("does not mutate input slice", func(t *testing.T) {
+		t.Parallel()
+		edits := []rules.TextEdit{
+			{Location: rules.NewRangeLocation("Dockerfile", 1, 0, 1, 4), NewText: "ENV"},
+			{Location: rules.NewRangeLocation("Dockerfile", 2, 0, 2, 4), NewText: "ENV"},
+		}
+		first := edits[0]
+		_ = ApplyEdits([]byte("FROM alpine\nFROM alpine\n"), edits)
+		if edits[0] != first {
+			t.Errorf("ApplyEdits mutated input slice: edits[0] = %+v, want %+v", edits[0], first)
+		}
+	})
+}
+
+func TestApplyFix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil fix returns src", func(t *testing.T) {
+		t.Parallel()
+		src := []byte("FROM alpine\n")
+		if got := ApplyFix(src, nil); !bytes.Equal(got, src) {
+			t.Errorf("ApplyFix(nil) = %q, want %q", got, src)
+		}
+	})
+
+	t.Run("applies edits from fix", func(t *testing.T) {
+		t.Parallel()
+		src := []byte("RUN apt install curl\n")
+		fix := &rules.SuggestedFix{
+			Edits: []rules.TextEdit{
+				{Location: rules.NewRangeLocation("Dockerfile", 1, 4, 1, 7), NewText: "apt-get"},
+			},
+		}
+		want := "RUN apt-get install curl\n"
+		if got := ApplyFix(src, fix); string(got) != want {
+			t.Errorf("ApplyFix() = %q, want %q", got, want)
+		}
+	})
 }

--- a/internal/rules/tally/no_multi_spaces_test.go
+++ b/internal/rules/tally/no_multi_spaces_test.go
@@ -1,7 +1,6 @@
 package tally
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
@@ -250,9 +249,7 @@ func TestNoMultiSpacesCheckWithFixes(t *testing.T) {
 				if v.SuggestedFix.Safety != rules.FixSafe {
 					t.Errorf("fix safety = %v, want FixSafe", v.SuggestedFix.Safety)
 				}
-				for _, edit := range slices.Backward(v.SuggestedFix.Edits) {
-					got = fixpkg.ApplyEdit(got, edit)
-				}
+				got = fixpkg.ApplyFix(got, v.SuggestedFix)
 			}
 
 			if string(got) != tt.want {

--- a/internal/rules/tally/require_secret_mounts_test.go
+++ b/internal/rules/tally/require_secret_mounts_test.go
@@ -468,7 +468,7 @@ RUN pip install -r requirements.txt
 			}
 
 			if tt.name == "indented RUN keeps mount after keyword" {
-				got := string(fixpkg.ApplyEdit([]byte(tt.content), edit))
+				got := string(fixpkg.ApplyFix([]byte(tt.content), v.SuggestedFix))
 				want := `FROM python:3.12-slim
     RUN --mount=type=secret,id=pipconf,target=/root/.config/pip/pip.conf pip install -r requirements.txt
 `

--- a/internal/rules/tally/sort_packages_test.go
+++ b/internal/rules/tally/sort_packages_test.go
@@ -205,7 +205,7 @@ func TestSortPackagesFix(t *testing.T) {
 				t.Errorf("fix safety = %v, want FixSafe", fix.Safety)
 			}
 
-			// Apply edits back-to-front using the production fix engine.
+			// Round-trip the fix through the production helper.
 			got := fixpkg.ApplyFix([]byte(tt.content), fix)
 			if string(got) != tt.want {
 				t.Errorf("after fix:\ngot:  %q\nwant: %q", got, tt.want)

--- a/internal/rules/tally/sort_packages_test.go
+++ b/internal/rules/tally/sort_packages_test.go
@@ -1,7 +1,6 @@
 package tally
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
@@ -207,10 +206,7 @@ func TestSortPackagesFix(t *testing.T) {
 			}
 
 			// Apply edits back-to-front using the production fix engine.
-			got := []byte(tt.content)
-			for _, edit := range slices.Backward(fix.Edits) {
-				got = fixpkg.ApplyEdit(got, edit)
-			}
+			got := fixpkg.ApplyFix([]byte(tt.content), fix)
 			if string(got) != tt.want {
 				t.Errorf("after fix:\ngot:  %q\nwant: %q", got, tt.want)
 			}


### PR DESCRIPTION
Closes #541.

## Summary

Adds thin test helpers in `internal/fix` so rule and resolver tests can round-trip a fix back to source without reimplementing the reverse-order `ApplyEdit` loop.

- `fix.ApplyEdits(src []byte, edits []rules.TextEdit) []byte` — clones the slice, sorts by descending (line, column), applies via the existing `ApplyEdit` primitive.
- `fix.ApplyFix(src []byte, fix *rules.SuggestedFix) []byte` — nil-safe convenience that delegates to `ApplyEdits(src, fix.Edits)`.

The ordering matches what the production fixer uses within a single fix. `ApplyEdit` stays exported for callers that need the primitive (per the issue).

## Migrated call sites

- `internal/rules/tally/sort_packages_test.go`
- `internal/rules/tally/no_multi_spaces_test.go`
- `internal/rules/tally/require_secret_mounts_test.go`
- `internal/fix/dl4001_cleanup_resolver_test.go`

`internal/lsptest/setup_test.go` was intentionally left alone — it operates on `lsp.TextEdit` via `textedits.ApplyTextChange`, not `rules.TextEdit`, so the new wrapper doesn't apply.

## Tests

New unit tests in `internal/fix/fix_test.go` cover:
- empty / nil edits
- ascending-order edits getting reversed before application
- multi-line edits
- input slice is not mutated
- nil fix passed to `ApplyFix`
- `ApplyFix` happy path

Also updated `CLAUDE.md` and `AGENTS.md` with a one-line pointer so new rule authors pick up the helper.

## Verification

- `make lint` ✅
- `make cpd` ✅
- `make test` ✅ (no snapshots changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for fix application logic
  * Updated test cases to use centralized fix application approach

* **Refactor**
  * Simplified fix application workflow in test utilities
  * Consolidated edit application handling

* **Documentation**
  * Updated testing guidelines to reflect recommended fix application practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->