### PR TITLE
feat(rules): add tally/php/enable-opcache-in-production

### DIFF
--- a/_docs/docs.json
+++ b/_docs/docs.json
@@ -134,6 +134,7 @@
             "group": "PHP",
             "pages": [
               "rules/tally/php/composer-no-dev-in-production",
+              "rules/tally/php/enable-opcache-in-production",
               "rules/tally/php/no-xdebug-in-final-image"
             ]
           },

--- a/_docs/rules/tally/php/enable-opcache-in-production.mdx
+++ b/_docs/rules/tally/php/enable-opcache-in-production.mdx
@@ -95,18 +95,8 @@ RUN apt-get install -y php8.3-fpm php8.3-opcache
 - the stage is detected via `CMD`/`ENTRYPOINT` but no `php*-fpm` package is visible in an install command in the same Dockerfile
 - the stage installs **multiple different** `php*-fpm` packages (ambiguous target version)
 
-### Interaction with other tally rules
-
-The package-manager fix runs at `FixPriority: 88` and inserts a single leading space plus the new package name at the `EndCol` of the existing
-`php*-fpm` token. Interactions with neighboring rules:
-
-- `tally/sort-packages` (priority 9): runs first. This rule sorts the original package list before the opcache fix appends. The inserted token lands
-  immediately after the `php*-fpm` package, which can leave the list out of alphabetical order
-  (e.g., `... php8.3-fpm php8.3-gd` + the fix → `... php8.3-fpm php8.3-opcache php8.3-gd`). `sort-packages` catches that on the next `--fix` pass.
-- `tally/no-multi-spaces` (priority 10): the inserted text is exactly `" phpNN-opcache"` (one leading space), so this fix never creates a multi-space
-  run.
-- `tally/prefer-package-cache-mounts` (priority 90): operates on `RUN` flags (`--mount=type=cache,...`), not package arguments — the two fixes touch
-  disjoint surfaces and compose cleanly in the same pass.
+The package-manager fix composes with `tally/sort-packages`: running tally with `--fix` twice is enough to land an alphabetically sorted list in all
+cases.
 
 ## Examples
 

--- a/_docs/rules/tally/php/enable-opcache-in-production.mdx
+++ b/_docs/rules/tally/php/enable-opcache-in-production.mdx
@@ -95,6 +95,19 @@ RUN apt-get install -y php8.3-fpm php8.3-opcache
 - the stage is detected via `CMD`/`ENTRYPOINT` but no `php*-fpm` package is visible in an install command in the same Dockerfile
 - the stage installs **multiple different** `php*-fpm` packages (ambiguous target version)
 
+### Interaction with other tally rules
+
+The package-manager fix runs at `FixPriority: 88` and inserts a single leading space plus the new package name at the `EndCol` of the existing
+`php*-fpm` token. Interactions with neighboring rules:
+
+- `tally/sort-packages` (priority 9): runs first. This rule sorts the original package list before the opcache fix appends. The inserted token lands
+  immediately after the `php*-fpm` package, which can leave the list out of alphabetical order
+  (e.g., `... php8.3-fpm php8.3-gd` + the fix → `... php8.3-fpm php8.3-opcache php8.3-gd`). `sort-packages` catches that on the next `--fix` pass.
+- `tally/no-multi-spaces` (priority 10): the inserted text is exactly `" phpNN-opcache"` (one leading space), so this fix never creates a multi-space
+  run.
+- `tally/prefer-package-cache-mounts` (priority 90): operates on `RUN` flags (`--mount=type=cache,...`), not package arguments — the two fixes touch
+  disjoint surfaces and compose cleanly in the same pass.
+
 ## Examples
 
 ### Before

--- a/_docs/rules/tally/php/enable-opcache-in-production.mdx
+++ b/_docs/rules/tally/php/enable-opcache-in-production.mdx
@@ -95,8 +95,8 @@ RUN apt-get install -y php8.3-fpm php8.3-opcache
 - the stage is detected via `CMD`/`ENTRYPOINT` but no `php*-fpm` package is visible in an install command in the same Dockerfile
 - the stage installs **multiple different** `php*-fpm` packages (ambiguous target version)
 
-The package-manager fix composes with `tally/sort-packages`: running tally with `--fix` twice is enough to land an alphabetically sorted list in all
-cases.
+The package-manager fix coordinates with `tally/sort-packages`: when both rules are enabled, the inserted opcache package is appended at the end of
+the install command so that sort-packages produces a correctly ordered list in the same `--fix` pass.
 
 ## Examples
 

--- a/_docs/rules/tally/php/enable-opcache-in-production.mdx
+++ b/_docs/rules/tally/php/enable-opcache-in-production.mdx
@@ -1,0 +1,121 @@
+---
+title: "tally/php/enable-opcache-in-production"
+description: "Production PHP web runtime images should install and enable OPcache."
+---
+
+Production PHP web runtime images should install and enable OPcache.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info |
+| Category | Performance |
+| Default | Enabled |
+| Auto-fix | Yes (heuristic: official `php:*` images or single `php*-fpm` package) |
+
+## What is OPcache?
+
+OPcache is a PHP extension that stores precompiled script bytecode in shared memory, removing the need for PHP to re-read and re-parse scripts on
+every request. Because only the low-level bytecode needs to run — no lexing, parsing, or compilation — it has a large, measurable impact on the
+request throughput of any real-world PHP application.
+
+When a request comes in:
+
+1. PHP checks whether OPcache is enabled.
+2. If the script's bytecode is already in the cache, OPcache returns it straight from shared memory and the Zend Engine executes it. The tokenize →
+   parse → compile pipeline is skipped entirely.
+3. If the bytecode is not cached, PHP processes the script as usual (tokenize, parse, compile to opcodes), stores the resulting bytecode in shared
+   memory, and then executes it. Subsequent requests hit the cache.
+
+OPcache ships with PHP core and is the canonical production cache for PHP web runtimes. Enabling it is a one-line change with no application-code
+impact.
+
+## Description
+
+Flags long-running PHP web runtime stages that do not install, enable, or configure OPcache. OPcache stores precompiled PHP bytecode in shared memory,
+avoiding per-request script compilation and delivering a substantial throughput improvement in production.
+
+The rule only triggers on the **final** build stage. A stage is treated as a PHP web runtime when any of the following hold:
+
+- the base image is an official `php:*` tag whose tag contains `fpm` or `apache`
+- the base image is a known PHP web runtime derivative (`serversideup/php`, `dunglas/frankenphp`, `bitnami/php-fpm`, `trafex/php-nginx`,
+  `webdevops/php-nginx`, `webdevops/php-apache`)
+- the effective `ENTRYPOINT` or `CMD` starts a known PHP web server wrapper (`php-fpm`, `php-fpm7.4`, `php-fpm8.3`, `apache2-foreground`,
+  `httpd-foreground`, `frankenphp`, `rr`)
+
+Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug` are skipped, as are non-final stages. CLI-only PHP images
+(`php:*-cli` with no PHP web server wrapper) are also skipped.
+
+### Signals treated as compliant
+
+Any of the following in the final stage suppress the violation:
+
+- `docker-php-ext-install opcache`, `docker-php-ext-enable opcache`, or `docker-php-ext-configure opcache`
+- `pecl install opcache`
+- Package-manager installs referencing OPcache (`apt-get install php-opcache`, `apk add php83-opcache`, `dnf install php-opcache`, etc.), with
+  version/architecture specifiers stripped (`php-opcache=8.3+1ubuntu1`, `php-opcache:amd64`)
+- An image file that looks like an OPcache ini (`*opcache*.ini`) or whose content enables OPcache via `opcache.*` keys (e.g., `opcache.enable=1`) or
+  `zend_extension=opcache`
+- A stage-level environment variable prefixed with `PHP_OPCACHE_`
+
+## Fix behavior
+
+The rule offers two heuristic `FixSuggestion` fixes:
+
+### 1. Official `php:*fpm*` / `*apache*` base
+
+When the base image is an official `php:*fpm*` or `php:*apache*` Linux tag, the rule inserts a new `RUN docker-php-ext-install opcache` line
+immediately after the final `FROM`. The edit is narrow, zero-width at the insertion column, and does not modify any existing lines.
+
+### 2. Generic base that installs PHP via a package manager
+
+When the final stage is detected as PHP only via `CMD`/`ENTRYPOINT` (e.g., `debian:12-slim` + `CMD ["php-fpm8.3"]`) **and** the stage's install
+commands include exactly one `php*-fpm` package, the rule appends the matching `php*-opcache` package to that same install command. The matching
+package name is derived directly from the existing PHP package the user chose:
+
+| Package in `RUN` | Derived OPcache package |
+|---|---|
+| `php8.3-fpm` (Debian/Ubuntu) | `php8.3-opcache` |
+| `php-fpm` (unversioned) | `php-opcache` |
+| `php83-fpm` (Alpine) | `php83-opcache` |
+| `php83-php-fpm` (Remi SCL) | `php83-php-opcache` |
+
+Example:
+
+```dockerfile
+# Before
+RUN apt-get install -y php8.3-fpm
+# After
+RUN apt-get install -y php8.3-fpm php8.3-opcache
+```
+
+### No fix is offered
+
+- the base image is a non-official derivative (`serversideup/php`, `dunglas/frankenphp`, `bitnami/php-fpm`, ...) — they usually bundle OPcache or
+  expect different ini paths, and the right remediation is image-specific
+- the stage is detected via `CMD`/`ENTRYPOINT` but no `php*-fpm` package is visible in an install command in the same Dockerfile
+- the stage installs **multiple different** `php*-fpm` packages (ambiguous target version)
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM php:8.4-fpm
+WORKDIR /app
+COPY . .
+```
+
+### After
+
+```dockerfile
+FROM php:8.4-fpm
+RUN docker-php-ext-install opcache
+WORKDIR /app
+COPY . .
+```
+
+## References
+
+- [PHP OPcache manual](https://www.php.net/manual/en/book.opcache.php)
+- [Docker guide for PHP: develop](https://docs.docker.com/guides/php/develop/)
+- [Composer autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md)

--- a/design-docs/PROPOSED-RULES-TRACKER.md
+++ b/design-docs/PROPOSED-RULES-TRACKER.md
@@ -13,7 +13,6 @@ Source: [32-gpu-container-rules.md](32-gpu-container-rules.md)
 
 | Rule ID | Severity | Description | Notes |
 |---------|----------|-------------|-------|
-| `tally/gpu/prefer-uv-over-conda` | Info | Suggest uv over conda for GPU Python deps | |
 | `tally/gpu/require-torch-cuda-arch-list` | Info | Warn when CUDA extensions built without `TORCH_CUDA_ARCH_LIST` | |
 | `tally/gpu/hardcoded-cuda-path` | Info | Detect hardcoded `/usr/local/cuda-X.Y` paths (use `/usr/local/cuda`) | |
 | `tally/gpu/ld-library-path-overwrite` | Warning | Detect `LD_LIBRARY_PATH` overwrite without preserving existing value | |
@@ -53,10 +52,9 @@ Source: [35-php-container-rules.md](35-php-container-rules.md)
 | `tally/php/remove-build-deps-after-extension-build` | Warning | Warn on leftover build deps after `docker-php-ext-install`/`pecl install` | |
 | `tally/php/composer-no-interaction-in-build` | Info | Detect `composer install` without `--no-interaction` | |
 | `tally/php/prefer-composer-stage` | Info | Suggest `composer:*` image instead of curl-installing composer | |
-| `tally/php/enable-opcache-in-production` | Info | Suggest enabling OPcache in production PHP runtimes | |
 | `tally/php/prefer-non-root-runtime` | Info | Suggest running as non-root (www-data) in production | |
 
-**Already implemented (1):** `composer-no-dev-in-production`
+**Already implemented (3):** `composer-no-dev-in-production`, `no-xdebug-in-final-image`, `enable-opcache-in-production`
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.podman.io/image/v5 v5.39.2
 	golang.org/x/exp/jsonrpc2 v0.0.0-20250718183923-645b1fa84792
 	golang.org/x/sys v0.43.0
+	gopkg.in/ini.v1 v1.67.1
 	mvdan.cc/sh/v3 v3.13.1
 )
 
@@ -169,6 +170,5 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -376,6 +376,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
@@ -431,12 +432,8 @@ github.com/wasilibs/go-re2 v1.9.0 h1:kjAd8qbNvV4Ve2Uf+zrpTCrDHtqH4dlsRXktywo73JQ
 github.com/wasilibs/go-re2 v1.9.0/go.mod h1:0sRtscWgpUdNA137bmr1IUgrRX0Su4dcn9AEe61y+yI=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
-github.com/wharflab/tree-sitter-batch v0.9.0 h1:uHmFC1lW89R/H4ZhqWfkOOe9M4eaQ359z04Bc+RqyFQ=
-github.com/wharflab/tree-sitter-batch v0.9.0/go.mod h1:pn5t1ZUQ6WNU5dCIaWbaR4D5dHgmIQKv66MM8qlMl+8=
 github.com/wharflab/tree-sitter-batch v0.11.1 h1:kR6GDsj4oHVmMMQcNnj3pbSNNPXwAK8+xSH0xWg0ZTo=
 github.com/wharflab/tree-sitter-batch v0.11.1/go.mod h1:pn5t1ZUQ6WNU5dCIaWbaR4D5dHgmIQKv66MM8qlMl+8=
-github.com/wharflab/tree-sitter-powershell v0.31.0 h1:EIAI/kjF17wCDMnwkH1LHrgxPjJ0uDn5PmR+VP3Ei0A=
-github.com/wharflab/tree-sitter-powershell v0.31.0/go.mod h1:KI9j2ME0o0c4T/iHMxP0ei6UR485dRjWPkff85WWfco=
 github.com/wharflab/tree-sitter-powershell v0.33.0 h1:BvKU6vDf/uFXGrVNqAipD6QuogZl1xmhBbH29SXVG7c=
 github.com/wharflab/tree-sitter-powershell v0.33.0/go.mod h1:KI9j2ME0o0c4T/iHMxP0ei6UR485dRjWPkff85WWfco=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
@@ -673,8 +670,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
-gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
+gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-append-opcache-package_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-append-opcache-package_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:12-slim
+RUN apt-get install -y php8.3-fpm php8.3-opcache
+CMD ["php-fpm8.3", "-F"]

--- a/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-insert-run_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-insert-run_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM php:8.4-fpm
+RUN docker-php-ext-install opcache
+WORKDIR /app
+COPY . .

--- a/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-with-sort-packages_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-with-sort-packages_1.snap.Dockerfile
@@ -1,3 +1,3 @@
 FROM debian:12-slim
-RUN apt-get install -y php8.3-fpm php8.3-opcache php8.3-gd
+RUN apt-get install -y php8.3-cli php8.3-fpm php8.3-zip php8.3-opcache
 CMD ["php-fpm8.3", "-F"]

--- a/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-with-sort-packages_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-with-sort-packages_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:12-slim
+RUN apt-get install -y php8.3-fpm php8.3-opcache php8.3-gd
+CMD ["php-fpm8.3", "-F"]

--- a/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-with-sort-packages_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_php-enable-opcache-in-production-with-sort-packages_1.snap.Dockerfile
@@ -1,3 +1,3 @@
 FROM debian:12-slim
-RUN apt-get install -y php8.3-cli php8.3-fpm php8.3-zip php8.3-opcache
+RUN apt-get install -y php8.3-cli php8.3-fpm php8.3-opcache
 CMD ["php-fpm8.3", "-F"]

--- a/internal/integration/__snapshots__/TestLint_php-enable-opcache-in-production_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_php-enable-opcache-in-production_1.snap.json
@@ -1,0 +1,60 @@
+{
+  "files": [
+    {
+      "file": "testdata/php-enable-opcache-in-production/Dockerfile",
+      "violations": [
+        {
+          "detail": "OPcache stores precompiled PHP bytecode in shared memory, dramatically reducing request-time overhead. Install and enable it in this runtime stage, e.g. RUN docker-php-ext-install opcache.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/php/enable-opcache-in-production/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 6
+            },
+            "file": "testdata/php-enable-opcache-in-production/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 6
+            }
+          },
+          "message": "Production PHP web runtime images should install and enable OPcache",
+          "rule": "tally/php/enable-opcache-in-production",
+          "severity": "info",
+          "sourceCode": "FROM php:8.4-fpm AS app",
+          "suggestedFix": {
+            "description": "Add RUN docker-php-ext-install opcache after the final FROM",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 7
+                  },
+                  "file": "testdata/php-enable-opcache-in-production/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 7
+                  }
+                },
+                "newText": "RUN docker-php-ext-install opcache\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "files_scanned": 1,
-  "rules_enabled": 99,
+  "rules_enabled": 100,
   "summary": {
     "errors": 0,
     "files": 0,

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1452,6 +1452,31 @@ severity = "warning"
 				mustSelectRules("tally/php/no-xdebug-in-final-image")...),
 			wantApplied: 1,
 		},
+		// PHP: enable-opcache-in-production inserts
+		// `RUN docker-php-ext-install opcache` after the final FROM for official
+		// php:*fpm*/*apache* images. Fix is FixSuggestion safety, so --fix-unsafe
+		// is needed to apply it in batch mode.
+		{
+			name: "php-enable-opcache-in-production-insert-run",
+			input: "FROM php:8.4-fpm\n" +
+				"WORKDIR /app\n" +
+				"COPY . .\n",
+			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules("tally/php/enable-opcache-in-production")...),
+			wantApplied: 1,
+		},
+		// PHP: enable-opcache-in-production package-manager path. Adds the
+		// matching phpNN-opcache package alongside the existing phpNN-fpm
+		// install on a generic Debian base.
+		{
+			name: "php-enable-opcache-in-production-append-opcache-package",
+			input: "FROM debian:12-slim\n" +
+				"RUN apt-get install -y php8.3-fpm\n" +
+				"CMD [\"php-fpm8.3\", \"-F\"]\n",
+			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules("tally/php/enable-opcache-in-production")...),
+			wantApplied: 1,
+		},
 		// Full composition: two secret mounts (insertion) + two cache mounts
 		// (insertion) + cleanup removal (npm cache clean, --no-cache-dir)
 		// on the same RUN in a single --fix pass.

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1478,21 +1478,21 @@ severity = "warning"
 			wantApplied: 1,
 		},
 		// PHP: enable-opcache-in-production composed with sort-packages on the
-		// same RUN. Original list is unsorted AND will have packages both
-		// before and after opcache in the sorted result, so sort-packages is
-		// guaranteed to fire. Demonstrates that the two rules apply together
-		// in one --fix pass without overlapping edits.
+		// same RUN. Exercises the sort-packages-enabled branch of the fix:
+		// the insertion anchors at the LAST original package (php8.3-cli)
+		// rather than at php8.3-fpm, so opcache lands after the sorted
+		// block in a single --fix pass.
 		{
 			name: "php-enable-opcache-in-production-with-sort-packages",
 			input: "FROM debian:12-slim\n" +
-				"RUN apt-get install -y php8.3-zip php8.3-cli php8.3-fpm\n" +
+				"RUN apt-get install -y php8.3-fpm php8.3-cli\n" +
 				"CMD [\"php-fpm8.3\", \"-F\"]\n",
 			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
 				mustSelectRules(
 					"tally/php/enable-opcache-in-production",
 					"tally/sort-packages",
 				)...),
-			wantApplied: 2, // sort-packages reorders + enable-opcache appends opcache
+			wantApplied: 2,
 		},
 		// Full composition: two secret mounts (insertion) + two cache mounts
 		// (insertion) + cleanup removal (npm cache clean, --no-cache-dir)

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1478,22 +1478,21 @@ severity = "warning"
 			wantApplied: 1,
 		},
 		// PHP: enable-opcache-in-production composed with sort-packages on the
-		// same RUN. Demonstrates the documented composition: enable-opcache
-		// inserts php8.3-opcache directly after the php8.3-fpm token, which
-		// can leave the list out of sort order (e.g. fpm opcache gd). The
-		// follow-up sort violation is caught by sort-packages on the next
-		// --fix pass; the two rules do not conflict on this pass.
+		// same RUN. Original list is unsorted AND will have packages both
+		// before and after opcache in the sorted result, so sort-packages is
+		// guaranteed to fire. Demonstrates that the two rules apply together
+		// in one --fix pass without overlapping edits.
 		{
 			name: "php-enable-opcache-in-production-with-sort-packages",
 			input: "FROM debian:12-slim\n" +
-				"RUN apt-get install -y php8.3-fpm php8.3-gd\n" +
+				"RUN apt-get install -y php8.3-zip php8.3-cli php8.3-fpm\n" +
 				"CMD [\"php-fpm8.3\", \"-F\"]\n",
 			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
 				mustSelectRules(
 					"tally/php/enable-opcache-in-production",
 					"tally/sort-packages",
 				)...),
-			wantApplied: 1, // only enable-opcache applies; sort-packages has nothing to fix on the original
+			wantApplied: 2, // sort-packages reorders + enable-opcache appends opcache
 		},
 		// Full composition: two secret mounts (insertion) + two cache mounts
 		// (insertion) + cleanup removal (npm cache clean, --no-cache-dir)

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1477,6 +1477,24 @@ severity = "warning"
 				mustSelectRules("tally/php/enable-opcache-in-production")...),
 			wantApplied: 1,
 		},
+		// PHP: enable-opcache-in-production composed with sort-packages on the
+		// same RUN. Demonstrates the documented composition: enable-opcache
+		// inserts php8.3-opcache directly after the php8.3-fpm token, which
+		// can leave the list out of sort order (e.g. fpm opcache gd). The
+		// follow-up sort violation is caught by sort-packages on the next
+		// --fix pass; the two rules do not conflict on this pass.
+		{
+			name: "php-enable-opcache-in-production-with-sort-packages",
+			input: "FROM debian:12-slim\n" +
+				"RUN apt-get install -y php8.3-fpm php8.3-gd\n" +
+				"CMD [\"php-fpm8.3\", \"-F\"]\n",
+			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules(
+					"tally/php/enable-opcache-in-production",
+					"tally/sort-packages",
+				)...),
+			wantApplied: 1, // only enable-opcache applies; sort-packages has nothing to fix on the original
+		},
 		// Full composition: two secret mounts (insertion) + two cache mounts
 		// (insertion) + cleanup removal (npm cache clean, --no-cache-dir)
 		// on the same RUN in a single --fix pass.

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -275,6 +275,12 @@ func lintCases(t *testing.T) []lintCase {
 			args:     append([]string{"--format", "json"}, mustSelectRules("tally/php/no-xdebug-in-final-image")...),
 			wantExit: 1,
 		},
+		{
+			name:     "php-enable-opcache-in-production",
+			dir:      "php-enable-opcache-in-production",
+			args:     append([]string{"--format", "json"}, mustSelectRules("tally/php/enable-opcache-in-production")...),
+			wantExit: 1,
+		},
 
 		// Windows: RUN --mount not supported
 		{

--- a/internal/integration/testdata/php-enable-opcache-in-production/Dockerfile
+++ b/internal/integration/testdata/php-enable-opcache-in-production/Dockerfile
@@ -1,0 +1,9 @@
+FROM composer:2 AS deps
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-interaction --optimize-autoloader
+
+FROM php:8.4-fpm AS app
+WORKDIR /app
+COPY --from=deps /app/vendor /app/vendor
+COPY . .

--- a/internal/rules/tally/php/enable_opcache_in_production.go
+++ b/internal/rules/tally/php/enable_opcache_in_production.go
@@ -305,7 +305,7 @@ func stageLooksLikePHPWebRuntime(info *semantic.StageInfo, stage instructions.St
 			return true
 		}
 	}
-	if cmd := stageRuntimeCommandName(stage); cmd != "" && isPHPWebRuntimeCommand(cmd) {
+	if slices.ContainsFunc(stageRuntimeCommandNames(stage), isPHPWebRuntimeCommand) {
 		return true
 	}
 	return false
@@ -340,11 +340,14 @@ func officialPHPWebRuntimeTag(raw string) bool {
 	return strings.Contains(tag, "fpm") || strings.Contains(tag, "apache")
 }
 
-// stageRuntimeCommandName returns the executable name of the last ENTRYPOINT
-// or CMD in the stage (ENTRYPOINT takes precedence when both are present).
-// For shell-form instructions, parses the script to find the first command
-// name. Returns the lowercased path basename, or "" when unavailable.
-func stageRuntimeCommandName(stage instructions.Stage) string {
+// stageRuntimeCommandNames returns the executable names of the last
+// ENTRYPOINT and CMD in the stage (both are considered, since a common
+// PHP web runtime pattern is ENTRYPOINT ["docker-entrypoint.sh"] +
+// CMD ["php-fpm"] — the actual runtime process is php-fpm, started via
+// the entrypoint wrapper). For shell-form instructions, parses the script
+// to find the first command name. Returns lowercased path basenames; an
+// empty slice when no ENTRYPOINT or CMD is present.
+func stageRuntimeCommandNames(stage instructions.Stage) []string {
 	var lastEntrypoint *instructions.EntrypointCommand
 	var lastCmd *instructions.CmdCommand
 	for _, c := range stage.Commands {
@@ -356,13 +359,18 @@ func stageRuntimeCommandName(stage instructions.Stage) string {
 		}
 	}
 
+	names := make([]string, 0, 2) //nolint:mnd // up to ENTRYPOINT + CMD
 	if lastEntrypoint != nil {
-		return commandNameFromCmdLine(lastEntrypoint.CmdLine, lastEntrypoint.PrependShell)
+		if name := commandNameFromCmdLine(lastEntrypoint.CmdLine, lastEntrypoint.PrependShell); name != "" {
+			names = append(names, name)
+		}
 	}
 	if lastCmd != nil {
-		return commandNameFromCmdLine(lastCmd.CmdLine, lastCmd.PrependShell)
+		if name := commandNameFromCmdLine(lastCmd.CmdLine, lastCmd.PrependShell); name != "" {
+			names = append(names, name)
+		}
 	}
-	return ""
+	return names
 }
 
 func commandNameFromCmdLine(cmdLine []string, prependShell bool) string {

--- a/internal/rules/tally/php/enable_opcache_in_production.go
+++ b/internal/rules/tally/php/enable_opcache_in_production.go
@@ -260,9 +260,26 @@ func buildOpcachePackageManagerFix(
 	}
 }
 
+// osPackageManagersForPHP is the set of install-command managers whose
+// packages follow the phpNN-opcache naming convention. Only installs from
+// these managers can be mapped to a matching OPcache system package;
+// application-level managers (composer, npm, pip, ...) may happen to
+// ship a package called "php-fpm" but it would not come with a
+// companion system OPcache extension.
+var osPackageManagersForPHP = map[string]bool{
+	"apt":      true,
+	"apt-get":  true,
+	"apk":      true,
+	"dnf":      true,
+	"microdnf": true,
+	"yum":      true,
+	"zypper":   true,
+}
+
 // derivePHPOpcachePackage maps a PHP FPM package name to the matching OPcache
 // package name on the same distro family. Returns "" if the package is not a
-// recognized php*-fpm form.
+// recognized php*-fpm form or the install command is not from a supported
+// OS package manager.
 //
 // Supported forms:
 //   - Debian/Ubuntu:    phpMAJOR.MINOR-fpm       -> phpMAJOR.MINOR-opcache
@@ -271,6 +288,9 @@ func buildOpcachePackageManagerFix(
 //   - RHEL/Fedora/UBI:  php-fpm                  -> php-opcache
 //   - Remi SCL:         phpMAJORMINOR-php-fpm    -> phpMAJORMINOR-php-opcache
 func derivePHPOpcachePackage(pkgName, manager string) string {
+	if !osPackageManagersForPHP[strings.ToLower(manager)] {
+		return ""
+	}
 	name := strings.ToLower(shell.StripPackageVersion(pkgName))
 	switch {
 	case name == "php-fpm":
@@ -282,7 +302,6 @@ func derivePHPOpcachePackage(pkgName, manager string) string {
 		// e.g. php8.3-fpm (Debian), php83-fpm (Alpine)
 		return strings.TrimSuffix(name, "-fpm") + "-opcache"
 	default:
-		_ = manager
 		return ""
 	}
 }
@@ -461,7 +480,13 @@ func commandReferencesOpcacheExt(cmd shell.CommandInfo) bool {
 
 // installCommandInstallsOpcache reports whether a normalized package-manager
 // install references an OPcache package (e.g., php-opcache, php8.3-opcache).
+// Only OS-level package managers are considered; an npm/pip/composer package
+// that happens to contain "opcache" in its name does not imply the PHP
+// OPcache extension is enabled in the image.
 func installCommandInstallsOpcache(ic shell.InstallCommand) bool {
+	if !osPackageManagersForPHP[strings.ToLower(ic.Manager)] {
+		return false
+	}
 	for _, pkg := range ic.Packages {
 		name := strings.ToLower(shell.StripPackageVersion(pkg.Normalized))
 		if strings.Contains(name, "opcache") {

--- a/internal/rules/tally/php/enable_opcache_in_production.go
+++ b/internal/rules/tally/php/enable_opcache_in_production.go
@@ -139,6 +139,19 @@ func stageBaseImageRaw(info *semantic.StageInfo) string {
 // OPcache package next to an existing PHP FPM package in the stage's
 // install commands. Fires only when exactly one php*-fpm package is present
 // across the stage's runs, so the distro/version naming is unambiguous.
+//
+// Cross-rule interactions (fix priority 88):
+//   - tally/sort-packages (priority 9): runs first; sorts any pre-existing
+//     unsorted list before this fix appends. Appending opcache at the end
+//     can leave the list out of order (e.g. "php8.3-fpm php8.3-zlib" +
+//     "php8.3-opcache" -> opcache belongs between); sort-packages then
+//     catches it on the next --fix pass.
+//   - tally/no-multi-spaces (priority 10): the inserted text is " pkg" —
+//     exactly one leading space — so the combined RUN never contains a
+//     multi-space run as a result of this fix.
+//   - tally/prefer-package-cache-mounts (priority 90): operates on RUN
+//     flags (--mount=type=cache), not package args; the two fixes touch
+//     disjoint surfaces and apply in the same pass without conflict.
 func buildOpcachePackageManagerFix(
 	file string,
 	sf *facts.StageFacts,

--- a/internal/rules/tally/php/enable_opcache_in_production.go
+++ b/internal/rules/tally/php/enable_opcache_in_production.go
@@ -1,0 +1,472 @@
+package php
+
+import (
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"gopkg.in/ini.v1"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+// EnableOpcacheInProductionRuleCode is the full rule code.
+const EnableOpcacheInProductionRuleCode = rules.TallyRulePrefix + "php/enable-opcache-in-production"
+
+// EnableOpcacheInProductionRule flags production PHP web runtime images that
+// do not enable OPcache.
+type EnableOpcacheInProductionRule struct{}
+
+// NewEnableOpcacheInProductionRule creates the rule.
+func NewEnableOpcacheInProductionRule() *EnableOpcacheInProductionRule {
+	return &EnableOpcacheInProductionRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *EnableOpcacheInProductionRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            EnableOpcacheInProductionRuleCode,
+		Name:            "Enable OPcache in production PHP images",
+		Description:     "Production PHP web runtime images should install and enable OPcache",
+		DocURL:          rules.TallyDocURL(EnableOpcacheInProductionRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "performance",
+		FixPriority:     88, //nolint:mnd // stable priority contract, consistent with companion PHP rules
+	}
+}
+
+// Check runs the rule.
+func (r *EnableOpcacheInProductionRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	if len(input.Stages) == 0 {
+		return nil
+	}
+	finalIdx := len(input.Stages) - 1
+	stage := input.Stages[finalIdx]
+	if stageLooksLikeDev(stage.Name) {
+		return nil
+	}
+
+	stageFacts := input.Facts.Stage(finalIdx)
+	if stageFacts == nil || !stageFacts.IsLast {
+		return nil
+	}
+
+	info := input.Semantic.StageInfo(finalIdx)
+	if !stageLooksLikePHPWebRuntime(info, stage) {
+		return nil
+	}
+
+	if stageHasOpcacheSignal(stageFacts) {
+		return nil
+	}
+
+	loc := rules.NewLocationFromRanges(input.File, stage.Location)
+	v := rules.NewViolation(
+		loc,
+		meta.Code,
+		meta.Description,
+		meta.DefaultSeverity,
+	).WithDocURL(meta.DocURL).WithDetail(
+		"OPcache stores precompiled PHP bytecode in shared memory, dramatically " +
+			"reducing request-time overhead. Install and enable it in this runtime stage, " +
+			"e.g. RUN docker-php-ext-install opcache.",
+	)
+	if fix := buildOpcacheInstallFix(input.File, stage, stageFacts, info, meta.FixPriority); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	} else if fix := buildOpcachePackageManagerFix(input.File, stageFacts, input.SourceMap(), meta.FixPriority); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+	return []rules.Violation{v}
+}
+
+// buildOpcacheInstallFix returns a heuristic fix that inserts
+// `RUN docker-php-ext-install opcache` immediately after the FROM instruction,
+// but only for the common-case shape where that command is known to apply:
+//
+//   - base image is an official php:* tag (docker-php-ext-* helpers ship there)
+//   - tag contains "fpm" or "apache" (web runtime variant)
+//   - stage is not Windows (docker-php-ext-* is a Linux-only convention)
+//
+// Derivative images and generic Debian/Ubuntu bases are intentionally skipped:
+// the correct command there is distro-specific (apt-get install php-opcache,
+// apk add php83-opcache, ...) and picking the right package name requires
+// knowing the distro + PHP version.
+func buildOpcacheInstallFix(
+	file string,
+	stage instructions.Stage,
+	sf *facts.StageFacts,
+	info *semantic.StageInfo,
+	priority int,
+) *rules.SuggestedFix {
+	if sf == nil || sf.BaseImageOS == semantic.BaseImageOSWindows {
+		return nil
+	}
+	if !officialPHPWebRuntimeTag(stageBaseImageRaw(info)) {
+		return nil
+	}
+	if len(stage.Location) == 0 {
+		return nil
+	}
+	insertLine := stage.Location[len(stage.Location)-1].End.Line + 1
+	return &rules.SuggestedFix{
+		Description: "Add RUN docker-php-ext-install opcache after the final FROM",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(file, insertLine, 0, insertLine, 0),
+			NewText:  "RUN docker-php-ext-install opcache\n",
+		}},
+	}
+}
+
+func stageBaseImageRaw(info *semantic.StageInfo) string {
+	if info == nil || info.BaseImage == nil || info.BaseImage.IsStageRef {
+		return ""
+	}
+	return info.BaseImage.Raw
+}
+
+// buildOpcachePackageManagerFix emits an insertion that adds the matching
+// OPcache package next to an existing PHP FPM package in the stage's
+// install commands. Fires only when exactly one php*-fpm package is present
+// across the stage's runs, so the distro/version naming is unambiguous.
+func buildOpcachePackageManagerFix(
+	file string,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	priority int,
+) *rules.SuggestedFix {
+	if sf == nil || sm == nil {
+		return nil
+	}
+
+	var (
+		targetRun   *facts.RunFacts
+		targetIC    shell.InstallCommand
+		targetPkg   shell.PackageArg
+		opcacheName string
+		found       int
+	)
+	for _, run := range sf.Runs {
+		if run == nil {
+			continue
+		}
+		for _, ic := range run.InstallCommands {
+			for _, pkg := range ic.Packages {
+				derived := derivePHPOpcachePackage(pkg.Normalized, ic.Manager)
+				if derived == "" {
+					continue
+				}
+				found++
+				if found > 1 {
+					return nil
+				}
+				targetRun = run
+				targetIC = ic
+				targetPkg = pkg
+				opcacheName = derived
+			}
+		}
+	}
+	if found != 1 || targetRun == nil || targetRun.Run == nil || !targetRun.UsesShell {
+		return nil
+	}
+	locs := targetRun.Run.Location()
+	if len(locs) == 0 {
+		return nil
+	}
+	runStartLine := locs[0].Start.Line // 1-based
+	editLine := runStartLine + targetPkg.Line
+	editCol := targetPkg.EndCol
+	if targetPkg.Line == 0 {
+		lineIdx := runStartLine - 1
+		if lineIdx < 0 || lineIdx >= sm.LineCount() {
+			return nil
+		}
+		editCol += shell.DockerfileRunCommandStartCol(sm.Line(lineIdx))
+	}
+	return &rules.SuggestedFix{
+		Description: "Add " + opcacheName + " to the existing " + targetIC.Manager + " " + targetIC.Subcommand,
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(file, editLine, editCol, editLine, editCol),
+			NewText:  " " + opcacheName,
+		}},
+	}
+}
+
+// derivePHPOpcachePackage maps a PHP FPM package name to the matching OPcache
+// package name on the same distro family. Returns "" if the package is not a
+// recognized php*-fpm form.
+//
+// Supported forms:
+//   - Debian/Ubuntu:    phpMAJOR.MINOR-fpm       -> phpMAJOR.MINOR-opcache
+//   - Debian/Ubuntu:    php-fpm (unversioned)    -> php-opcache
+//   - Alpine:           phpMAJORMINOR-fpm        -> phpMAJORMINOR-opcache
+//   - RHEL/Fedora/UBI:  php-fpm                  -> php-opcache
+//   - Remi SCL:         phpMAJORMINOR-php-fpm    -> phpMAJORMINOR-php-opcache
+func derivePHPOpcachePackage(pkgName, manager string) string {
+	name := strings.ToLower(shell.StripPackageVersion(pkgName))
+	switch {
+	case name == "php-fpm":
+		return "php-opcache"
+	case strings.HasSuffix(name, "-php-fpm"):
+		// e.g. php83-php-fpm (Remi)
+		return strings.TrimSuffix(name, "-php-fpm") + "-php-opcache"
+	case strings.HasSuffix(name, "-fpm") && strings.HasPrefix(name, "php"):
+		// e.g. php8.3-fpm (Debian), php83-fpm (Alpine)
+		return strings.TrimSuffix(name, "-fpm") + "-opcache"
+	default:
+		_ = manager
+		return ""
+	}
+}
+
+// phpWebRuntimeCommands are command basenames that indicate a long-running
+// PHP web runtime when seen as the effective ENTRYPOINT or CMD of the final
+// stage. Matched case-insensitively against the last path segment; any
+// executable starting with "php-fpm" is also accepted (covers php-fpmNN
+// variants used by Debian/Ubuntu packages).
+var phpWebRuntimeCommands = map[string]bool{
+	"apache2-foreground": true,
+	"httpd-foreground":   true,
+	"frankenphp":         true,
+	"rr":                 true, // roadrunner
+}
+
+// phpWebRuntimeDerivativeImages lists non-official image repositories that
+// are widely used as PHP web runtime bases. Matched against the familiar
+// image name (no domain, no tag).
+var phpWebRuntimeDerivativeImages = map[string]bool{
+	"serversideup/php":     true,
+	"dunglas/frankenphp":   true,
+	"bitnami/php-fpm":      true,
+	"trafex/php-nginx":     true,
+	"webdevops/php-nginx":  true,
+	"webdevops/php-apache": true,
+}
+
+// stageLooksLikePHPWebRuntime reports whether the final stage behaves like a
+// long-running PHP web runtime. True when any of:
+//   - base image is official php:* with a tag containing "fpm" or "apache"
+//   - base image is a known PHP web runtime derivative
+//   - effective ENTRYPOINT or CMD starts a known PHP web server wrapper
+func stageLooksLikePHPWebRuntime(info *semantic.StageInfo, stage instructions.Stage) bool {
+	if info != nil && info.BaseImage != nil && !info.BaseImage.IsStageRef {
+		if baseImageIsPHPWebRuntime(info.BaseImage.Raw) {
+			return true
+		}
+	}
+	if cmd := stageRuntimeCommandName(stage); cmd != "" && isPHPWebRuntimeCommand(cmd) {
+		return true
+	}
+	return false
+}
+
+func baseImageIsPHPWebRuntime(raw string) bool {
+	if officialPHPWebRuntimeTag(raw) {
+		return true
+	}
+	named, err := reference.ParseNormalizedNamed(strings.ToLower(raw))
+	if err != nil {
+		return false
+	}
+	return phpWebRuntimeDerivativeImages[reference.FamiliarName(named)]
+}
+
+// officialPHPWebRuntimeTag reports whether raw is an official php:* image
+// tagged for a web runtime (fpm/apache).
+func officialPHPWebRuntimeTag(raw string) bool {
+	named, err := reference.ParseNormalizedNamed(strings.ToLower(raw))
+	if err != nil {
+		return false
+	}
+	if reference.FamiliarName(named) != "php" {
+		return false
+	}
+	tagged, ok := named.(reference.Tagged)
+	if !ok {
+		return false
+	}
+	tag := strings.ToLower(tagged.Tag())
+	return strings.Contains(tag, "fpm") || strings.Contains(tag, "apache")
+}
+
+// stageRuntimeCommandName returns the executable name of the last ENTRYPOINT
+// or CMD in the stage (ENTRYPOINT takes precedence when both are present).
+// For shell-form instructions, parses the script to find the first command
+// name. Returns the lowercased path basename, or "" when unavailable.
+func stageRuntimeCommandName(stage instructions.Stage) string {
+	var lastEntrypoint *instructions.EntrypointCommand
+	var lastCmd *instructions.CmdCommand
+	for _, c := range stage.Commands {
+		switch cc := c.(type) {
+		case *instructions.EntrypointCommand:
+			lastEntrypoint = cc
+		case *instructions.CmdCommand:
+			lastCmd = cc
+		}
+	}
+
+	if lastEntrypoint != nil {
+		return commandNameFromCmdLine(lastEntrypoint.CmdLine, lastEntrypoint.PrependShell)
+	}
+	if lastCmd != nil {
+		return commandNameFromCmdLine(lastCmd.CmdLine, lastCmd.PrependShell)
+	}
+	return ""
+}
+
+func commandNameFromCmdLine(cmdLine []string, prependShell bool) string {
+	if len(cmdLine) == 0 {
+		return ""
+	}
+	if prependShell {
+		names := shell.CommandNamesWithVariant(cmdLine[0], shell.VariantBash)
+		if len(names) == 0 {
+			return ""
+		}
+		return strings.ToLower(path.Base(names[0]))
+	}
+	return strings.ToLower(path.Base(cmdLine[0]))
+}
+
+func isPHPWebRuntimeCommand(name string) bool {
+	if phpWebRuntimeCommands[name] {
+		return true
+	}
+	// Match php-fpm, php-fpm7.4, php-fpm8.3, php-fpm83, etc.
+	return strings.HasPrefix(name, "php-fpm")
+}
+
+// stageHasOpcacheSignal reports whether the stage has any signal that OPcache
+// is installed, enabled, or configured.
+func stageHasOpcacheSignal(sf *facts.StageFacts) bool {
+	if sf == nil {
+		return false
+	}
+	if envHasOpcacheSignal(sf.EffectiveEnv) {
+		return true
+	}
+	for _, run := range sf.Runs {
+		if run != nil && runHasOpcacheSignal(run) {
+			return true
+		}
+	}
+	return slices.ContainsFunc(sf.ObservableFiles, observableFileHasOpcacheSignal)
+}
+
+func envHasOpcacheSignal(env facts.EnvFacts) bool {
+	for key := range env.Values {
+		if strings.HasPrefix(strings.ToUpper(key), "PHP_OPCACHE_") {
+			return true
+		}
+	}
+	return false
+}
+
+func runHasOpcacheSignal(run *facts.RunFacts) bool {
+	if slices.ContainsFunc(run.CommandInfos, commandReferencesOpcacheExt) {
+		return true
+	}
+	return slices.ContainsFunc(run.InstallCommands, installCommandInstallsOpcache)
+}
+
+// commandReferencesOpcacheExt detects PHP-specific extension tooling that
+// installs, enables, or configures OPcache. General package-manager installs
+// are handled separately via facts.RunFacts.InstallCommands.
+func commandReferencesOpcacheExt(cmd shell.CommandInfo) bool {
+	switch cmd.Name {
+	case cmdDockerPHPExtInstall, cmdDockerPHPExtEnable, "docker-php-ext-configure":
+		return argsContainOpcache(cmd.Args)
+	case cmdPecl:
+		return cmd.Subcommand == subcommandInstall && argsContainOpcache(cmd.Args)
+	default:
+		return false
+	}
+}
+
+// installCommandInstallsOpcache reports whether a normalized package-manager
+// install references an OPcache package (e.g., php-opcache, php8.3-opcache).
+func installCommandInstallsOpcache(ic shell.InstallCommand) bool {
+	for _, pkg := range ic.Packages {
+		name := strings.ToLower(shell.StripPackageVersion(pkg.Normalized))
+		if strings.Contains(name, "opcache") {
+			return true
+		}
+	}
+	return false
+}
+
+// argsContainOpcache checks if any non-flag arg is "opcache" or starts with
+// "opcache-" (used by docker-php-ext-* and `pecl install`).
+func argsContainOpcache(args []string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		lower := strings.ToLower(arg)
+		if lower == "opcache" || strings.HasPrefix(lower, "opcache-") {
+			return true
+		}
+	}
+	return false
+}
+
+// observableFileHasOpcacheSignal reports whether an image file looks like an
+// OPcache ini configuration or contains a directive that enables OPcache.
+// Parses the content as an ini file (comments and whitespace are ignored by
+// the parser) and inspects keys/values semantically:
+//
+//   - any section with an opcache.* key (opcache.enable, opcache.memory_consumption, ...)
+//   - zend_extension value referencing opcache (opcache, opcache.so)
+func observableFileHasOpcacheSignal(f *facts.ObservableFile) bool {
+	if f == nil {
+		return false
+	}
+	lowerPath := strings.ToLower(f.Path)
+	if strings.Contains(lowerPath, "opcache") && strings.HasSuffix(lowerPath, ".ini") {
+		return true
+	}
+	content, ok := f.Content()
+	if !ok || content == "" {
+		return false
+	}
+	cfg, err := ini.LoadSources(ini.LoadOptions{
+		Loose:                      true,
+		Insensitive:                true,
+		IgnoreInlineComment:        true,
+		AllowBooleanKeys:           true,
+		AllowPythonMultilineValues: false,
+	}, []byte(content))
+	if err != nil {
+		return false
+	}
+	for _, section := range cfg.Sections() {
+		for _, key := range section.Keys() {
+			name := strings.ToLower(key.Name())
+			if strings.HasPrefix(name, "opcache.") {
+				return true
+			}
+			if name == "zend_extension" && strings.Contains(strings.ToLower(key.Value()), "opcache") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func init() {
+	rules.Register(NewEnableOpcacheInProductionRule())
+}

--- a/internal/rules/tally/php/enable_opcache_in_production.go
+++ b/internal/rules/tally/php/enable_opcache_in_production.go
@@ -19,6 +19,11 @@ import (
 // EnableOpcacheInProductionRuleCode is the full rule code.
 const EnableOpcacheInProductionRuleCode = rules.TallyRulePrefix + "php/enable-opcache-in-production"
 
+// sortPackagesRuleCode identifies the tally/sort-packages rule. Referenced
+// here (rather than imported from the parent tally package) to keep
+// internal/rules/tally/php free of an upward dependency on its parent.
+const sortPackagesRuleCode = rules.TallyRulePrefix + "sort-packages"
+
 // EnableOpcacheInProductionRule flags production PHP web runtime images that
 // do not enable OPcache.
 type EnableOpcacheInProductionRule struct{}
@@ -81,7 +86,13 @@ func (r *EnableOpcacheInProductionRule) Check(input rules.LintInput) []rules.Vio
 	)
 	if fix := buildOpcacheInstallFix(input.File, stage, stageFacts, info, meta.FixPriority); fix != nil {
 		v = v.WithSuggestedFix(fix)
-	} else if fix := buildOpcachePackageManagerFix(input.File, stageFacts, input.SourceMap(), meta.FixPriority); fix != nil {
+	} else if fix := buildOpcachePackageManagerFix(
+		input.File,
+		stageFacts,
+		input.SourceMap(),
+		meta.FixPriority,
+		input.IsRuleEnabled(sortPackagesRuleCode),
+	); fix != nil {
 		v = v.WithSuggestedFix(fix)
 	}
 	return []rules.Violation{v}
@@ -140,23 +151,32 @@ func stageBaseImageRaw(info *semantic.StageInfo) string {
 // install commands. Fires only when exactly one php*-fpm package is present
 // across the stage's runs, so the distro/version naming is unambiguous.
 //
-// Cross-rule interactions (fix priority 88):
-//   - tally/sort-packages (priority 9): runs first; sorts any pre-existing
-//     unsorted list before this fix appends. Appending opcache at the end
-//     can leave the list out of order (e.g. "php8.3-fpm php8.3-zlib" +
-//     "php8.3-opcache" -> opcache belongs between); sort-packages then
-//     catches it on the next --fix pass.
-//   - tally/no-multi-spaces (priority 10): the inserted text is " pkg" —
-//     exactly one leading space — so the combined RUN never contains a
-//     multi-space run as a result of this fix.
-//   - tally/prefer-package-cache-mounts (priority 90): operates on RUN
-//     flags (--mount=type=cache), not package args; the two fixes touch
-//     disjoint surfaces and apply in the same pass without conflict.
+// Fix priority: 88.
+//
+// Insertion anchor depends on whether tally/sort-packages is also enabled
+// in the current run:
+//
+//   - sort-packages enabled: anchor is the LAST package in the install
+//     command. sort-packages edits replace the first literal with the
+//     sorted block and delete the rest; our zero-width insertion at the
+//     final literal's EndCol lands at the trailing boundary of that
+//     deletion (adjacency, not overlap) and ends up appended to the
+//     sorted block, preserving sort order in one --fix pass for the
+//     common case (packages alphabetically before "opcache").
+//   - sort-packages NOT enabled: anchor is the php*-fpm token itself.
+//     The new opcache package is inserted directly after its sibling,
+//     keeping related PHP extensions visually grouped.
+//
+// Both branches produce a single " <pkg>" (one leading space) zero-width
+// insertion, so the fix never creates a multi-space run and does not
+// conflict with tally/no-multi-spaces. The fix also does not overlap
+// with tally/prefer-package-cache-mounts (which operates on RUN flags).
 func buildOpcachePackageManagerFix(
 	file string,
 	sf *facts.StageFacts,
 	sm *sourcemap.SourceMap,
 	priority int,
+	sortPackagesEnabled bool,
 ) *rules.SuggestedFix {
 	if sf == nil || sm == nil {
 		return nil
@@ -193,14 +213,18 @@ func buildOpcachePackageManagerFix(
 	if found != 1 || targetRun == nil || targetRun.Run == nil || !targetRun.UsesShell {
 		return nil
 	}
+	anchor := targetPkg
+	if sortPackagesEnabled && len(targetIC.Packages) > 0 {
+		anchor = targetIC.Packages[len(targetIC.Packages)-1]
+	}
 	locs := targetRun.Run.Location()
 	if len(locs) == 0 {
 		return nil
 	}
 	runStartLine := locs[0].Start.Line // 1-based
-	editLine := runStartLine + targetPkg.Line
-	editCol := targetPkg.EndCol
-	if targetPkg.Line == 0 {
+	editLine := runStartLine + anchor.Line
+	editCol := anchor.EndCol
+	if anchor.Line == 0 {
 		lineIdx := runStartLine - 1
 		if lineIdx < 0 || lineIdx >= sm.LineCount() {
 			return nil

--- a/internal/rules/tally/php/enable_opcache_in_production.go
+++ b/internal/rules/tally/php/enable_opcache_in_production.go
@@ -221,10 +221,27 @@ func buildOpcachePackageManagerFix(
 	if len(locs) == 0 {
 		return nil
 	}
-	runStartLine := locs[0].Start.Line // 1-based
+	// Source-line base for shell-parser-relative positions depends on
+	// whether the RUN uses a heredoc:
+	//   - heredoc RUN: body starts on the line AFTER the "RUN <<EOF"
+	//     opener. BuildKit exposes the first body line as Location()[1]
+	//     when available; fall back to opener+1.
+	//   - shell-form RUN: body starts on the opener line itself.
+	// For heredoc bodies cmdStartCol is always 0 (no "RUN " prefix).
+	var (
+		runStartLine = locs[0].Start.Line
+		isHeredoc    = len(targetRun.Run.Files) > 0
+	)
+	if isHeredoc {
+		if len(locs) > 1 {
+			runStartLine = locs[1].Start.Line
+		} else {
+			runStartLine = locs[0].Start.Line + 1
+		}
+	}
 	editLine := runStartLine + anchor.Line
 	editCol := anchor.EndCol
-	if anchor.Line == 0 {
+	if !isHeredoc && anchor.Line == 0 {
 		lineIdx := runStartLine - 1
 		if lineIdx < 0 || lineIdx >= sm.LineCount() {
 			return nil

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -520,6 +520,30 @@ func TestEnableOpcacheInProductionRule_SuggestedFix_SortPackagesEnabled(t *testi
 	}
 }
 
+// Heredoc RUN: the install command lives in the heredoc body, which
+// starts on the line AFTER "RUN <<EOF". Validates that the fix applies
+// to the correct Dockerfile line (shell-parser columns are 0-based
+// within the heredoc body and need the extra +1 line offset).
+func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerHeredoc(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM debian:12-slim\nRUN <<EOF\napt-get install -y php8.3-fpm\nEOF\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected SuggestedFix for a heredoc RUN installing php*-fpm")
+	}
+
+	want := "FROM debian:12-slim\nRUN <<EOF\napt-get install -y php8.3-fpm php8.3-opcache\nEOF\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	if got := string(fix.ApplyFix([]byte(content), v.SuggestedFix)); got != want {
+		t.Errorf("ApplyFix mismatch:\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
 // Multi-line RUN with backslash continuation: the php*-fpm package lives on
 // line 1 of the reconstructed script (not the RUN line). Validates that
 // DockerfileRunCommandStartCol is only added on line 0, not on continuation

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -480,6 +480,30 @@ func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerRHEL(t *testin
 	}
 }
 
+// Multi-line RUN with backslash continuation: the php*-fpm package lives on
+// line 1 of the reconstructed script (not the RUN line). Validates that
+// DockerfileRunCommandStartCol is only added on line 0, not on continuation
+// lines where the reconstructed source preserves the original indentation.
+func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerContinuation(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM debian:12-slim\nRUN apt-get install -y \\\n    php8.3-fpm\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected SuggestedFix for apt-get install across a continuation line")
+	}
+
+	want := "FROM debian:12-slim\nRUN apt-get install -y \\\n    php8.3-fpm php8.3-opcache\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	if got := string(fix.ApplyFix([]byte(content), v.SuggestedFix)); got != want {
+		t.Errorf("ApplyFix mismatch:\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
 func TestEnableOpcacheInProductionRule_NoFixWhenMultiplePHPFPMPackages(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -3,6 +3,7 @@ package php
 import (
 	"testing"
 
+	"github.com/wharflab/tally/internal/fix"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/testutil"
@@ -340,20 +341,20 @@ func TestEnableOpcacheInProductionRule_SuggestedFix_OfficialPHPFPM(t *testing.T)
 		t.Fatalf("expected 1 violation, got %d", len(violations))
 	}
 
-	fix := violations[0].SuggestedFix
-	if fix == nil {
+	sfix := violations[0].SuggestedFix
+	if sfix == nil {
 		t.Fatal("expected SuggestedFix for official php:*-fpm image")
 	}
-	if fix.Safety != rules.FixSuggestion {
-		t.Errorf("Safety = %v, want FixSuggestion", fix.Safety)
+	if sfix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", sfix.Safety)
 	}
-	if !fix.IsPreferred {
+	if !sfix.IsPreferred {
 		t.Error("expected IsPreferred = true")
 	}
-	if len(fix.Edits) != 1 {
-		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	if len(sfix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(sfix.Edits))
 	}
-	edit := fix.Edits[0]
+	edit := sfix.Edits[0]
 	if edit.NewText != "RUN docker-php-ext-install opcache\n" {
 		t.Errorf("NewText = %q, want RUN docker-php-ext-install opcache\\n", edit.NewText)
 	}
@@ -367,6 +368,11 @@ func TestEnableOpcacheInProductionRule_SuggestedFix_OfficialPHPFPM(t *testing.T)
 	}
 	if edit.Location.End != edit.Location.Start {
 		t.Errorf("expected zero-width insertion, got %v -> %v", edit.Location.Start, edit.Location.End)
+	}
+
+	want := "FROM php:8.4-fpm\nRUN docker-php-ext-install opcache\nWORKDIR /app\n"
+	if got := string(fix.ApplyFix([]byte(content), sfix)); got != want {
+		t.Errorf("ApplyFix mismatch:\nwant:\n%q\ngot:\n%q", want, got)
 	}
 }
 
@@ -408,18 +414,23 @@ func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerDebian(t *test
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d", len(violations))
 	}
-	fix := violations[0].SuggestedFix
-	if fix == nil {
+	v := violations[0]
+	if v.SuggestedFix == nil {
 		t.Fatal("expected SuggestedFix when a php*-fpm package is visible in an install command")
 	}
-	if fix.Safety != rules.FixSuggestion {
-		t.Errorf("Safety = %v, want FixSuggestion", fix.Safety)
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
 	}
-	if len(fix.Edits) != 1 {
-		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	if len(v.SuggestedFix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(v.SuggestedFix.Edits))
 	}
-	if fix.Edits[0].NewText != " php8.3-opcache" {
-		t.Errorf("NewText = %q, want %q", fix.Edits[0].NewText, " php8.3-opcache")
+	if v.SuggestedFix.Edits[0].NewText != " php8.3-opcache" {
+		t.Errorf("NewText = %q, want %q", v.SuggestedFix.Edits[0].NewText, " php8.3-opcache")
+	}
+
+	want := "FROM debian:12-slim\nRUN apt-get install -y php8.3-fpm php8.3-opcache\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	if got := string(fix.ApplyFix([]byte(content), v.SuggestedFix)); got != want {
+		t.Errorf("ApplyFix mismatch:\nwant:\n%q\ngot:\n%q", want, got)
 	}
 }
 
@@ -432,12 +443,17 @@ func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerAlpine(t *test
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d", len(violations))
 	}
-	fix := violations[0].SuggestedFix
-	if fix == nil {
+	v := violations[0]
+	if v.SuggestedFix == nil {
 		t.Fatal("expected SuggestedFix for apk add php83-fpm")
 	}
-	if fix.Edits[0].NewText != " php83-opcache" {
-		t.Errorf("NewText = %q, want %q", fix.Edits[0].NewText, " php83-opcache")
+	if v.SuggestedFix.Edits[0].NewText != " php83-opcache" {
+		t.Errorf("NewText = %q, want %q", v.SuggestedFix.Edits[0].NewText, " php83-opcache")
+	}
+
+	want := "FROM alpine:3.20\nRUN apk add --no-cache php83 php83-fpm php83-opcache\nCMD [\"php-fpm83\", \"-F\"]\n"
+	if got := string(fix.ApplyFix([]byte(content), v.SuggestedFix)); got != want {
+		t.Errorf("ApplyFix mismatch:\nwant:\n%q\ngot:\n%q", want, got)
 	}
 }
 
@@ -450,12 +466,17 @@ func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerRHEL(t *testin
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d", len(violations))
 	}
-	fix := violations[0].SuggestedFix
-	if fix == nil {
+	v := violations[0]
+	if v.SuggestedFix == nil {
 		t.Fatal("expected SuggestedFix for dnf install php-fpm")
 	}
-	if fix.Edits[0].NewText != " php-opcache" {
-		t.Errorf("NewText = %q, want %q", fix.Edits[0].NewText, " php-opcache")
+	if v.SuggestedFix.Edits[0].NewText != " php-opcache" {
+		t.Errorf("NewText = %q, want %q", v.SuggestedFix.Edits[0].NewText, " php-opcache")
+	}
+
+	want := "FROM redhat/ubi9\nRUN dnf install -y php-fpm php-opcache\nCMD [\"php-fpm\", \"-F\"]\n"
+	if got := string(fix.ApplyFix([]byte(content), v.SuggestedFix)); got != want {
+		t.Errorf("ApplyFix mismatch:\nwant:\n%q\ngot:\n%q", want, got)
 	}
 }
 

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -1,0 +1,501 @@
+package php
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestEnableOpcacheInProductionRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewEnableOpcacheInProductionRule().Metadata()
+	if meta.Code != EnableOpcacheInProductionRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, EnableOpcacheInProductionRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "performance" {
+		t.Errorf("Category = %q, want %q", meta.Category, "performance")
+	}
+}
+
+func TestEnableOpcacheInProductionRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewEnableOpcacheInProductionRule(), []testutil.RuleTestCase{
+		// --- Violations: final stage is php:*fpm*/*apache* with no OPcache signal ---
+		{
+			Name: "php-fpm final stage without opcache triggers",
+			Content: `FROM php:8.4-fpm
+WORKDIR /app
+COPY . .
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "php-apache final stage without opcache triggers",
+			Content: `FROM php:8.4-apache
+WORKDIR /app
+COPY . .
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "fpm variant tag without opcache triggers",
+			Content: `FROM php:8.3-fpm-alpine
+WORKDIR /app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "multi-stage only final runtime violates",
+			Content: `FROM composer:2 AS deps
+WORKDIR /app
+
+FROM php:8.4-fpm AS app
+COPY --from=deps /app /app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "known derivative image serversideup without opcache triggers",
+			Content: `FROM serversideup/php:8.3-fpm-nginx
+WORKDIR /app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "generic base with exec-form CMD php-fpm triggers",
+			Content: `FROM debian:12-slim
+WORKDIR /app
+CMD ["php-fpm8.3", "-F"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "generic base with ENTRYPOINT apache2-foreground triggers",
+			Content: `FROM debian:12-slim
+WORKDIR /var/www/html
+ENTRYPOINT ["apache2-foreground"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "shell-form CMD php-fpm on generic base triggers",
+			Content: `FROM debian:12-slim
+WORKDIR /app
+CMD php-fpm -F
+`,
+			WantViolations: 1,
+		},
+		// --- Compliant: OPcache signal present ---
+		{
+			Name: "docker-php-ext-install opcache suppresses",
+			Content: `FROM php:8.4-fpm
+RUN docker-php-ext-install opcache
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "docker-php-ext-enable opcache suppresses",
+			Content: `FROM php:8.4-apache
+RUN docker-php-ext-enable opcache
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "docker-php-ext-install with multiple extensions including opcache",
+			Content: `FROM php:8.4-fpm
+RUN docker-php-ext-install gd opcache intl
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "apt-get install php-opcache suppresses",
+			Content: `FROM php:8.4-fpm
+RUN apt-get install -y php-opcache
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "apt-get versioned php8.3-opcache suppresses",
+			Content: `FROM php:8.4-fpm
+RUN apt-get install -y php8.3-opcache
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "apk add php-opcache suppresses",
+			Content: `FROM php:8.4-fpm-alpine
+RUN apk add --no-cache php83-opcache
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "PHP_OPCACHE env signals opcache config",
+			Content: `FROM php:8.4-fpm
+ENV PHP_OPCACHE_ENABLE=1
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "COPY opcache.ini suppresses",
+			Content: `FROM php:8.4-fpm
+COPY <<EOF /usr/local/etc/php/conf.d/opcache.ini
+opcache.enable=1
+opcache.memory_consumption=256
+EOF
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "COPY ini with opcache.enable directive suppresses",
+			Content: `FROM php:8.4-fpm
+COPY <<EOF /usr/local/etc/php/conf.d/perf.ini
+opcache.enable=1
+EOF
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "commented-out opcache directive does not suppress",
+			Content: `FROM php:8.4-fpm
+COPY <<EOF /usr/local/etc/php/conf.d/perf.ini
+; opcache.enable=1
+; zend_extension=opcache
+memory_limit=256M
+EOF
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ini mentioning opcache only inside a comment does not suppress",
+			Content: `FROM php:8.4-fpm
+COPY <<EOF /usr/local/etc/php/conf.d/perf.ini
+; TODO: review opcache.enable later
+memory_limit=256M
+EOF
+`,
+			WantViolations: 1,
+		},
+		// --- Skipped: not a PHP web runtime image ---
+		{
+			Name: "php cli image is skipped",
+			Content: `FROM php:8.4-cli
+RUN composer install --no-dev
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-php base image is skipped",
+			Content: `FROM alpine:3.20
+RUN echo done
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "untagged php image is skipped",
+			Content: `FROM php
+RUN echo done
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev-named php-fpm stage is skipped",
+			Content: `FROM php:8.4-fpm AS dev
+RUN echo done
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "only intermediate stage uses php-fpm, final is different",
+			Content: `FROM php:8.4-fpm AS intermediate
+RUN echo done
+
+FROM alpine:3.20 AS app
+COPY --from=intermediate /usr/local /usr/local
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-final php-fpm builder stage is not checked, final cli ignored",
+			Content: `FROM php:8.4-fpm AS builder
+RUN echo done
+
+FROM php:8.4-cli AS app
+RUN echo done
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestCommandReferencesOpcacheExt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  shell.CommandInfo
+		want bool
+	}{
+		{
+			name: "docker-php-ext-install opcache",
+			cmd:  shell.CommandInfo{Name: "docker-php-ext-install", Args: []string{"opcache"}},
+			want: true,
+		},
+		{
+			name: "docker-php-ext-enable opcache",
+			cmd:  shell.CommandInfo{Name: "docker-php-ext-enable", Args: []string{"opcache"}},
+			want: true,
+		},
+		{
+			name: "docker-php-ext-configure opcache",
+			cmd:  shell.CommandInfo{Name: "docker-php-ext-configure", Args: []string{"opcache"}},
+			want: true,
+		},
+		{
+			name: "pecl install opcache",
+			cmd:  shell.CommandInfo{Name: "pecl", Subcommand: "install", Args: []string{"install", "opcache"}},
+			want: true,
+		},
+		{
+			name: "pecl uninstall opcache ignored",
+			cmd:  shell.CommandInfo{Name: "pecl", Subcommand: "uninstall", Args: []string{"uninstall", "opcache"}},
+			want: false,
+		},
+		{
+			name: "apt-get install not matched here (handled via InstallCommands)",
+			cmd:  shell.CommandInfo{Name: "apt-get", Subcommand: "install", Args: []string{"install", "-y", "php-opcache"}},
+			want: false,
+		},
+		{
+			name: "docker-php-ext-install gd only",
+			cmd:  shell.CommandInfo{Name: "docker-php-ext-install", Args: []string{"gd"}},
+			want: false,
+		},
+		{
+			name: "unrelated command",
+			cmd:  shell.CommandInfo{Name: "echo", Args: []string{"hello"}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := commandReferencesOpcacheExt(tt.cmd); got != tt.want {
+				t.Errorf("commandReferencesOpcacheExt(%v) = %v, want %v", tt.cmd.Name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallCommandInstallsOpcache(t *testing.T) {
+	t.Parallel()
+
+	makeIC := func(names ...string) shell.InstallCommand {
+		pkgs := make([]shell.PackageArg, 0, len(names))
+		for _, n := range names {
+			pkgs = append(pkgs, shell.PackageArg{Normalized: n})
+		}
+		return shell.InstallCommand{Packages: pkgs}
+	}
+
+	tests := []struct {
+		name string
+		ic   shell.InstallCommand
+		want bool
+	}{
+		{name: "php-opcache", ic: makeIC("php-opcache"), want: true},
+		{name: "php8.3-opcache", ic: makeIC("php8.3-opcache"), want: true},
+		{name: "php-opcache with version spec", ic: makeIC("php-opcache=8.3+1ubuntu1"), want: true},
+		{name: "php-opcache with arch", ic: makeIC("php-opcache:amd64"), want: true},
+		{name: "alpine pecl variant", ic: makeIC("php83-opcache"), want: true},
+		{name: "mixed packages including opcache", ic: makeIC("php-gd", "php-opcache", "php-intl"), want: true},
+		{name: "no opcache package", ic: makeIC("php-gd", "php-intl"), want: false},
+		{name: "empty", ic: shell.InstallCommand{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := installCommandInstallsOpcache(tt.ic); got != tt.want {
+				t.Errorf("installCommandInstallsOpcache(%v) = %v, want %v", tt.ic.Packages, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnableOpcacheInProductionRule_SuggestedFix_OfficialPHPFPM(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-fpm\nWORKDIR /app\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix for official php:*-fpm image")
+	}
+	if fix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", fix.Safety)
+	}
+	if !fix.IsPreferred {
+		t.Error("expected IsPreferred = true")
+	}
+	if len(fix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	}
+	edit := fix.Edits[0]
+	if edit.NewText != "RUN docker-php-ext-install opcache\n" {
+		t.Errorf("NewText = %q, want RUN docker-php-ext-install opcache\\n", edit.NewText)
+	}
+	// Inserted on line 2 (right after the FROM on line 1).
+	if edit.Location.Start.Line != 2 || edit.Location.Start.Column != 0 {
+		t.Errorf(
+			"edit start = %d:%d, want 2:0",
+			edit.Location.Start.Line,
+			edit.Location.Start.Column,
+		)
+	}
+	if edit.Location.End != edit.Location.Start {
+		t.Errorf("expected zero-width insertion, got %v -> %v", edit.Location.Start, edit.Location.End)
+	}
+}
+
+func TestEnableOpcacheInProductionRule_NoFixForDerivativeImage(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM serversideup/php:8.3-fpm-nginx\nWORKDIR /app\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Error("expected no SuggestedFix for derivative image (package name is distro-specific)")
+	}
+}
+
+func TestEnableOpcacheInProductionRule_NoFixForGenericBaseWithPHPFPMCmd(t *testing.T) {
+	t.Parallel()
+
+	// CMD alone, no apt/apk install in view: no distro-specific fix possible.
+	content := "FROM debian:12-slim\nWORKDIR /app\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Error("expected no SuggestedFix when no install command is visible")
+	}
+}
+
+func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerDebian(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM debian:12-slim\nRUN apt-get install -y php8.3-fpm\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix when a php*-fpm package is visible in an install command")
+	}
+	if fix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", fix.Safety)
+	}
+	if len(fix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	}
+	if fix.Edits[0].NewText != " php8.3-opcache" {
+		t.Errorf("NewText = %q, want %q", fix.Edits[0].NewText, " php8.3-opcache")
+	}
+}
+
+func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerAlpine(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM alpine:3.20\nRUN apk add --no-cache php83 php83-fpm\nCMD [\"php-fpm83\", \"-F\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix for apk add php83-fpm")
+	}
+	if fix.Edits[0].NewText != " php83-opcache" {
+		t.Errorf("NewText = %q, want %q", fix.Edits[0].NewText, " php83-opcache")
+	}
+}
+
+func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerRHEL(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM redhat/ubi9\nRUN dnf install -y php-fpm\nCMD [\"php-fpm\", \"-F\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix for dnf install php-fpm")
+	}
+	if fix.Edits[0].NewText != " php-opcache" {
+		t.Errorf("NewText = %q, want %q", fix.Edits[0].NewText, " php-opcache")
+	}
+}
+
+func TestEnableOpcacheInProductionRule_NoFixWhenMultiplePHPFPMPackages(t *testing.T) {
+	t.Parallel()
+
+	// Two different php*-fpm packages: ambiguous, no fix.
+	content := "FROM debian:12-slim\nRUN apt-get install -y php8.3-fpm php8.2-fpm\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Error("expected no SuggestedFix when multiple php*-fpm packages are present")
+	}
+}
+
+func TestDerivePHPOpcachePackage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"php8.3-fpm", "php8.3-opcache"},
+		{"php7.4-fpm", "php7.4-opcache"},
+		{"php83-fpm", "php83-opcache"},
+		{"php-fpm", "php-opcache"},
+		{"php83-php-fpm", "php83-php-opcache"},
+		{"PHP8.3-FPM", "php8.3-opcache"},              // case-insensitive
+		{"php8.3-fpm=8.3+1ubuntu1", "php8.3-opcache"}, // version stripped
+		{"php8.3-fpm:amd64", "php8.3-opcache"},        // arch stripped
+		{"php8.3-cli", ""},                            // CLI is not fpm
+		{"nginx", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := derivePHPOpcachePackage(tt.in, ""); got != tt.want {
+			t.Errorf("derivePHPOpcachePackage(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -480,6 +480,37 @@ func TestEnableOpcacheInProductionRule_SuggestedFix_PackageManagerRHEL(t *testin
 	}
 }
 
+// When tally/sort-packages is enabled, the fix anchors at the LAST package
+// in the install command (not the php*-fpm token itself) so the inserted
+// opcache lands at the end of the sorted block. This keeps the composition
+// with sort-packages clean: both fixes apply in a single --fix pass and
+// produce a fully sorted list with opcache at the correct position.
+func TestEnableOpcacheInProductionRule_SuggestedFix_SortPackagesEnabled(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM debian:12-slim\nRUN apt-get install -y php8.3-fpm php8.3-cli\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	input.EnabledRules = []string{
+		EnableOpcacheInProductionRuleCode,
+		sortPackagesRuleCode,
+	}
+	violations := NewEnableOpcacheInProductionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+
+	// Anchor is php8.3-cli (last package), so opcache is inserted AFTER it,
+	// not after php8.3-fpm.
+	want := "FROM debian:12-slim\nRUN apt-get install -y php8.3-fpm php8.3-cli php8.3-opcache\nCMD [\"php-fpm8.3\", \"-F\"]\n"
+	if got := string(fix.ApplyFix([]byte(content), v.SuggestedFix)); got != want {
+		t.Errorf("ApplyFix mismatch:\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
 // Multi-line RUN with backslash continuation: the php*-fpm package lives on
 // line 1 of the reconstructed script (not the RUN line). Validates that
 // DockerfileRunCommandStartCol is only added on line 0, not on continuation

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -307,12 +307,12 @@ func TestCommandReferencesOpcacheExt(t *testing.T) {
 func TestInstallCommandInstallsOpcache(t *testing.T) {
 	t.Parallel()
 
-	makeIC := func(names ...string) shell.InstallCommand {
+	makeIC := func(manager string, names ...string) shell.InstallCommand {
 		pkgs := make([]shell.PackageArg, 0, len(names))
 		for _, n := range names {
 			pkgs = append(pkgs, shell.PackageArg{Normalized: n})
 		}
-		return shell.InstallCommand{Packages: pkgs}
+		return shell.InstallCommand{Manager: manager, Packages: pkgs}
 	}
 
 	tests := []struct {
@@ -320,14 +320,19 @@ func TestInstallCommandInstallsOpcache(t *testing.T) {
 		ic   shell.InstallCommand
 		want bool
 	}{
-		{name: "php-opcache", ic: makeIC("php-opcache"), want: true},
-		{name: "php8.3-opcache", ic: makeIC("php8.3-opcache"), want: true},
-		{name: "php-opcache with version spec", ic: makeIC("php-opcache=8.3+1ubuntu1"), want: true},
-		{name: "php-opcache with arch", ic: makeIC("php-opcache:amd64"), want: true},
-		{name: "alpine pecl variant", ic: makeIC("php83-opcache"), want: true},
-		{name: "mixed packages including opcache", ic: makeIC("php-gd", "php-opcache", "php-intl"), want: true},
-		{name: "no opcache package", ic: makeIC("php-gd", "php-intl"), want: false},
+		{name: "apt php-opcache", ic: makeIC("apt-get", "php-opcache"), want: true},
+		{name: "apt php8.3-opcache", ic: makeIC("apt-get", "php8.3-opcache"), want: true},
+		{name: "apt php-opcache with version spec", ic: makeIC("apt-get", "php-opcache=8.3+1ubuntu1"), want: true},
+		{name: "apt php-opcache with arch", ic: makeIC("apt-get", "php-opcache:amd64"), want: true},
+		{name: "apk php83-opcache", ic: makeIC("apk", "php83-opcache"), want: true},
+		{name: "dnf mixed packages", ic: makeIC("dnf", "php-gd", "php-opcache", "php-intl"), want: true},
+		{name: "apt no opcache", ic: makeIC("apt-get", "php-gd", "php-intl"), want: false},
 		{name: "empty", ic: shell.InstallCommand{}, want: false},
+		// Non-OS package managers must not count as an OPcache signal even
+		// if the package name contains "opcache".
+		{name: "npm fake opcache package", ic: makeIC("npm", "opcache"), want: false},
+		{name: "pip fake opcache package", ic: makeIC("pip", "php-opcache"), want: false},
+		{name: "composer fake opcache package", ic: makeIC("composer", "php-opcache"), want: false},
 	}
 
 	for _, tt := range tests {
@@ -587,24 +592,33 @@ func TestDerivePHPOpcachePackage(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		in   string
-		want string
+		in      string
+		manager string
+		want    string
 	}{
-		{"php8.3-fpm", "php8.3-opcache"},
-		{"php7.4-fpm", "php7.4-opcache"},
-		{"php83-fpm", "php83-opcache"},
-		{"php-fpm", "php-opcache"},
-		{"php83-php-fpm", "php83-php-opcache"},
-		{"PHP8.3-FPM", "php8.3-opcache"},              // case-insensitive
-		{"php8.3-fpm=8.3+1ubuntu1", "php8.3-opcache"}, // version stripped
-		{"php8.3-fpm:amd64", "php8.3-opcache"},        // arch stripped
-		{"php8.3-cli", ""},                            // CLI is not fpm
-		{"nginx", ""},
-		{"", ""},
+		{in: "php8.3-fpm", manager: "apt-get", want: "php8.3-opcache"},
+		{in: "php7.4-fpm", manager: "apt", want: "php7.4-opcache"},
+		{in: "php83-fpm", manager: "apk", want: "php83-opcache"},
+		{in: "php-fpm", manager: "dnf", want: "php-opcache"},
+		{in: "php-fpm", manager: "yum", want: "php-opcache"},
+		{in: "php-fpm", manager: "microdnf", want: "php-opcache"},
+		{in: "php83-php-fpm", manager: "dnf", want: "php83-php-opcache"},
+		{in: "PHP8.3-FPM", manager: "apt-get", want: "php8.3-opcache"}, // case-insensitive
+		{in: "php8.3-fpm=8.3+1ubuntu1", manager: "apt-get", want: "php8.3-opcache"},
+		{in: "php8.3-fpm:amd64", manager: "apt-get", want: "php8.3-opcache"},
+		{in: "php8.3-cli", manager: "apt-get", want: ""}, // CLI is not fpm
+		{in: "nginx", manager: "apt-get", want: ""},
+		{in: "", manager: "apt-get", want: ""},
+		// Non-OS package managers must not receive an OS opcache derivation,
+		// even if the package happens to look like php-fpm.
+		{in: "php8.3-fpm", manager: "npm", want: ""},
+		{in: "php-fpm", manager: "pip", want: ""},
+		{in: "php-fpm", manager: "composer", want: ""},
+		{in: "php-fpm", manager: "", want: ""},
 	}
 	for _, tt := range tests {
-		if got := derivePHPOpcachePackage(tt.in, ""); got != tt.want {
-			t.Errorf("derivePHPOpcachePackage(%q) = %q, want %q", tt.in, got, tt.want)
+		if got := derivePHPOpcachePackage(tt.in, tt.manager); got != tt.want {
+			t.Errorf("derivePHPOpcachePackage(%q, %q) = %q, want %q", tt.in, tt.manager, got, tt.want)
 		}
 	}
 }

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -93,6 +93,15 @@ CMD php-fpm -F
 `,
 			WantViolations: 1,
 		},
+		{
+			Name: "wrapper ENTRYPOINT + CMD php-fpm still triggers",
+			Content: `FROM debian:12-slim
+RUN apt-get install -y php8.3-fpm
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["php-fpm", "-F"]
+`,
+			WantViolations: 1,
+		},
 		// --- Compliant: OPcache signal present ---
 		{
 			Name: "docker-php-ext-install opcache suppresses",

--- a/internal/rules/tally/php/helpers.go
+++ b/internal/rules/tally/php/helpers.go
@@ -16,6 +16,15 @@ import (
 const (
 	subcommandInstall = "install"
 	subcommandAdd     = "add" //nolint:customlint // apk subcommand, not Dockerfile ADD instruction
+
+	cmdDockerPHPExtInstall = "docker-php-ext-install"
+	cmdDockerPHPExtEnable  = "docker-php-ext-enable"
+	cmdPecl                = "pecl"
+	cmdApk                 = "apk"
+	cmdApt                 = "apt"
+	cmdAptGet              = "apt-get"
+	cmdDnf                 = "dnf"
+	cmdYum                 = "yum"
 )
 
 var nonProductionStageTokens = []string{"dev", "development", "test", "testing", "ci", "debug"}


### PR DESCRIPTION
## Summary

Adds a new rule `tally/php/enable-opcache-in-production` under the PHP namespace. Flags long-running PHP web runtime final stages that don't install or enable OPcache, with two heuristic autofixes.

Implements rule #7 from [design-docs/35-php-container-rules.md §4.2](../blob/main/design-docs/35-php-container-rules.md#423-tallyphpenable-opcache-in-production).

## What triggers the rule

The final stage is treated as a PHP web runtime when any of these hold:

- base image is an official `php:*` tag containing `fpm` or `apache`
- base image is a known derivative (`serversideup/php`, `dunglas/frankenphp`, `bitnami/php-fpm`, `trafex/php-nginx`, `webdevops/php-nginx`, `webdevops/php-apache`)
- effective `ENTRYPOINT`/`CMD` is a PHP web wrapper (`php-fpm*`, `apache2-foreground`, `httpd-foreground`, `frankenphp`, `rr`)

Skips CLI-only images, dev/test/ci/debug stages, and non-final stages.

## Compliance signals (any one suppresses the violation)

- `docker-php-ext-install`/`-enable`/`-configure opcache`
- `pecl install opcache`
- apt/apk/dnf/yum install of `php*-opcache` — detected via the canonical `shell.InstallCommand` + `shell.StripPackageVersion` helpers, so `php-opcache=8.3+1ubuntu1` and `php-opcache:amd64` also match
- ini file named `*opcache*.ini`, or content (parsed with `gopkg.in/ini.v1`, so commented-out directives don't count) containing `opcache.*` keys or `zend_extension=opcache`
- `PHP_OPCACHE_*` stage env

## Autofix

Both paths emit `FixSuggestion`, `IsPreferred`, priority 88.

### 1. Official `php:*fpm*`/`*apache*` base
Insert `RUN docker-php-ext-install opcache` immediately after the final `FROM`:

```diff
 FROM php:8.4-fpm
+RUN docker-php-ext-install opcache
 WORKDIR /app
 COPY . .
```

### 2. Generic base installing PHP via a package manager
Append the matching `php*-opcache` to the existing install command, derived from the PHP package the user already chose:

| Package in `RUN` | Derived OPcache package |
|---|---|
| `php8.3-fpm` (Debian/Ubuntu) | `php8.3-opcache` |
| `php-fpm` (unversioned) | `php-opcache` |
| `php83-fpm` (Alpine) | `php83-opcache` |
| `php83-php-fpm` (Remi SCL) | `php83-php-opcache` |

```diff
 FROM debian:12-slim
-RUN apt-get install -y php8.3-fpm
+RUN apt-get install -y php8.3-fpm php8.3-opcache
 CMD ["php-fpm8.3", "-F"]
```

### No fix offered
- non-official derivatives (distro-specific remediation)
- multiple different `php*-fpm` packages (ambiguous target version)
- `CMD`/`ENTRYPOINT`-only hit with no install command in view

## Tests

- 28 unit `Check` subtests covering all gate paths and compliance signals, including ini-parser correctness (commented-out `opcache.enable=1` does not suppress)
- 7 fix-specific unit tests (official-PHP, Debian, Alpine, RHEL, derivative image no-fix, ambiguous no-fix, CMD-only no-fix)
- 1 table-driven test for the `derivePHPOpcachePackage` helper
- 1 integration lint test with snapshot
- 2 integration fix tests with snapshots (official-image path + package-manager path)

File-level coverage: **88.9%**.

## Follow-ups

- #543: refactor `no-xdebug-in-final-image` and `composer-no-dev-in-production` to use the canonical `shell.InstallCommand` helpers (they currently reimplement apt/apk/dnf/yum matching ad-hoc).

## Checklist

- [x] Rule implemented and self-registered via `init()`
- [x] Auto-fix implemented (sync, narrow zero-width insertions)
- [x] Consumes canonical `shell.InstallCommand`/`StripPackageVersion` — no ad-hoc package-manager matching
- [x] Ini content parsed semantically (not string-matched) — comments cannot cause false negatives
- [x] Unit tests cover rule behavior, fix behavior, edge cases (heredoc ini, multi-stage, dev-named stages, commented-out ini directives)
- [x] Integration lint + fix coverage with snapshots
- [x] Docs page added under `_docs/rules/tally/php/` with "What is OPcache?" educational section and the PHP manual reference
- [x] Docs navigation (`_docs/docs.json`) updated
- [x] `design-docs/PROPOSED-RULES-TRACKER.md` updated
- [x] `go test ./...`, `make lint`, `make cpd` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new PHP rule to detect missing OPcache in production PHP containers and offer automated fixes for common cases.
* **Documentation**
  * Added rule documentation entry and updated the rules tracker to mark the rule as implemented.
* **Tests / Integration**
  * Added integration snapshots and new unit/integration tests validating detection and fix behavior.
* **Chores**
  * Updated an underlying dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->