### PR TITLE
feat(prefer-copy-heredoc): detect grouped echo|tee and split multi-target RUNs

### DIFF
--- a/_docs/rules/tally/prefer-copy-heredoc.mdx
+++ b/_docs/rules/tally/prefer-copy-heredoc.mdx
@@ -118,12 +118,18 @@ exec nginx -g "daemon off;"
 EOF
 
 RUN apt-get update
+
 COPY <<EOF /etc/myapp.env
 APP_ENV=production
 LOG_FORMAT=json
 EOF
+
 RUN apt-get clean
 ```
+
+Emitted `COPY <<EOF` blocks are surrounded by blank lines to keep the embedded
+file content readable; the fix doesn't inject duplicate blanks when the source
+already has one adjacent to the replacement.
 
 ### Multi-target with brace-grouped pipes
 
@@ -164,15 +170,18 @@ COPY <<EOF /usr/local/etc/php-fpm.d/www.conf
 [global]
 daemonize = no
 EOF
+
 COPY <<EOF /usr/local/php/php/auto_prepends/default_prepend.php
 <?php
 if (function_exists("uopz_allow_exit")) { uopz_allow_exit(true); }
 ?>
 EOF
+
 COPY <<EOF /etc/ssmtp/ssmtp.conf
 FromLineOverride=YES
 UseTLS=NO
 EOF
+
 COPY <<EOF /usr/local/etc/php/conf.d/php.ini
 [PHP]
 log_errors = On

--- a/_docs/rules/tally/prefer-copy-heredoc.mdx
+++ b/_docs/rules/tally/prefer-copy-heredoc.mdx
@@ -21,9 +21,45 @@ It relies on Dockerfile [here-documents](https://docs.docker.com/reference/docke
 
 ## Why COPY heredoc?
 
-- **Performance**: `COPY` doesn't spawn a shell container, making it faster
-- **Atomicity**: `COPY --chmod` sets permissions in a single layer
-- **Readability**: Heredocs are cleaner than escaped echo statements
+Three reasons, in order of importance:
+
+1. **Hermeticity and intent.** A `RUN` that writes a file is an opaque shell
+   invocation: the frontend cannot tell, without parsing your shell, whether
+   the instruction installs a package, mutates system state, or just drops a
+   config file. `COPY <<EOF` declares the same operation as a pure, fully
+   specified input-to-output mapping. See Bazel's
+   [hermeticity](https://bazel.build/basics/hermeticity) guide for the
+   underlying principle — a build step whose output is a function of its
+   declared inputs is easier to cache, reason about, and reproduce.
+
+2. **Observable content for other rules.** tally tracks files written via
+   `COPY <<EOF` (and `ADD <<EOF`) as
+   [observable files](https://pkg.go.dev/github.com/wharflab/tally/internal/facts#ObservableFile):
+   their content is visible at lint time. This lets other rules reason about
+   what the image actually contains. For example:
+
+   - [`tally/secrets-in-code`](/rules/tally/secrets-in-code) scans heredoc
+     bodies for API keys and tokens.
+   - [`tally/user-created-but-never-used`](/rules/tally/user-created-but-never-used)
+     inspects `/etc/passwd`-style content to learn about created users.
+   - [`tally/php/no-xdebug-in-final-image`](/rules/tally/php/no-xdebug-in-final-image)
+     reads `php.ini`-style config to detect Xdebug activation.
+
+   Content hidden inside a `RUN echo ... > /path` is **not** observable —
+   tally can only see the shell source, not the final file — so downstream
+   rules give up, and the rule set catches fewer real issues in your image.
+
+3. **Predictable cache keys.** `COPY <<EOF` participates in BuildKit's content
+   cache: the layer hash is derived from the literal heredoc body, so the
+   layer hits cache whenever the content is unchanged. A `RUN` layer hashes
+   over the command string, so any innocuous edit (trailing whitespace,
+   reordered `&&` clauses, comments) busts the cache even when the file it
+   produces is identical. Splitting "create this file" into its own `COPY`
+   keeps it out of the rebuild path of unrelated shell changes.
+
+Secondary benefits: `COPY --chmod` sets permissions in a single layer (no
+follow-up `chmod`), and heredoc bodies are easier to read than escaped
+`echo` statements with manual `\n` separators.
 
 ## Detected Patterns
 
@@ -32,8 +68,10 @@ It relies on Dockerfile [here-documents](https://docs.docker.com/reference/docke
 3. **File creation with chmod**: `echo "x" > /file && chmod 0755 /file`
 4. **BuildKit heredoc piped to cat**: `RUN <<EOF cat > /path/to/file`
 5. **BuildKit heredoc piped to tee**: `RUN <<EOF tee /path/to/file`
-6. **Consecutive RUN instructions** writing to the same file
-7. **Mixed commands** with file creation in the middle (extracts just the file creation)
+6. **Brace-grouped producers piped to tee**: `{ echo a; printf 'b\n'; } | tee /path` (mixes of `echo` / `printf` / `cat <<EOF` are supported)
+7. **Consecutive RUN instructions** writing to the same file
+8. **Mixed commands** with file creation in the middle (extracts just the file creation)
+9. **Multiple distinct targets in one RUN**: a single `&&` chain that writes to several files is split into one `COPY <<EOF` per target. Any `mkdir -p /parent` whose target is a prefix of a COPY destination is dropped, since `COPY` auto-creates parent directories.
 
 ## Examples
 
@@ -85,6 +123,60 @@ APP_ENV=production
 LOG_FORMAT=json
 EOF
 RUN apt-get clean
+```
+
+### Multi-target with brace-grouped pipes
+
+A single `RUN` that builds several config files via `{ echo ...; echo ...; } | tee /path`
+chains — a common pattern in official images such as `php:fpm` — expands into one
+`COPY <<EOF` per destination. `mkdir -p` is absorbed when a later `COPY` writes under
+the same directory tree.
+
+#### Before (violation)
+
+```dockerfile
+RUN set -ex \
+    && { \
+        echo '[global]'; \
+        echo 'daemonize = no'; \
+    } | tee /usr/local/etc/php-fpm.d/www.conf \
+    && mkdir -p /usr/local/php/php/auto_prepends \
+    && { \
+        echo '<?php'; \
+        echo 'if (function_exists("uopz_allow_exit")) { uopz_allow_exit(true); }'; \
+        echo '?>'; \
+    } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
+    && { \
+        echo 'FromLineOverride=YES'; \
+        echo 'UseTLS=NO'; \
+    } | tee /etc/ssmtp/ssmtp.conf \
+    && { \
+        echo '[PHP]'; \
+        echo 'log_errors = On'; \
+    } | tee /usr/local/etc/php/conf.d/php.ini
+```
+
+#### After (fixed with `--fix --fix-unsafe`)
+
+```dockerfile
+RUN set -ex
+COPY <<EOF /usr/local/etc/php-fpm.d/www.conf
+[global]
+daemonize = no
+EOF
+COPY <<EOF /usr/local/php/php/auto_prepends/default_prepend.php
+<?php
+if (function_exists("uopz_allow_exit")) { uopz_allow_exit(true); }
+?>
+EOF
+COPY <<EOF /etc/ssmtp/ssmtp.conf
+FromLineOverride=YES
+UseTLS=NO
+EOF
+COPY <<EOF /usr/local/etc/php/conf.d/php.ini
+[PHP]
+log_errors = On
+EOF
 ```
 
 ## Limitations
@@ -141,3 +233,4 @@ it.
 
 - [Dockerfile here-documents](https://docs.docker.com/reference/dockerfile/#here-documents)
 - [Introduction to heredocs in Dockerfiles](https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/)
+- [Bazel: hermeticity](https://bazel.build/basics/hermeticity) — the build-system principle behind motivation #1

--- a/_docs/rules/tally/prefer-copy-heredoc.mdx
+++ b/_docs/rules/tally/prefer-copy-heredoc.mdx
@@ -71,7 +71,8 @@ follow-up `chmod`), and heredoc bodies are easier to read than escaped
 6. **Brace-grouped producers piped to tee**: `{ echo a; printf 'b\n'; } | tee /path` (mixes of `echo` / `printf` / `cat <<EOF` are supported)
 7. **Consecutive RUN instructions** writing to the same file
 8. **Mixed commands** with file creation in the middle (extracts just the file creation)
-9. **Multiple distinct targets in one RUN**: a single `&&` chain that writes to several files is split into one `COPY <<EOF` per target. Any `mkdir -p /parent` whose target is a prefix of a COPY destination is dropped, since `COPY` auto-creates parent directories.
+9. **Multiple distinct targets in one RUN**: a single `&&` chain that writes to several files is split into one `COPY <<EOF` per target. Any
+   `mkdir -p /parent` whose target is a prefix of a COPY destination is dropped, since `COPY` auto-creates parent directories.
 
 ## Examples
 

--- a/_docs/rules/tally/prefer-copy-heredoc.mdx
+++ b/_docs/rules/tally/prefer-copy-heredoc.mdx
@@ -130,7 +130,8 @@ RUN apt-get clean
 A single `RUN` that builds several config files via `{ echo ...; echo ...; } | tee /path`
 chains — a common pattern in official images such as `php:fpm` — expands into one
 `COPY <<EOF` per destination. `mkdir -p` is absorbed when a later `COPY` writes under
-the same directory tree.
+the same directory tree, and a leading `set -ex` is dropped entirely (shell options
+don't cross RUN boundaries, so preserving it in a standalone RUN would be pure noise).
 
 #### Before (violation)
 
@@ -159,7 +160,6 @@ RUN set -ex \
 #### After (fixed with `--fix --fix-unsafe`)
 
 ```dockerfile
-RUN set -ex
 COPY <<EOF /usr/local/etc/php-fpm.d/www.conf
 [global]
 daemonize = no

--- a/_docs/rules/tally/prefer-copy-heredoc.mdx
+++ b/_docs/rules/tally/prefer-copy-heredoc.mdx
@@ -210,12 +210,15 @@ When extracting file creation from mixed commands, mounts are preserved on the r
 
 ## Chmod Support
 
-Converts both octal and symbolic chmod modes to `COPY --chmod`:
+Preserves the original mode notation on `COPY --chmod`. `COPY --chmod`
+accepts both octal and symbolic modes (Dockerfile frontend 1.14+), so the
+fixer emits whichever form the source wrote:
 
-- Octal: `chmod 755` → `--chmod=0755`
-- Symbolic: `chmod +x` → `--chmod=0755`, `chmod u+x` → `--chmod=0744`
+- Octal: `chmod 755` → `--chmod=755`, `chmod 0755` → `--chmod=0755`
+- Symbolic: `chmod +x` → `--chmod=+x`, `chmod u+x` → `--chmod=u+x`
 
-Symbolic modes are converted based on a 0644 base (default for newly created files).
+Symbolic modes are copied verbatim — the fixer does not convert them to
+octal. That keeps the diff minimal and preserves the author's intent.
 
 ## Options
 

--- a/internal/integration/__snapshots__/TestFixCrossRuleCopyChmodHeredoc_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixCrossRuleCopyChmodHeredoc_1.snap.Dockerfile
@@ -1,12 +1,16 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY --chmod=+x entrypoint.sh /app/entrypoint.sh
+
 COPY <<EOF /app/.env
 APP_ENV=production
 EOF
+
 COPY --chmod=755 --chown=app:app healthcheck.sh /app/healthcheck.sh
+
 COPY <<EOF /etc/app.conf
 log_level = info
 workers = 4
 EOF
+
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/internal/integration/__snapshots__/TestFixHeredocCombined_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixHeredocCombined_1.snap.Dockerfile
@@ -3,7 +3,8 @@
 FROM ubuntu:22.04 AS builder
 
 # Case 1: prefer-copy-heredoc — single RUN creating a config file via echo redirect
-	COPY <<EOF /etc/nginx/conf.d/default.conf
+	
+COPY <<EOF /etc/nginx/conf.d/default.conf
 server { listen 80; }
 EOF
 
@@ -19,7 +20,8 @@ EOF
 		EOF
 
 # Case 4: prefer-copy-heredoc — consecutive RUNs appending to same file
-	COPY <<EOF /app/data.txt
+	
+COPY <<EOF /app/data.txt
 line1
 line2
 EOF
@@ -28,17 +30,20 @@ EOF
 	RUN echo "extra" >> /tmp/log.txt
 
 # Case 6: prefer-copy-heredoc — echo with cat pattern
+
 COPY <<EOF /etc/motd
 Welcome to the build container
 EOF
 
 # Case 6b: prefer-copy-heredoc — BuildKit heredoc piped to cat
+
 COPY <<EOF /aria2/aria2.conf
 dir=/downloads
 max-concurrent-downloads=16
 EOF
 
 # Case 6c: prefer-copy-heredoc — BuildKit heredoc piped to tee
+
 COPY <<EOF /etc/supervisor/conf.d/app.conf
 [program:app]
 command=/usr/bin/app
@@ -58,7 +63,8 @@ EOF
 FROM alpine:3.20 AS runtime
 
 # Case 9: prefer-copy-heredoc in second stage — file creation
-	COPY --chmod=+x <<EOF /entrypoint.sh
+	
+COPY --chmod=+x <<EOF /entrypoint.sh
 #!/bin/sh
 EOF
 

--- a/internal/integration/__snapshots__/TestFix_heredoc-both-rules-combined_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_heredoc-both-rules-combined_1.snap.Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:22.04
+
 COPY <<EOF /etc/nginx.conf
 server {}
 EOF
+
 RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked --mount=type=cache,target=/var/lib/apt,id=aptlib,sharing=locked apt-get update
 # [tally] curl configuration for improved robustness
 ENV CURL_HOME=/etc/curl

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-buildkit-heredoc-cat_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-buildkit-heredoc-cat_1.snap.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+
 COPY <<EOF /aria2/aria2.conf
 dir=/downloads
 max-concurrent-downloads=16

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-buildkit-heredoc-tee_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-buildkit-heredoc-tee_1.snap.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+
 COPY <<EOF /etc/app.conf
 [app]
 key=value

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-consecutive-writes_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-consecutive-writes_1.snap.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+
 COPY <<EOF /app/data.txt
 line1
 line2

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-printf-chmod_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-printf-chmod_1.snap.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+
 COPY --chmod=+x <<EOF /app/run.sh
 #!/bin/sh
 exec app

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-printf-escapes_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-printf-escapes_1.snap.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+
 COPY <<EOF /usr/include/stub.h
 #ifndef H
 #define H

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-single-echo_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-single-echo_1.snap.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+
 COPY <<EOF /app/greeting.txt
 hello world
 EOF

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-tilde-home-root_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-tilde-home-root_1.snap.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+
 COPY <<EOF /root/.bashrc
 #!/bin/bash
 EOF

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-with-chmod_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-with-chmod_1.snap.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
+
 COPY --chmod=+x <<EOF /entrypoint.sh
 #!/bin/sh
 EOF

--- a/internal/integration/__snapshots__/TestLint_heredoc-combined_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_heredoc-combined_1.snap.json
@@ -36,7 +36,7 @@
                     "line": 6
                   }
                 },
-                "newText": "COPY \u003c\u003cEOF /etc/nginx/conf.d/default.conf\nserver { listen 80; }\nEOF"
+                "newText": "\nCOPY \u003c\u003cEOF /etc/nginx/conf.d/default.conf\nserver { listen 80; }\nEOF"
               }
             ],
             "priority": 99,
@@ -128,7 +128,7 @@
                     "line": 17
                   }
                 },
-                "newText": "COPY \u003c\u003cEOF /app/data.txt\nline1\nline2\nEOF"
+                "newText": "\nCOPY \u003c\u003cEOF /app/data.txt\nline1\nline2\nEOF"
               }
             ],
             "priority": 99,
@@ -168,7 +168,7 @@
                     "line": 24
                   }
                 },
-                "newText": "COPY \u003c\u003cEOF /etc/motd\nWelcome to the build container\nEOF"
+                "newText": "\nCOPY \u003c\u003cEOF /etc/motd\nWelcome to the build container\nEOF"
               }
             ],
             "priority": 99,
@@ -208,7 +208,7 @@
                     "line": 29
                   }
                 },
-                "newText": "COPY \u003c\u003cEOF /aria2/aria2.conf\ndir=/downloads\nmax-concurrent-downloads=16\nEOF"
+                "newText": "\nCOPY \u003c\u003cEOF /aria2/aria2.conf\ndir=/downloads\nmax-concurrent-downloads=16\nEOF"
               }
             ],
             "priority": 99,
@@ -248,7 +248,7 @@
                     "line": 35
                   }
                 },
-                "newText": "COPY \u003c\u003cEOF /etc/supervisor/conf.d/app.conf\n[program:app]\ncommand=/usr/bin/app\nautostart=true\nEOF"
+                "newText": "\nCOPY \u003c\u003cEOF /etc/supervisor/conf.d/app.conf\n[program:app]\ncommand=/usr/bin/app\nautostart=true\nEOF"
               }
             ],
             "priority": 99,
@@ -288,7 +288,7 @@
                     "line": 56
                   }
                 },
-                "newText": "COPY --chmod=+x \u003c\u003cEOF /entrypoint.sh\n#!/bin/sh\nEOF"
+                "newText": "\nCOPY --chmod=+x \u003c\u003cEOF /entrypoint.sh\n#!/bin/sh\nEOF"
               }
             ],
             "priority": 99,

--- a/internal/rules/tally/prefer_copy_heredoc.go
+++ b/internal/rules/tally/prefer_copy_heredoc.go
@@ -498,8 +498,19 @@ func (r *PreferCopyHeredocRule) createSequenceViolation(
 
 // multiTargetViolation builds a Violation and fix for a RUN that creates
 // multiple distinct files in one && chain. Returns ok=false when the fix
-// can't be generated (missing location, any slot appends without a prior
-// overwrite, mount conflicts with any target, etc.).
+// can't be generated.
+//
+// Conservative bail-out: the multi-target path requires every slot in the
+// RUN to be a clean overwrite with literal content and no mount conflict.
+// If *any* slot is append-only, uses unsafe variables, or conflicts with a
+// mount target, the whole multi-target fix is aborted — mixed cases (say,
+// one overwrite slot plus one append slot) then fall through to the
+// single-target path in checkSingleRuns, which will typically flag only the
+// first extractable block. This is intentional: generating a partial fix
+// for a multi-write RUN risks silently dropping content we can't inline.
+//
+// generateMultiFix performs the actual location/range checks; this function
+// only validates the per-slot preconditions listed above.
 func (r *PreferCopyHeredocRule) multiTargetViolation(
 	run *instructions.RunCommand,
 	multi *shell.MultiFileCreationInfo,
@@ -522,11 +533,6 @@ func (r *PreferCopyHeredocRule) multiTargetViolation(
 		if shouldSkipForMounts(run, slot.Info.TargetPath) {
 			return rules.Violation{}, false
 		}
-	}
-
-	runLoc := run.Location()
-	if len(runLoc) == 0 {
-		return rules.Violation{}, false
 	}
 
 	fix := r.generateMultiFix(run, multi, ctx, effectiveUser)

--- a/internal/rules/tally/prefer_copy_heredoc.go
+++ b/internal/rules/tally/prefer_copy_heredoc.go
@@ -557,35 +557,30 @@ func (r *PreferCopyHeredocRule) multiTargetViolation(
 	return v, true
 }
 
-// generateMultiFix builds a fix that replaces a multi-target RUN with a
-// sequence of COPY heredocs (one per distinct target) and, when non-creation
-// commands remain, a surrounding RUN. `mkdir -p /parent` entries are dropped
-// when a subsequent COPY writes under /parent — BuildKit COPY auto-creates
-// parent directories.
-func (r *PreferCopyHeredocRule) generateMultiFix(
+// runPrefixToken is the literal "RUN " prefix used when emitting shell-form
+// RUN instructions in generated fixes. Declared once so lints like goconst
+// don't nudge us per call site.
+const runPrefixToken = "RUN "
+
+// buildMultiFixParts walks the multi-target analysis and produces the ordered
+// sequence of fix parts: COPY heredocs for each distinct target, interleaved
+// with RUN-wrapped surviving commands. `mkdir -p /parent` commands absorbed
+// by a following COPY destination are skipped, and a leftover RUN that
+// contains only shell-state-only commands (set/shopt) is dropped.
+func buildMultiFixParts(
 	run *instructions.RunCommand,
 	multi *shell.MultiFileCreationInfo,
-	ctx copyHeredocCheckContext,
 	effectiveUser string,
-) *rules.SuggestedFix {
-	runLoc := run.Location()
-	if len(runLoc) == 0 {
-		return nil
-	}
-
+) []string {
 	creationTargets := make([]string, 0, len(multi.Slots))
 	for _, slot := range multi.Slots {
 		creationTargets = append(creationTargets, slot.Info.TargetPath)
 	}
 
-	// Build the output: walk commands in order, emitting either a COPY heredoc
-	// for creation slots or a preserved shell command for others. Contiguous
-	// "other" commands collapse into a single RUN; mkdir -p entries absorbed
-	// by a later COPY destination are skipped.
 	mountFlags := runmount.FormatMounts(runmount.GetMounts(run))
-	runPrefix := "RUN "
+	runPrefix := runPrefixToken
 	if mountFlags != "" {
-		runPrefix = "RUN " + mountFlags + " "
+		runPrefix = runPrefixToken + mountFlags + " "
 	}
 
 	chownUser := chownUserForCopy(effectiveUser)
@@ -604,8 +599,8 @@ func (r *PreferCopyHeredocRule) generateMultiFix(
 			return
 		}
 		// Drop a leftover RUN that contains only shell-state commands
-		// (`set -ex`, `shopt`, `trap`) — these don't cross RUN boundaries,
-		// so preserving them after extraction is pure noise.
+		// (`set -ex`, `shopt`) — these don't cross RUN boundaries, so
+		// preserving them after extraction is pure noise.
 		if !pendingAllStateOnly {
 			parts = append(parts, runPrefix+strings.Join(pendingRun, " && "))
 		}
@@ -635,12 +630,31 @@ func (r *PreferCopyHeredocRule) generateMultiFix(
 				continue
 			}
 			appendPending(cmd.Text, false)
-		default:
+		case shell.MultiCmdOther:
 			appendPending(cmd.Text, cmd.IsShellStateOnly)
 		}
 	}
 	flushRun()
+	return parts
+}
 
+// generateMultiFix builds a fix that replaces a multi-target RUN with a
+// sequence of COPY heredocs (one per distinct target) and, when non-creation
+// commands remain, a surrounding RUN. `mkdir -p /parent` entries are dropped
+// when a subsequent COPY writes under /parent — BuildKit COPY auto-creates
+// parent directories.
+func (r *PreferCopyHeredocRule) generateMultiFix(
+	run *instructions.RunCommand,
+	multi *shell.MultiFileCreationInfo,
+	ctx copyHeredocCheckContext,
+	effectiveUser string,
+) *rules.SuggestedFix {
+	runLoc := run.Location()
+	if len(runLoc) == 0 {
+		return nil
+	}
+
+	parts := buildMultiFixParts(run, multi, effectiveUser)
 	if len(parts) == 0 {
 		return nil
 	}
@@ -685,9 +699,10 @@ func joinFixParts(parts []string, sm *sourcemap.SourceMap, runStartLine, runEndL
 
 	// Interior joints: blank line around any COPY block.
 	var sb strings.Builder
+	var prevPart string
 	for i, part := range parts {
 		if i > 0 {
-			prevIsCopy := isCopyHeredocPart(parts[i-1])
+			prevIsCopy := isCopyHeredocPart(prevPart)
 			curIsCopy := isCopyHeredocPart(part)
 			if prevIsCopy || curIsCopy {
 				sb.WriteString("\n\n")
@@ -696,6 +711,7 @@ func joinFixParts(parts []string, sm *sourcemap.SourceMap, runStartLine, runEndL
 			}
 		}
 		sb.WriteString(part)
+		prevPart = part
 	}
 	body := sb.String()
 
@@ -773,9 +789,9 @@ func (r *PreferCopyHeredocRule) generateFix(
 
 	// Get mount flags to preserve on remaining RUN commands
 	mountFlags := runmount.FormatMounts(runmount.GetMounts(run))
-	runPrefix := "RUN "
+	runPrefix := runPrefixToken
 	if mountFlags != "" {
-		runPrefix = "RUN " + mountFlags + " "
+		runPrefix = runPrefixToken + mountFlags + " "
 	}
 
 	// Add preceding commands as RUN if any (preserve mounts). The shell
@@ -1372,7 +1388,7 @@ func resolveRunEndPosition(loc []parser.Range, sm *sourcemap.SourceMap, run *ins
 	if endLine == loc[0].Start.Line && endCol == loc[0].Start.Character {
 		cmdStr := getRunScriptFromCmd(run)
 		mountFlags := runmount.FormatMounts(runmount.GetMounts(run))
-		fullInstr := "RUN "
+		fullInstr := runPrefixToken
 		if mountFlags != "" {
 			fullInstr += mountFlags + " "
 		}

--- a/internal/rules/tally/prefer_copy_heredoc.go
+++ b/internal/rules/tally/prefer_copy_heredoc.go
@@ -639,9 +639,8 @@ func (r *PreferCopyHeredocRule) generateMultiFix(
 		return nil
 	}
 
-	newText := strings.Join(parts, "\n")
-
 	endLine, endCol := resolveRunEndPosition(runLoc, ctx.sm, run)
+	newText := joinFixParts(parts, ctx.sm, runLoc[0].Start.Line, endLine)
 
 	safety := rules.FixSuggestion
 	if multi.ResolvedHomePath {
@@ -663,6 +662,74 @@ func (r *PreferCopyHeredocRule) generateMultiFix(
 			NewText: newText,
 		}},
 	}
+}
+
+// joinFixParts joins fix output fragments, inserting blank-line padding
+// around every COPY heredoc block. Embedded file bodies are a lot easier
+// to read when they're visually separated from surrounding instructions
+// (it's the convention in every hand-crafted Dockerfile using heredocs).
+//
+// Top/bottom edges are padded based on what's above/below the replaced
+// RUN: if the adjacent source line already has a blank line, we don't
+// inject a duplicate.
+func joinFixParts(parts []string, sm *sourcemap.SourceMap, runStartLine, runEndLine int) string {
+	if len(parts) == 0 {
+		return ""
+	}
+
+	// Interior joints: blank line around any COPY block.
+	var sb strings.Builder
+	for i, part := range parts {
+		if i > 0 {
+			prevIsCopy := isCopyHeredocPart(parts[i-1])
+			curIsCopy := isCopyHeredocPart(part)
+			if prevIsCopy || curIsCopy {
+				sb.WriteString("\n\n")
+			} else {
+				sb.WriteString("\n")
+			}
+		}
+		sb.WriteString(part)
+	}
+	body := sb.String()
+
+	// Top edge: if the first emitted part is a COPY and the previous
+	// source line (just before the RUN) isn't already blank, prepend one.
+	if isCopyHeredocPart(parts[0]) && !prevLineIsBlank(sm, runStartLine) {
+		body = "\n" + body
+	}
+	// Bottom edge: same check against the line just after the RUN.
+	if isCopyHeredocPart(parts[len(parts)-1]) && !nextLineIsBlank(sm, runEndLine) {
+		body += "\n"
+	}
+
+	return body
+}
+
+// isCopyHeredocPart reports whether a fix fragment is a COPY <<... heredoc
+// block (as produced by buildCopyHeredoc).
+func isCopyHeredocPart(part string) bool {
+	return strings.HasPrefix(part, "COPY ")
+}
+
+// prevLineIsBlank checks whether the source line immediately before the
+// given 1-based line number is blank (or doesn't exist). Used to avoid
+// injecting a duplicate blank separator above the edit.
+func prevLineIsBlank(sm *sourcemap.SourceMap, line int) bool {
+	if sm == nil || line <= 1 {
+		return true
+	}
+	return strings.TrimSpace(sm.Line(line-2)) == ""
+}
+
+// nextLineIsBlank checks whether the source line immediately after the
+// given 1-based line number is blank (or doesn't exist). Used to avoid
+// injecting a duplicate blank separator below the edit.
+func nextLineIsBlank(sm *sourcemap.SourceMap, line int) bool {
+	if sm == nil || line >= sm.LineCount() {
+		return true
+	}
+	return strings.TrimSpace(sm.Line(line)) == ""
 }
 
 // mkdirAbsorbedByCopy reports whether the given mkdir -p target is created
@@ -722,9 +789,8 @@ func (r *PreferCopyHeredocRule) generateFix(
 		parts = append(parts, runPrefix+info.RemainingCommands)
 	}
 
-	newText := strings.Join(parts, "\n")
-
 	endLine, endCol := resolveRunEndPosition(runLoc, sm, run)
+	newText := joinFixParts(parts, sm, runLoc[0].Start.Line, endLine)
 
 	description := "Replace RUN with COPY <<EOF to " + info.TargetPath
 	if info.PrecedingCommands != "" || info.RemainingCommands != "" {
@@ -819,6 +885,7 @@ func (r *PreferCopyHeredocRule) generateSequenceFix(
 	}
 
 	endLine, endCol := resolveRunEndPosition(lastLoc, ctx.sm, lastRun)
+	newText := joinFixParts([]string{copyCmd}, ctx.sm, firstLoc[0].Start.Line, endLine)
 
 	runCount := len(sequence)
 	if trailingChmodRun != nil {
@@ -837,7 +904,7 @@ func (r *PreferCopyHeredocRule) generateSequenceFix(
 				endLine,
 				endCol,
 			),
-			NewText: copyCmd,
+			NewText: newText,
 		}},
 	}
 }

--- a/internal/rules/tally/prefer_copy_heredoc.go
+++ b/internal/rules/tally/prefer_copy_heredoc.go
@@ -665,31 +665,6 @@ func (r *PreferCopyHeredocRule) generateMultiFix(
 	}
 }
 
-// isShellStateOnlyChain reports whether a joined " && " command string is
-// built entirely from shell-state commands (`set`, `shopt`, `trap`). Such
-// chains have no effect across RUN boundaries — each RUN starts a fresh
-// shell — so they can be dropped when extraction would otherwise leave
-// them alone in a leftover RUN.
-func isShellStateOnlyChain(chain string) bool {
-	chain = strings.TrimSpace(chain)
-	if chain == "" {
-		return false
-	}
-	for part := range strings.SplitSeq(chain, " && ") {
-		fields := strings.Fields(strings.TrimSpace(part))
-		if len(fields) == 0 {
-			return false
-		}
-		switch fields[0] {
-		case "set", "shopt", "trap":
-			// state-only
-		default:
-			return false
-		}
-	}
-	return true
-}
-
 // mkdirAbsorbedByCopy reports whether the given mkdir -p target is created
 // (implicitly) by a subsequent COPY heredoc destination. BuildKit's COPY
 // creates all missing parent directories of its destination.
@@ -730,10 +705,10 @@ func (r *PreferCopyHeredocRule) generateFix(
 		runPrefix = "RUN " + mountFlags + " "
 	}
 
-	// Add preceding commands as RUN if any (preserve mounts). Drop a RUN
-	// that would contain only shell-state commands (`set -ex`, `shopt`,
-	// `trap`) — they don't cross RUN boundaries, so they'd be noise.
-	if info.PrecedingCommands != "" && !isShellStateOnlyChain(info.PrecedingCommands) {
+	// Add preceding commands as RUN if any (preserve mounts). The shell
+	// layer already drops chains that would be pure shell-state noise
+	// (`set -ex`, `shopt`, `trap`) — options don't cross RUN boundaries.
+	if info.PrecedingCommands != "" {
 		parts = append(parts, runPrefix+info.PrecedingCommands)
 	}
 
@@ -743,7 +718,7 @@ func (r *PreferCopyHeredocRule) generateFix(
 	parts = append(parts, copyCmd)
 
 	// Add remaining commands as RUN if any (preserve mounts)
-	if info.RemainingCommands != "" && !isShellStateOnlyChain(info.RemainingCommands) {
+	if info.RemainingCommands != "" {
 		parts = append(parts, runPrefix+info.RemainingCommands)
 	}
 
@@ -752,9 +727,7 @@ func (r *PreferCopyHeredocRule) generateFix(
 	endLine, endCol := resolveRunEndPosition(runLoc, sm, run)
 
 	description := "Replace RUN with COPY <<EOF to " + info.TargetPath
-	hasRealSurrounding := (info.PrecedingCommands != "" && !isShellStateOnlyChain(info.PrecedingCommands)) ||
-		(info.RemainingCommands != "" && !isShellStateOnlyChain(info.RemainingCommands))
-	if hasRealSurrounding {
+	if info.PrecedingCommands != "" || info.RemainingCommands != "" {
 		description = "Extract file creation to COPY <<EOF"
 	}
 

--- a/internal/rules/tally/prefer_copy_heredoc.go
+++ b/internal/rules/tally/prefer_copy_heredoc.go
@@ -270,6 +270,7 @@ func (r *PreferCopyHeredocRule) checkSingleRuns(
 			userState.currentUser = c.User
 		case *instructions.RunCommand:
 			shellCtx := preferCopyHeredocShellContextForRun(c, ctx.stageInfo, ctx.fallbackVariant)
+			multi := detectRunFileCreations(c, shellCtx.variant, shellCtx.fileCreationOptions, ctx.knownVars, userState)
 			info := detectRunFileCreation(c, shellCtx.variant, shellCtx.fileCreationOptions, ctx.knownVars, userState)
 			userState.learnHomesFromRun(c, shellCtx.variant)
 
@@ -279,7 +280,19 @@ func (r *PreferCopyHeredocRule) checkSingleRuns(
 			}
 
 			// Only check shell form
-			if !c.PrependShell || info == nil {
+			if !c.PrependShell {
+				continue
+			}
+
+			// Multi-target path: emit a single violation covering all targets.
+			if multi != nil && len(multi.Slots) > 1 && !multi.HasUnsafeVariables {
+				if v, ok := r.multiTargetViolation(c, multi, ctx, userState.currentUser); ok {
+					violations = append(violations, v)
+					continue
+				}
+			}
+
+			if info == nil {
 				continue
 			}
 
@@ -481,6 +494,177 @@ func (r *PreferCopyHeredocRule) createSequenceViolation(
 	}
 
 	return &v
+}
+
+// multiTargetViolation builds a Violation and fix for a RUN that creates
+// multiple distinct files in one && chain. Returns ok=false when the fix
+// can't be generated (missing location, any slot appends without a prior
+// overwrite, mount conflicts with any target, etc.).
+func (r *PreferCopyHeredocRule) multiTargetViolation(
+	run *instructions.RunCommand,
+	multi *shell.MultiFileCreationInfo,
+	ctx copyHeredocCheckContext,
+	effectiveUser string,
+) (rules.Violation, bool) {
+	if multi == nil || len(multi.Slots) < 2 {
+		return rules.Violation{}, false
+	}
+
+	for _, slot := range multi.Slots {
+		if slot.Info.HasUnsafeVariables {
+			return rules.Violation{}, false
+		}
+		// Append-only slots need prior content to merge — skip multi-fix
+		// since each slot is independent and can't safely be converted.
+		if slot.Info.IsAppend {
+			return rules.Violation{}, false
+		}
+		if shouldSkipForMounts(run, slot.Info.TargetPath) {
+			return rules.Violation{}, false
+		}
+	}
+
+	runLoc := run.Location()
+	if len(runLoc) == 0 {
+		return rules.Violation{}, false
+	}
+
+	fix := r.generateMultiFix(run, multi, ctx, effectiveUser)
+	if fix == nil {
+		return rules.Violation{}, false
+	}
+
+	loc := rules.NewLocationFromRanges(ctx.file, run.Location())
+	targetList := make([]string, 0, len(multi.Slots))
+	for _, slot := range multi.Slots {
+		targetList = append(targetList, slot.Info.TargetPath)
+	}
+	v := rules.NewViolation(
+		loc,
+		ctx.meta.Code,
+		"use COPY <<EOF instead of RUN for file creation",
+		ctx.meta.DefaultSeverity,
+	).WithDocURL(ctx.meta.DocURL).WithDetail(
+		fmt.Sprintf("RUN creates %d files (%s); each can become its own COPY heredoc",
+			len(multi.Slots), strings.Join(targetList, ", ")),
+	).WithSuggestedFix(fix)
+	return v, true
+}
+
+// generateMultiFix builds a fix that replaces a multi-target RUN with a
+// sequence of COPY heredocs (one per distinct target) and, when non-creation
+// commands remain, a surrounding RUN. `mkdir -p /parent` entries are dropped
+// when a subsequent COPY writes under /parent — BuildKit COPY auto-creates
+// parent directories.
+func (r *PreferCopyHeredocRule) generateMultiFix(
+	run *instructions.RunCommand,
+	multi *shell.MultiFileCreationInfo,
+	ctx copyHeredocCheckContext,
+	effectiveUser string,
+) *rules.SuggestedFix {
+	runLoc := run.Location()
+	if len(runLoc) == 0 {
+		return nil
+	}
+
+	creationTargets := make([]string, 0, len(multi.Slots))
+	for _, slot := range multi.Slots {
+		creationTargets = append(creationTargets, slot.Info.TargetPath)
+	}
+
+	// Build the output: walk commands in order, emitting either a COPY heredoc
+	// for creation slots or a preserved shell command for others. Contiguous
+	// "other" commands collapse into a single RUN; mkdir -p entries absorbed
+	// by a later COPY destination are skipped.
+	mountFlags := runmount.FormatMounts(runmount.GetMounts(run))
+	runPrefix := "RUN "
+	if mountFlags != "" {
+		runPrefix = "RUN " + mountFlags + " "
+	}
+
+	chownUser := chownUserForCopy(effectiveUser)
+
+	var parts []string
+	var pendingRun []string
+	flushRun := func() {
+		if len(pendingRun) == 0 {
+			return
+		}
+		parts = append(parts, runPrefix+strings.Join(pendingRun, " && "))
+		pendingRun = pendingRun[:0]
+	}
+
+	emittedSlots := make(map[int]bool, len(multi.Slots))
+	for _, cmd := range multi.Commands {
+		switch cmd.Kind {
+		case shell.MultiCmdCreation:
+			if emittedSlots[cmd.SlotIndex] {
+				continue
+			}
+			emittedSlots[cmd.SlotIndex] = true
+			flushRun()
+			slot := multi.Slots[cmd.SlotIndex]
+			parts = append(parts,
+				buildCopyHeredoc(slot.Info.TargetPath, slot.Info.Content, slot.Info.RawChmodMode, chownUser))
+		case shell.MultiCmdChmod:
+			// Chmod commands targeting a slot are already folded into that
+			// slot; any chmod that reaches us here targets something outside
+			// our creation set — preserve it as a shell command.
+			pendingRun = append(pendingRun, cmd.Text)
+		case shell.MultiCmdMkdirP:
+			if mkdirAbsorbedByCopy(cmd.MkdirTarget, creationTargets) {
+				continue
+			}
+			pendingRun = append(pendingRun, cmd.Text)
+		default:
+			pendingRun = append(pendingRun, cmd.Text)
+		}
+	}
+	flushRun()
+
+	if len(parts) == 0 {
+		return nil
+	}
+
+	newText := strings.Join(parts, "\n")
+
+	endLine, endCol := resolveRunEndPosition(runLoc, ctx.sm, run)
+
+	safety := rules.FixSuggestion
+	if multi.ResolvedHomePath {
+		safety = rules.FixUnsafe
+	}
+
+	return &rules.SuggestedFix{
+		Description: fmt.Sprintf("Split RUN into %d COPY <<EOF instructions", len(multi.Slots)),
+		Safety:      safety,
+		Priority:    ctx.meta.FixPriority,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(
+				ctx.file,
+				runLoc[0].Start.Line,
+				runLoc[0].Start.Character,
+				endLine,
+				endCol,
+			),
+			NewText: newText,
+		}},
+	}
+}
+
+// mkdirAbsorbedByCopy reports whether the given mkdir -p target is created
+// (implicitly) by a subsequent COPY heredoc destination. BuildKit's COPY
+// creates all missing parent directories of its destination.
+func mkdirAbsorbedByCopy(mkdirTarget string, creationTargets []string) bool {
+	if mkdirTarget == "" {
+		return false
+	}
+	for _, dest := range creationTargets {
+		if isPathUnder(dest, mkdirTarget) {
+			return true
+		}
+	}
+	return false
 }
 
 // generateFix generates a fix for a single RUN file creation.
@@ -861,6 +1045,30 @@ func detectRunFileCreation(
 	}
 
 	return shell.DetectFileCreationWithOptions(script, shellVariant, knownVars, options)
+}
+
+// detectRunFileCreations runs the multi-target analysis for a RUN instruction,
+// applying the same options (target-path resolution, plain-echo escape
+// semantics) used by the single-target detector. Returns nil if the script is
+// not a file-creation chain or uses unsupported shell features.
+func detectRunFileCreations(
+	run *instructions.RunCommand,
+	shellVariant shell.Variant,
+	options shell.FileCreationOptions,
+	knownVars func(string) bool,
+	userState *preferCopyHeredocUserState,
+) *shell.MultiFileCreationInfo {
+	if run == nil || !run.PrependShell {
+		return nil
+	}
+	script := getRunCmdLine(run)
+	if script == "" {
+		return nil
+	}
+	if userState != nil {
+		options.ResolveTargetPath = userState.resolveTargetPath
+	}
+	return shell.DetectFileCreations(script, shellVariant, knownVars, options)
 }
 
 type preferCopyHeredocShellContext struct {

--- a/internal/rules/tally/prefer_copy_heredoc.go
+++ b/internal/rules/tally/prefer_copy_heredoc.go
@@ -586,12 +586,25 @@ func (r *PreferCopyHeredocRule) generateMultiFix(
 
 	var parts []string
 	var pendingRun []string
+	pendingAllStateOnly := true
+	appendPending := func(text string, stateOnly bool) {
+		pendingRun = append(pendingRun, text)
+		if !stateOnly {
+			pendingAllStateOnly = false
+		}
+	}
 	flushRun := func() {
 		if len(pendingRun) == 0 {
 			return
 		}
-		parts = append(parts, runPrefix+strings.Join(pendingRun, " && "))
+		// Drop a leftover RUN that contains only shell-state commands
+		// (`set -ex`, `shopt`, `trap`) — these don't cross RUN boundaries,
+		// so preserving them after extraction is pure noise.
+		if !pendingAllStateOnly {
+			parts = append(parts, runPrefix+strings.Join(pendingRun, " && "))
+		}
 		pendingRun = pendingRun[:0]
+		pendingAllStateOnly = true
 	}
 
 	emittedSlots := make(map[int]bool, len(multi.Slots))
@@ -610,14 +623,14 @@ func (r *PreferCopyHeredocRule) generateMultiFix(
 			// Chmod commands targeting a slot are already folded into that
 			// slot; any chmod that reaches us here targets something outside
 			// our creation set — preserve it as a shell command.
-			pendingRun = append(pendingRun, cmd.Text)
+			appendPending(cmd.Text, false)
 		case shell.MultiCmdMkdirP:
 			if mkdirAbsorbedByCopy(cmd.MkdirTarget, creationTargets) {
 				continue
 			}
-			pendingRun = append(pendingRun, cmd.Text)
+			appendPending(cmd.Text, false)
 		default:
-			pendingRun = append(pendingRun, cmd.Text)
+			appendPending(cmd.Text, cmd.IsShellStateOnly)
 		}
 	}
 	flushRun()
@@ -650,6 +663,31 @@ func (r *PreferCopyHeredocRule) generateMultiFix(
 			NewText: newText,
 		}},
 	}
+}
+
+// isShellStateOnlyChain reports whether a joined " && " command string is
+// built entirely from shell-state commands (`set`, `shopt`, `trap`). Such
+// chains have no effect across RUN boundaries — each RUN starts a fresh
+// shell — so they can be dropped when extraction would otherwise leave
+// them alone in a leftover RUN.
+func isShellStateOnlyChain(chain string) bool {
+	chain = strings.TrimSpace(chain)
+	if chain == "" {
+		return false
+	}
+	for part := range strings.SplitSeq(chain, " && ") {
+		fields := strings.Fields(strings.TrimSpace(part))
+		if len(fields) == 0 {
+			return false
+		}
+		switch fields[0] {
+		case "set", "shopt", "trap":
+			// state-only
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // mkdirAbsorbedByCopy reports whether the given mkdir -p target is created
@@ -692,8 +730,10 @@ func (r *PreferCopyHeredocRule) generateFix(
 		runPrefix = "RUN " + mountFlags + " "
 	}
 
-	// Add preceding commands as RUN if any (preserve mounts)
-	if info.PrecedingCommands != "" {
+	// Add preceding commands as RUN if any (preserve mounts). Drop a RUN
+	// that would contain only shell-state commands (`set -ex`, `shopt`,
+	// `trap`) — they don't cross RUN boundaries, so they'd be noise.
+	if info.PrecedingCommands != "" && !isShellStateOnlyChain(info.PrecedingCommands) {
 		parts = append(parts, runPrefix+info.PrecedingCommands)
 	}
 
@@ -703,7 +743,7 @@ func (r *PreferCopyHeredocRule) generateFix(
 	parts = append(parts, copyCmd)
 
 	// Add remaining commands as RUN if any (preserve mounts)
-	if info.RemainingCommands != "" {
+	if info.RemainingCommands != "" && !isShellStateOnlyChain(info.RemainingCommands) {
 		parts = append(parts, runPrefix+info.RemainingCommands)
 	}
 
@@ -712,7 +752,9 @@ func (r *PreferCopyHeredocRule) generateFix(
 	endLine, endCol := resolveRunEndPosition(runLoc, sm, run)
 
 	description := "Replace RUN with COPY <<EOF to " + info.TargetPath
-	if info.PrecedingCommands != "" || info.RemainingCommands != "" {
+	hasRealSurrounding := (info.PrecedingCommands != "" && !isShellStateOnlyChain(info.PrecedingCommands)) ||
+		(info.RemainingCommands != "" && !isShellStateOnlyChain(info.RemainingCommands))
+	if hasRealSurrounding {
 		description = "Extract file creation to COPY <<EOF"
 	}
 

--- a/internal/rules/tally/prefer_copy_heredoc_test.go
+++ b/internal/rules/tally/prefer_copy_heredoc_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
+	fixpkg "github.com/wharflab/tally/internal/fix"
 	"github.com/wharflab/tally/internal/testutil"
 )
 
@@ -766,5 +767,158 @@ RUN printf '#!/bin/sh\nexec app\n' > /app/run.sh
 	runViolations := runRule.Check(runInput)
 	if len(runViolations) != 0 {
 		t.Errorf("prefer-run-heredoc: got %d violations, want 0 (should yield to prefer-copy-heredoc)", len(runViolations))
+	}
+}
+
+// TestPreferCopyHeredocRule_PhpFpmStyleFullFix is a snapshot-style test that
+// runs the fix against the exact shape from the original feature request and
+// verifies the applied output.
+func TestPreferCopyHeredocRule_PhpFpmStyleFullFix(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM php:8.3-fpm-alpine
+RUN set -ex \
+    && { \
+        echo '[global]'; \
+        echo 'daemonize = no'; \
+        echo 'error_log = /proc/self/fd/2'; \
+        echo; \
+        echo '[www]'; \
+        echo 'listen = [::]:9000'; \
+        echo 'listen.owner = www-data'; \
+        echo 'listen.group = www-data'; \
+        echo; \
+        echo 'user = www-data'; \
+        echo 'group = www-data'; \
+        echo; \
+        echo 'access.log = /proc/self/fd/2'; \
+        echo; \
+        echo 'pm = static'; \
+        echo 'pm.max_children = 1'; \
+        echo 'pm.start_servers = 1'; \
+        echo 'request_terminate_timeout = 65s'; \
+        echo 'pm.max_requests = 1000'; \
+        echo 'catch_workers_output = yes'; \
+    } | tee /usr/local/etc/php-fpm.d/www.conf \
+    && mkdir -p /usr/local/php/php/auto_prepends \
+    && { \
+        echo '<?php'; \
+        echo 'if (function_exists("uopz_allow_exit")) {'; \
+        echo '    uopz_allow_exit(true);'; \
+        echo '}'; \
+        echo '?>'; \
+    } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
+    && { \
+        echo 'FromLineOverride=YES'; \
+        echo 'mailhub=127.0.0.1'; \
+        echo 'UseTLS=NO'; \
+        echo 'UseSTARTTLS=NO'; \
+    } | tee /etc/ssmtp/ssmtp.conf \
+    && { \
+        echo '[PHP]'; \
+        echo 'log_errors = On'; \
+        echo 'error_log = /dev/stderr'; \
+        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php'; \
+    } | tee /usr/local/etc/php/conf.d/php.ini \
+    ;
+`
+	input := testutil.MakeLintInputWithConfig(t, "Dockerfile", content, nil)
+	violations := NewPreferCopyHeredocRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+
+	fix := violations[0].SuggestedFix
+	if fix == nil || len(fix.Edits) == 0 {
+		t.Fatal("expected a suggested fix")
+	}
+
+	applied := string(fixpkg.ApplyFix([]byte(content), fix))
+	// Collapse leading whitespace to make the snapshot diff-friendly.
+	if strings.Contains(applied, "mkdir -p /usr/local/php/php/auto_prepends") {
+		t.Errorf("mkdir -p should be absorbed by COPY destination\n--- applied ---\n%s", applied)
+	}
+	if got := strings.Count(applied, "COPY <<EOF "); got != 4 {
+		t.Errorf("got %d COPY heredocs, want 4\n--- applied ---\n%s", got, applied)
+	}
+	// set -ex should survive as a leading RUN.
+	if !strings.Contains(applied, "RUN set -ex") {
+		t.Errorf("leading RUN set -ex missing\n--- applied ---\n%s", applied)
+	}
+	// All four destination paths must be present.
+	wantTargets := []string{
+		"/usr/local/etc/php-fpm.d/www.conf",
+		"/usr/local/php/php/auto_prepends/default_prepend.php",
+		"/etc/ssmtp/ssmtp.conf",
+		"/usr/local/etc/php/conf.d/php.ini",
+	}
+	for _, want := range wantTargets {
+		if !strings.Contains(applied, "COPY <<EOF "+want) {
+			t.Errorf("missing COPY for %s\n--- applied ---\n%s", want, applied)
+		}
+	}
+}
+
+// TestPreferCopyHeredocRule_PhpFpmStyleMultiTargetFix covers the real-world
+// shape from the user request: a single RUN that builds several config files
+// via `{ echo ...; echo ...; } | tee /path` chains joined by &&, with an
+// intervening `mkdir -p` that the COPY destinations should absorb.
+func TestPreferCopyHeredocRule_PhpFpmStyleMultiTargetFix(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM php:8.3-fpm-alpine
+RUN set -ex \
+    && { \
+        echo '[global]'; \
+        echo 'daemonize = no'; \
+    } | tee /usr/local/etc/php-fpm.d/www.conf \
+    && mkdir -p /usr/local/php/php/auto_prepends \
+    && { \
+        echo '<?php'; \
+        echo '?>'; \
+    } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
+    && { \
+        echo 'FromLineOverride=YES'; \
+        echo 'UseTLS=NO'; \
+    } | tee /etc/ssmtp/ssmtp.conf \
+    && { \
+        echo '[PHP]'; \
+        echo 'log_errors = On'; \
+    } | tee /usr/local/etc/php/conf.d/php.ini \
+    ;
+`
+	input := testutil.MakeLintInputWithConfig(t, "Dockerfile", content, nil)
+	violations := NewPreferCopyHeredocRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+
+	fix := violations[0].SuggestedFix
+	if fix == nil || len(fix.Edits) == 0 {
+		t.Fatal("expected a suggested fix")
+	}
+
+	newText := fix.Edits[0].NewText
+
+	wantContains := []string{
+		"COPY <<EOF /usr/local/etc/php-fpm.d/www.conf",
+		"COPY <<EOF /usr/local/php/php/auto_prepends/default_prepend.php",
+		"COPY <<EOF /etc/ssmtp/ssmtp.conf",
+		"COPY <<EOF /usr/local/etc/php/conf.d/php.ini",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(newText, want) {
+			t.Errorf("fix text missing %q\nfull text:\n%s", want, newText)
+		}
+	}
+
+	// The mkdir -p should be absorbed: COPY auto-creates parent directories.
+	if strings.Contains(newText, "mkdir -p /usr/local/php/php/auto_prepends") {
+		t.Errorf("fix text should not retain mkdir -p absorbed by COPY destination\nfull text:\n%s", newText)
+	}
+
+	// The count should match: exactly four COPY lines.
+	if got := strings.Count(newText, "COPY <<EOF "); got != 4 {
+		t.Errorf("got %d COPY heredocs, want 4\nfull text:\n%s", got, newText)
 	}
 }

--- a/internal/rules/tally/prefer_copy_heredoc_test.go
+++ b/internal/rules/tally/prefer_copy_heredoc_test.go
@@ -1004,8 +1004,10 @@ RUN echo 'hi' > /etc/config
 
 // TestPreferCopyHeredocRule_DropsShellStateOnlyLeftovers verifies that
 // extraction drops a leftover RUN that would contain only shell-state-only
-// commands (set / shopt / trap) — those don't cross RUN boundaries and
-// would just clutter the output.
+// commands (`set`, `shopt`) — those don't cross RUN boundaries and would
+// just clutter the output. `trap` is deliberately NOT classified as
+// state-only: its registered handler body can still execute within the
+// same RUN (for example on EXIT) and is allowed to mutate the filesystem.
 func TestPreferCopyHeredocRule_DropsShellStateOnlyLeftovers(t *testing.T) {
 	t.Parallel()
 
@@ -1037,6 +1039,18 @@ RUN shopt -s nullglob && echo 'x' > /etc/config
 RUN set -ex && apt-get update && echo 'x' > /etc/config
 `,
 			wantFixText: "apt-get update",
+			wantFixLack: "",
+		},
+		{
+			// `trap 'echo cleanup >/marker' EXIT` registers an EXIT handler
+			// that executes before the RUN's shell exits and writes to
+			// /marker. Dropping the trap would silently lose that side
+			// effect, so `trap` must NEVER be treated as state-only.
+			name: "trap with EXIT handler is preserved",
+			content: `FROM alpine
+RUN trap 'echo cleanup > /marker' EXIT && echo 'x' > /etc/config
+`,
+			wantFixText: `trap 'echo cleanup > /marker' EXIT`,
 			wantFixLack: "",
 		},
 	}

--- a/internal/rules/tally/prefer_copy_heredoc_test.go
+++ b/internal/rules/tally/prefer_copy_heredoc_test.go
@@ -924,6 +924,84 @@ RUN set -ex \
 	}
 }
 
+// TestPreferCopyHeredocRule_BlankLinesAroundCopy verifies that COPY heredocs
+// emitted by the fix are visually separated from neighbouring instructions
+// with blank lines — the convention in hand-crafted Dockerfiles because the
+// heredoc body is embedded file content. Existing adjacent blanks aren't
+// duplicated.
+func TestPreferCopyHeredocRule_BlankLinesAroundCopy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		content        string
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name: "multi-target surrounded by RUNs gets blanks",
+			content: `FROM alpine
+RUN apk add --no-cache curl
+RUN { echo 'a=1'; } | tee /etc/one.conf \
+    && { echo 'b=2'; } | tee /etc/two.conf
+RUN apk add --no-cache bash
+`,
+			wantContains: []string{
+				"RUN apk add --no-cache curl\n\nCOPY <<EOF /etc/one.conf",
+				"EOF\n\nCOPY <<EOF /etc/two.conf",
+				"EOF\n\nRUN apk add --no-cache bash",
+			},
+		},
+		{
+			name: "already-blank line above is not duplicated",
+			content: `FROM alpine
+
+RUN echo 'hi' > /etc/config
+
+RUN echo bye
+`,
+			wantContains: []string{
+				"FROM alpine\n\nCOPY <<EOF /etc/config",
+				"EOF\n\nRUN echo bye",
+			},
+			// No triple-newlines anywhere.
+			wantNotContain: []string{"\n\n\n"},
+		},
+		{
+			name: "file-start RUN gets no leading blank",
+			content: `FROM alpine
+RUN echo 'hi' > /etc/config
+`,
+			wantContains: []string{
+				"FROM alpine\n\nCOPY <<EOF /etc/config",
+			},
+			wantNotContain: []string{"\n\n\n"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := testutil.MakeLintInputWithConfig(t, "Dockerfile", tt.content, nil)
+			violations := NewPreferCopyHeredocRule().Check(input)
+			if len(violations) == 0 {
+				t.Fatal("expected a violation")
+			}
+			applied := string(fixpkg.ApplyFix([]byte(tt.content), violations[0].SuggestedFix))
+			for _, want := range tt.wantContains {
+				if !strings.Contains(applied, want) {
+					t.Errorf("applied fix missing %q\n---\n%s", want, applied)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(applied, notWant) {
+					t.Errorf("applied fix should not contain %q\n---\n%s", notWant, applied)
+				}
+			}
+		})
+	}
+}
+
 // TestPreferCopyHeredocRule_DropsShellStateOnlyLeftovers verifies that
 // extraction drops a leftover RUN that would contain only shell-state-only
 // commands (set / shopt / trap) — those don't cross RUN boundaries and

--- a/internal/rules/tally/prefer_copy_heredoc_test.go
+++ b/internal/rules/tally/prefer_copy_heredoc_test.go
@@ -841,9 +841,10 @@ RUN set -ex \
 	if got := strings.Count(applied, "COPY <<EOF "); got != 4 {
 		t.Errorf("got %d COPY heredocs, want 4\n--- applied ---\n%s", got, applied)
 	}
-	// set -ex should survive as a leading RUN.
-	if !strings.Contains(applied, "RUN set -ex") {
-		t.Errorf("leading RUN set -ex missing\n--- applied ---\n%s", applied)
+	// A leftover `RUN set -ex` would be pure noise — shell options don't
+	// cross RUN boundaries — so the extraction should drop it entirely.
+	if strings.Contains(applied, "RUN set -ex") {
+		t.Errorf("leftover shell-state-only RUN should be dropped\n--- applied ---\n%s", applied)
 	}
 	// All four destination paths must be present.
 	wantTargets := []string{
@@ -920,5 +921,67 @@ RUN set -ex \
 	// The count should match: exactly four COPY lines.
 	if got := strings.Count(newText, "COPY <<EOF "); got != 4 {
 		t.Errorf("got %d COPY heredocs, want 4\nfull text:\n%s", got, newText)
+	}
+}
+
+// TestPreferCopyHeredocRule_DropsShellStateOnlyLeftovers verifies that
+// extraction drops a leftover RUN that would contain only shell-state-only
+// commands (set / shopt / trap) — those don't cross RUN boundaries and
+// would just clutter the output.
+func TestPreferCopyHeredocRule_DropsShellStateOnlyLeftovers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		content     string
+		wantFixText string
+		wantFixLack string
+	}{
+		{
+			name: "set -ex alone is dropped (single-target)",
+			content: `FROM alpine
+RUN set -ex && echo 'hello' > /etc/config
+`,
+			wantFixText: "COPY <<EOF /etc/config",
+			wantFixLack: "RUN set -ex",
+		},
+		{
+			name: "shopt alone is dropped (single-target)",
+			content: `FROM alpine
+RUN shopt -s nullglob && echo 'x' > /etc/config
+`,
+			wantFixText: "COPY <<EOF /etc/config",
+			wantFixLack: "RUN shopt",
+		},
+		{
+			name: "mixed set -ex + real command survives",
+			content: `FROM alpine
+RUN set -ex && apt-get update && echo 'x' > /etc/config
+`,
+			wantFixText: "apt-get update",
+			wantFixLack: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := testutil.MakeLintInputWithConfig(t, "Dockerfile", tt.content, nil)
+			violations := NewPreferCopyHeredocRule().Check(input)
+			if len(violations) == 0 {
+				t.Fatal("expected a violation")
+			}
+			fix := violations[0].SuggestedFix
+			if fix == nil || len(fix.Edits) == 0 {
+				t.Fatal("expected a fix")
+			}
+			got := fix.Edits[0].NewText
+			if !strings.Contains(got, tt.wantFixText) {
+				t.Errorf("fix text missing %q\nfull:\n%s", tt.wantFixText, got)
+			}
+			if tt.wantFixLack != "" && strings.Contains(got, tt.wantFixLack) {
+				t.Errorf("fix text should not contain %q\nfull:\n%s", tt.wantFixLack, got)
+			}
+		})
 	}
 }

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -878,7 +878,7 @@ func analyzeTeeCmd(
 		return other
 	}
 
-	if !teeRedirectsAreCompatible(stmt) {
+	if !teeRedirectsAreCompatible(stmt, true) {
 		return other
 	}
 
@@ -1012,12 +1012,23 @@ func isShellStateOnlyCmd(name string) bool {
 // (or its enclosing pipeline end) can be safely absorbed into a COPY. tee
 // echoes to stdout; a redirect to /dev/null is common and harmless, but
 // anything else (a real file, stderr) would be a side effect we can't drop.
-func teeRedirectsAreCompatible(stmt *syntax.Stmt) bool {
+//
+// allowInputHeredoc controls how a heredoc redirect is treated:
+//   - true: heredoc is tee's stdin (direct `tee /file <<EOF ... EOF` form),
+//     which is legitimate content we can reconstruct.
+//   - false: the caller is a `producer | tee /file` pipeline. A heredoc
+//     here would override the producer as tee's stdin (last input redirect
+//     wins in bash), so we cannot faithfully reconstruct content from the
+//     producer — reject the pattern.
+func teeRedirectsAreCompatible(stmt *syntax.Stmt, allowInputHeredoc bool) bool {
 	seenStdoutRedir := false
 	for _, redir := range stmt.Redirs {
 		switch redir.Op {
 		case syntax.Hdoc, syntax.DashHdoc:
-			// Heredoc input — stdin source for tee.
+			if !allowInputHeredoc {
+				return false
+			}
+			// Heredoc input — stdin source for direct tee.
 		case syntax.RdrOut, syntax.AppOut:
 			if seenStdoutRedir {
 				return false
@@ -1069,7 +1080,9 @@ func analyzePipeToTee(
 		return other, false
 	}
 
-	if !teeRedirectsAreCompatible(bin.Y) {
+	// Disallow heredoc on the pipe's tee side: it would override `producer`
+	// as tee's actual stdin, making producer content irrelevant.
+	if !teeRedirectsAreCompatible(bin.Y, false) {
 		return other, false
 	}
 

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -407,18 +407,13 @@ func analyzeFileCreation(
 		content.WriteString(c.content)
 	}
 
-	// Build preceding commands string
-	preceding := make([]string, 0, startIdx)
-	for i := range startIdx {
-		preceding = append(preceding, commands[i].text)
-	}
-
-	// Build remaining commands string
-	remainingCount := len(commands) - endIdx - 1
-	remaining := make([]string, 0, remainingCount)
-	for i := endIdx + 1; i < len(commands); i++ {
-		remaining = append(remaining, commands[i].text)
-	}
+	// Build preceding / remaining chains. Shell-state-only commands
+	// (`set -e`, `shopt`, `trap`) are dropped when *all* commands on the
+	// side are state-only, since shell options don't persist across RUN
+	// boundaries and preserving them alone would be pure noise. A mixed
+	// chain (state + real work) keeps everything.
+	preceding := collectNonStateOnlyChain(commands[:startIdx])
+	remaining := collectNonStateOnlyChain(commands[endIdx+1:])
 
 	// When umask-derived mode has no explicit raw string, format it
 	if chmodMode != 0 && rawChmodMode == "" {
@@ -659,6 +654,32 @@ func umaskDerivedChmodMode(activeUmask uint16, hasUmask bool) uint16 {
 		return 0
 	}
 	return effectiveMode
+}
+
+// collectNonStateOnlyChain returns the command texts of slice, dropping them
+// all when every entry is shell-state-only (e.g. `set -e`, `shopt`, `trap`).
+// Those commands don't cross RUN boundaries, so preserving them alone in a
+// leftover RUN is pure noise. A mix of state-only and real commands keeps
+// everything — the `set -e` guard matters when there's real work alongside.
+func collectNonStateOnlyChain(slice []analyzedCmd) []string {
+	if len(slice) == 0 {
+		return nil
+	}
+	allStateOnly := true
+	for _, cmd := range slice {
+		if !cmd.isShellState {
+			allStateOnly = false
+			break
+		}
+	}
+	if allStateOnly {
+		return nil
+	}
+	out := make([]string, 0, len(slice))
+	for _, cmd := range slice {
+		out = append(out, cmd.text)
+	}
+	return out
 }
 
 // collectCommands flattens && chains and collects all commands with their types.

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -82,6 +82,71 @@ type FileCreationOptions struct {
 	InterpretPlainEchoEscapes bool
 }
 
+// MultiFileCreationSlot describes a single file-creation sub-block inside a
+// chained script. Multiple slots can coexist when a RUN writes to several
+// distinct files in one && chain.
+type MultiFileCreationSlot struct {
+	// Info is the resolved creation for this slot (target, content, chmod, etc.).
+	Info FileCreationInfo
+	// CmdIndex is the index of the flattened command that produced this slot.
+	CmdIndex int
+	// EndIndex is the last contributing command index (inclusive).
+	EndIndex int
+}
+
+// MultiFileCreationInfo describes the set of file creations and interleaved
+// non-creation commands found in a single shell script. It is produced by
+// DetectFileCreations when the script has one or more distinct target paths.
+type MultiFileCreationInfo struct {
+	// Slots lists each distinct file creation in chain order.
+	Slots []MultiFileCreationSlot
+
+	// Commands is the flattened command list (file creations, chmods, umasks,
+	// and "other" commands) in original order. Non-creation commands are
+	// preserved verbatim so callers can emit them before/between COPYs.
+	Commands []MultiAnalyzedCmd
+
+	// HasUnsafeVariables is true if any command in the script uses unsafe
+	// variables (shell vars, command substitution, complex expansions).
+	HasUnsafeVariables bool
+
+	// ResolvedHomePath is true if any slot used tilde (~) expansion.
+	ResolvedHomePath bool
+}
+
+// MultiAnalyzedCmd is a per-command record exposed to callers alongside
+// MultiFileCreationInfo. It mirrors the internal analyzedCmd but is part of
+// the public API surface for rules that need to know which commands were
+// file creations vs other shell commands.
+type MultiAnalyzedCmd struct {
+	// Kind identifies how this command should be handled.
+	Kind MultiCmdKind
+	// Text is the original (printed) command text.
+	Text string
+	// SlotIndex points into MultiFileCreationInfo.Slots for Kind == MultiCmdCreation.
+	SlotIndex int
+	// MkdirTarget, for Kind == MultiCmdMkdirP, is the absolute directory path
+	// that `mkdir -p` would create. Empty for non-mkdir commands.
+	MkdirTarget string
+}
+
+// MultiCmdKind identifies the role of a command within a MultiFileCreationInfo.
+type MultiCmdKind int
+
+const (
+	// MultiCmdOther is a generic command we can't absorb into a COPY heredoc.
+	MultiCmdOther MultiCmdKind = iota
+	// MultiCmdCreation is a file-creation command contributing to Slots.
+	MultiCmdCreation
+	// MultiCmdChmod is a chmod command (already folded into the matching slot
+	// when possible; otherwise treated as "other").
+	MultiCmdChmod
+	// MultiCmdMkdirP is a `mkdir -p /path` command with a literal absolute path.
+	// Callers can elide it when a subsequent COPY creates the same (or a
+	// descendant) directory — BuildKit's COPY auto-creates parent directories.
+	MultiCmdMkdirP
+)
+
 // DetectFileCreation analyzes a shell script for file creation patterns.
 // Returns nil if the script is not primarily a file creation operation.
 //
@@ -125,6 +190,33 @@ func DetectFileCreationWithOptions(
 
 	// Analyze the script for file creation patterns
 	return analyzeFileCreation(prog, knownVars, options)
+}
+
+// DetectFileCreations analyzes a shell script and returns every distinct
+// file-creation target found in its && chain. Unlike DetectFileCreation it
+// does not collapse mixed scripts into preceding/remaining strings; instead
+// it returns the full flattened command list plus one slot per creation.
+// Returns nil if the script contains no recognizable file creation.
+func DetectFileCreations(
+	script string,
+	variant Variant,
+	knownVars func(name string) bool,
+	options FileCreationOptions,
+) *MultiFileCreationInfo {
+	if !variant.SupportsPOSIXShellAST() {
+		return nil
+	}
+
+	prog, err := parseScript(script, variant)
+	if err != nil {
+		return nil
+	}
+
+	if !isSimpleScriptFromAST(prog) {
+		return nil
+	}
+
+	return analyzeFileCreations(prog, knownVars, options)
 }
 
 // ChmodInfo describes a standalone chmod command.
@@ -333,6 +425,253 @@ func analyzeFileCreation(
 	}
 }
 
+// analyzeFileCreations performs multi-target file-creation analysis.
+// Unlike analyzeFileCreation it does not collapse to a single target; instead
+// it walks the flattened && chain and reports every distinct creation in
+// order, with interleaved non-creation commands preserved verbatim.
+func analyzeFileCreations(
+	prog *syntax.File,
+	knownVars func(name string) bool,
+	options FileCreationOptions,
+) *MultiFileCreationInfo {
+	if len(prog.Stmts) != 1 {
+		return nil
+	}
+
+	var commands []analyzedCmd
+	collectCommands(prog, &commands, knownVars, options)
+	if len(commands) == 0 {
+		return nil
+	}
+
+	// Compute an effective umask at each index for proper mode derivation.
+	umaskAt := make([]uint16, len(commands))
+	umaskSeen := make([]bool, len(commands))
+	var curUmask uint16
+	var curSeen bool
+	for i, cmd := range commands {
+		if cmd.cmdType == cmdTypeUmask {
+			curUmask = cmd.umaskValue
+			curSeen = true
+		}
+		umaskAt[i] = curUmask
+		umaskSeen[i] = curSeen
+	}
+
+	// Find contiguous creation blocks (file creations + chmod to same target).
+	// A new block starts whenever the target path differs from the previous
+	// creation, or a non-creation/non-matching-chmod command appears.
+	type blockRange struct {
+		start, end int
+		target     string
+	}
+	var blocks []blockRange
+	i := 0
+	for i < len(commands) {
+		cmd := commands[i]
+		if cmd.cmdType != cmdTypeFileCreation || cmd.creation == nil {
+			i++
+			continue
+		}
+		target := cmd.creation.targetPath
+		start := i
+		end := i
+		j := i + 1
+		for j < len(commands) {
+			next := commands[j]
+			switch {
+			case next.cmdType == cmdTypeFileCreation && next.creation != nil && next.creation.targetPath == target:
+				end = j
+				j++
+				continue
+			case next.cmdType == cmdTypeChmod && next.chmodTarget == target:
+				end = j
+				j++
+				continue
+			}
+			break
+		}
+		blocks = append(blocks, blockRange{start: start, end: end, target: target})
+		i = end + 1
+	}
+
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	// Build slots from blocks.
+	info := &MultiFileCreationInfo{}
+	// Track which command index belongs to which slot.
+	slotIndexByCmd := make(map[int]int, len(commands))
+	for _, blk := range blocks {
+		slot := buildSlotFromBlock(commands, blk.start, blk.end, blk.target, umaskAt, umaskSeen)
+		if slot == nil {
+			continue
+		}
+		slot.CmdIndex = blk.start
+		slot.EndIndex = blk.end
+		idx := len(info.Slots)
+		info.Slots = append(info.Slots, *slot)
+		for k := blk.start; k <= blk.end; k++ {
+			slotIndexByCmd[k] = idx
+		}
+	}
+
+	if len(info.Slots) == 0 {
+		return nil
+	}
+
+	// Emit a flat list of MultiAnalyzedCmd.
+	info.Commands = make([]MultiAnalyzedCmd, 0, len(commands))
+	for k, cmd := range commands {
+		entry := MultiAnalyzedCmd{Text: cmd.text, SlotIndex: -1}
+		if slotIdx, ok := slotIndexByCmd[k]; ok {
+			entry.Kind = MultiCmdCreation
+			entry.SlotIndex = slotIdx
+		} else {
+			switch cmd.cmdType {
+			case cmdTypeChmod:
+				entry.Kind = MultiCmdChmod
+			case cmdTypeFileCreation:
+				// Shouldn't happen: all creations are slot-mapped. Fall through.
+				entry.Kind = MultiCmdOther
+			default:
+				entry.Kind = MultiCmdOther
+				if target, ok := detectMkdirP(cmd.text); ok {
+					entry.Kind = MultiCmdMkdirP
+					entry.MkdirTarget = target
+				}
+			}
+		}
+		if cmd.hasUnsafe {
+			info.HasUnsafeVariables = true
+		}
+		info.Commands = append(info.Commands, entry)
+	}
+	for _, slot := range info.Slots {
+		if slot.Info.HasUnsafeVariables {
+			info.HasUnsafeVariables = true
+		}
+		if slot.Info.ResolvedHomePath {
+			info.ResolvedHomePath = true
+		}
+	}
+
+	return info
+}
+
+// buildSlotFromBlock constructs a MultiFileCreationSlot from a contiguous
+// block of commands, all targeting the same file path.
+func buildSlotFromBlock(
+	commands []analyzedCmd,
+	start, end int,
+	targetPath string,
+	umaskAt []uint16,
+	umaskSeen []bool,
+) *MultiFileCreationSlot {
+	var creations []fileCreationCmd
+	var chmodMode uint16
+	var rawChmodMode string
+	hasUnsafeVars := false
+	resolvedHomePath := false
+
+	for k := start; k <= end; k++ {
+		cmd := commands[k]
+		if cmd.hasUnsafe {
+			hasUnsafeVars = true
+		}
+		switch {
+		case cmd.cmdType == cmdTypeFileCreation && cmd.creation != nil:
+			creations = append(creations, *cmd.creation)
+			if cmd.creation.resolvedHomePath {
+				resolvedHomePath = true
+			}
+		case cmd.cmdType == cmdTypeChmod && cmd.chmodTarget == targetPath:
+			chmodMode = cmd.chmodMode
+			rawChmodMode = cmd.chmodRawMode
+		}
+	}
+
+	if len(creations) == 0 {
+		return nil
+	}
+
+	// umask contribution is read from the last umask seen at or before the block start.
+	if chmodMode == 0 && start < len(umaskAt) {
+		seenIdx := start
+		if seenIdx > 0 {
+			seenIdx = start - 1
+		}
+		if seenIdx < len(umaskAt) {
+			chmodMode = umaskDerivedChmodMode(umaskAt[seenIdx], umaskSeen[seenIdx])
+		}
+	}
+
+	var content strings.Builder
+	allAppend := true
+	for i, c := range creations {
+		if i > 0 && !c.isAppend {
+			content.Reset()
+		}
+		if !c.isAppend {
+			allAppend = false
+		}
+		content.WriteString(c.content)
+	}
+
+	if chmodMode != 0 && rawChmodMode == "" {
+		rawChmodMode = FormatOctalMode(chmodMode)
+	}
+
+	return &MultiFileCreationSlot{
+		Info: FileCreationInfo{
+			TargetPath:         targetPath,
+			ResolvedHomePath:   resolvedHomePath,
+			Content:            content.String(),
+			ChmodMode:          chmodMode,
+			RawChmodMode:       rawChmodMode,
+			IsAppend:           allAppend,
+			HasUnsafeVariables: hasUnsafeVars,
+		},
+	}
+}
+
+// detectMkdirP reports whether text is `mkdir -p <absolute path>` with a
+// single literal target. Other forms (multiple targets, --mode, relative
+// paths, variables) return false because we can't safely elide them.
+func detectMkdirP(text string) (string, bool) {
+	fields := strings.Fields(text)
+	if len(fields) < 3 || fields[0] != "mkdir" {
+		return "", false
+	}
+	sawP := false
+	var target string
+	for _, f := range fields[1:] {
+		switch {
+		case f == "-p", f == "--parents":
+			sawP = true
+		case strings.HasPrefix(f, "-"):
+			return "", false
+		default:
+			if target != "" {
+				return "", false
+			}
+			target = f
+		}
+	}
+	if !sawP || target == "" {
+		return "", false
+	}
+	// Strip matching surrounding quotes, if any; otherwise reject.
+	if strings.ContainsAny(target, "\"'`$") {
+		return "", false
+	}
+	if !path.IsAbs(target) {
+		return "", false
+	}
+	return path.Clean(target), true
+}
+
 // umaskDerivedChmodMode computes the effective chmod mode from a umask value.
 // Returns 0 if no umask was set or it matches the default (0o022 → 0o644).
 func umaskDerivedChmodMode(activeUmask uint16, hasUmask bool) uint16 {
@@ -371,11 +710,21 @@ func collectFromStatement(
 
 	switch cmd := stmt.Cmd.(type) {
 	case *syntax.BinaryCmd:
-		if cmd.Op == syntax.AndStmt {
+		switch cmd.Op {
+		case syntax.AndStmt:
 			collectFromStatement(cmd.X, commands, knownVars, options)
 			collectFromStatement(cmd.Y, commands, knownVars, options)
-		} else {
-			// Other binary ops (||, |) - treat as single opaque command
+		case syntax.Pipe, syntax.PipeAll:
+			if analyzed, ok := analyzePipeToTee(stmt, cmd, knownVars, options); ok {
+				*commands = append(*commands, analyzed)
+				return
+			}
+			*commands = append(*commands, analyzedCmd{
+				cmdType: cmdTypeOther,
+				text:    stmtToString(stmt),
+			})
+		default:
+			// Other binary ops (||) - treat as single opaque command
 			*commands = append(*commands, analyzedCmd{
 				cmdType: cmdTypeOther,
 				text:    stmtToString(stmt),
@@ -506,42 +855,9 @@ func analyzeTeeCmd(
 ) analyzedCmd {
 	other := analyzedCmd{cmdType: cmdTypeOther, text: text}
 
-	isAppend := false
-	var targetPath string
-	pastOptions := false
-
-	for i := 1; i < len(call.Args); i++ {
-		lit := call.Args[i].Lit()
-		if lit == "" {
-			return other // Non-literal argument (variable, etc.)
-		}
-
-		// "--" ends option parsing
-		if lit == "--" {
-			pastOptions = true
-			continue
-		}
-
-		// Parse flags (only before --)
-		if !pastOptions && strings.HasPrefix(lit, "-") && lit != "-" {
-			for _, r := range lit[1:] {
-				switch r {
-				case 'a':
-					isAppend = true
-				case 'i', 'p':
-					// -i (ignore interrupts), -p (diagnose errors) — safe to ignore
-				default:
-					return other // Unknown flag
-				}
-			}
-			continue
-		}
-
-		// File argument
-		if targetPath != "" {
-			return other // Multiple output files — can't convert to single COPY
-		}
-		targetPath = lit
+	targetPath, isAppend, ok := parseTeeTarget(call)
+	if !ok {
+		return other
 	}
 
 	targetPath, resolvedHomePath, ok := resolveFileCreationTarget(targetPath, resolveTargetPath)
@@ -549,29 +865,8 @@ func analyzeTeeCmd(
 		return other
 	}
 
-	// Validate redirects: allow heredoc input and at most one stdout
-	// redirect to /dev/null (tee echoes to stdout; suppress is common).
-	seenStdoutRedir := false
-	for _, redir := range stmt.Redirs {
-		switch redir.Op {
-		case syntax.Hdoc, syntax.DashHdoc:
-			// Heredoc input — this is the content source
-		case syntax.RdrOut, syntax.AppOut:
-			if seenStdoutRedir {
-				return other
-			}
-			if redir.N != nil && redir.N.Value != "1" {
-				return other // e.g. 2> — not stdout
-			}
-			if extractRedirectTarget(redir) != "/dev/null" {
-				return other // redirect to a real file — side effect we can't drop
-			}
-			seenStdoutRedir = true
-		case syntax.RdrIn, syntax.RdrInOut, syntax.DplIn, syntax.DplOut,
-			syntax.RdrClob, syntax.AppClob, syntax.WordHdoc,
-			syntax.RdrAll, syntax.RdrAllClob, syntax.AppAll, syntax.AppAllClob:
-			return other
-		}
+	if !teeRedirectsAreCompatible(stmt) {
+		return other
 	}
 
 	// Extract content from heredoc (same as cat — reads stdin)
@@ -588,6 +883,204 @@ func analyzeTeeCmd(
 		},
 		hasUnsafe: unsafe,
 	}
+}
+
+// parseTeeTarget parses tee's arguments and returns the single file target and
+// whether -a (append) was set. Returns ok=false if the form cannot be safely
+// converted to COPY (non-literal args, unknown flags, multiple output files).
+func parseTeeTarget(call *syntax.CallExpr) (target string, isAppend bool, ok bool) {
+	pastOptions := false
+	for i := 1; i < len(call.Args); i++ {
+		lit := call.Args[i].Lit()
+		if lit == "" {
+			return "", false, false
+		}
+
+		if lit == "--" {
+			pastOptions = true
+			continue
+		}
+
+		if !pastOptions && strings.HasPrefix(lit, "-") && lit != "-" {
+			for _, r := range lit[1:] {
+				switch r {
+				case 'a':
+					isAppend = true
+				case 'i', 'p':
+					// -i / -p are safe to ignore
+				default:
+					return "", false, false
+				}
+			}
+			continue
+		}
+
+		if target != "" {
+			return "", false, false
+		}
+		target = lit
+	}
+	return target, isAppend, true
+}
+
+// teeRedirectsAreCompatible reports whether the redirects on a tee statement
+// (or its enclosing pipeline end) can be safely absorbed into a COPY. tee
+// echoes to stdout; a redirect to /dev/null is common and harmless, but
+// anything else (a real file, stderr) would be a side effect we can't drop.
+func teeRedirectsAreCompatible(stmt *syntax.Stmt) bool {
+	seenStdoutRedir := false
+	for _, redir := range stmt.Redirs {
+		switch redir.Op {
+		case syntax.Hdoc, syntax.DashHdoc:
+			// Heredoc input — stdin source for tee.
+		case syntax.RdrOut, syntax.AppOut:
+			if seenStdoutRedir {
+				return false
+			}
+			if redir.N != nil && redir.N.Value != "1" {
+				return false
+			}
+			if extractRedirectTarget(redir) != "/dev/null" {
+				return false
+			}
+			seenStdoutRedir = true
+		case syntax.RdrIn, syntax.RdrInOut, syntax.DplIn, syntax.DplOut,
+			syntax.RdrClob, syntax.AppClob, syntax.WordHdoc,
+			syntax.RdrAll, syntax.RdrAllClob, syntax.AppAll, syntax.AppAllClob:
+			return false
+		}
+	}
+	return true
+}
+
+// analyzePipeToTee recognizes the pattern `producer | tee [-a] /path` and
+// converts it to a file-creation analyzed command. The producer can be a
+// single echo/cat/printf statement or a brace-group of such statements; their
+// output is concatenated and piped into tee.
+func analyzePipeToTee(
+	stmt *syntax.Stmt,
+	bin *syntax.BinaryCmd,
+	knownVars func(name string) bool,
+	options FileCreationOptions,
+) (analyzedCmd, bool) {
+	text := stmtToString(stmt)
+	other := analyzedCmd{cmdType: cmdTypeOther, text: text}
+
+	if bin.Y == nil || bin.Y.Cmd == nil {
+		return other, false
+	}
+	teeCall, ok := bin.Y.Cmd.(*syntax.CallExpr)
+	if !ok || len(teeCall.Args) == 0 || teeCall.Args[0].Lit() != cmdTee {
+		return other, false
+	}
+
+	target, isAppend, ok := parseTeeTarget(teeCall)
+	if !ok || target == "" {
+		return other, false
+	}
+
+	target, resolvedHomePath, ok := resolveFileCreationTarget(target, options.ResolveTargetPath)
+	if !ok {
+		return other, false
+	}
+
+	if !teeRedirectsAreCompatible(bin.Y) {
+		return other, false
+	}
+
+	// Producer side: echo/cat/printf statements that emit the file's content.
+	producers := flattenProducerStmts(bin.X)
+	if len(producers) == 0 {
+		return other, false
+	}
+
+	var content strings.Builder
+	hasUnsafe := false
+	for _, prod := range producers {
+		pc, prodUnsafe, ok := producerStmtContent(prod, knownVars, options)
+		if !ok {
+			return other, false
+		}
+		if prodUnsafe {
+			hasUnsafe = true
+		}
+		content.WriteString(pc)
+	}
+
+	return analyzedCmd{
+		cmdType: cmdTypeFileCreation,
+		text:    text,
+		creation: &fileCreationCmd{
+			targetPath:       target,
+			content:          content.String(),
+			isAppend:         isAppend,
+			resolvedHomePath: resolvedHomePath,
+		},
+		hasUnsafe: hasUnsafe,
+	}, true
+}
+
+// flattenProducerStmts returns the sequence of content-producing statements on
+// the left side of a pipe. Brace groups (`{ a; b; }`) are flattened to their
+// inner statements; a single statement is returned as-is.
+func flattenProducerStmts(stmt *syntax.Stmt) []*syntax.Stmt {
+	if stmt == nil || stmt.Cmd == nil {
+		return nil
+	}
+	// A brace group can't carry its own redirects — the pipe already sinks
+	// the whole group's output.
+	if _, isBlock := stmt.Cmd.(*syntax.Block); isBlock {
+		if len(stmt.Redirs) > 0 {
+			return nil
+		}
+		return stmt.Cmd.(*syntax.Block).Stmts
+	}
+	return []*syntax.Stmt{stmt}
+}
+
+// producerStmtContent extracts the stdout content a single producer statement
+// would emit. Only echo/cat/printf are recognized; any other command type
+// makes the producer ineligible for COPY conversion.
+func producerStmtContent(
+	stmt *syntax.Stmt,
+	knownVars func(name string) bool,
+	options FileCreationOptions,
+) (string, bool, bool) {
+	if stmt == nil || stmt.Cmd == nil {
+		return "", false, false
+	}
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Args) == 0 {
+		return "", false, false
+	}
+	// Only a heredoc redirect (for cat <<EOF) is acceptable on a producer;
+	// any stdout redirect would divert output away from the pipe, breaking
+	// the model we're converting to COPY.
+	for _, redir := range stmt.Redirs {
+		switch redir.Op {
+		case syntax.Hdoc, syntax.DashHdoc:
+			// OK — handled below for cat.
+		default:
+			return "", false, false
+		}
+	}
+	name := call.Args[0].Lit()
+	switch name {
+	case cmdEcho:
+		content, unsafe := extractEchoContent(call, knownVars, options.InterpretPlainEchoEscapes)
+		return content, unsafe, true
+	case cmdPrintf:
+		content, unsafe := extractPrintfContent(call, knownVars)
+		return content, unsafe, true
+	case cmdCat:
+		if len(call.Args) > 1 {
+			// cat with file args or flags: content depends on files we can't inline.
+			return "", true, true
+		}
+		content, unsafe := extractCatHeredocContentFromStmt(stmt)
+		return content, unsafe, true
+	}
+	return "", false, false
 }
 
 func resolveFileCreationTarget(

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -507,6 +507,20 @@ func analyzeFileCreations(
 		return nil
 	}
 
+	// Reject chains that write to the same target from more than one
+	// non-contiguous block (e.g. `echo a > /a && echo b > /b && echo c > /a`).
+	// Emitting one COPY per slot would silently overwrite earlier content
+	// or misrepresent append semantics — callers assume one slot per
+	// distinct target path. Merging non-contiguous same-target blocks is
+	// out of scope; reject as opaque for now.
+	seenTargets := make(map[string]struct{}, len(blocks))
+	for _, blk := range blocks {
+		if _, dup := seenTargets[blk.target]; dup {
+			return nil
+		}
+		seenTargets[blk.target] = struct{}{}
+	}
+
 	// Build slots from blocks.
 	info := &MultiFileCreationInfo{}
 	// Track which command index belongs to which slot.

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -485,6 +485,7 @@ func analyzeFileCreations(
 	info := &MultiFileCreationInfo{}
 	// Track which command index belongs to which slot.
 	slotIndexByCmd := make(map[int]int, len(commands))
+	slotIndexByTarget := make(map[string]int, len(blocks))
 	for _, blk := range blocks {
 		slot := buildSlotFromBlock(commands, blk.start, blk.end, blk.target, umaskAt, umaskSeen)
 		if slot == nil {
@@ -494,6 +495,7 @@ func analyzeFileCreations(
 		slot.EndIndex = blk.end
 		idx := len(info.Slots)
 		info.Slots = append(info.Slots, *slot)
+		slotIndexByTarget[blk.target] = idx
 		for k := blk.start; k <= blk.end; k++ {
 			slotIndexByCmd[k] = idx
 		}
@@ -502,6 +504,15 @@ func analyzeFileCreations(
 	if len(info.Slots) == 0 {
 		return nil
 	}
+
+	// Fold back trailing chmods that target an already-emitted slot. Example:
+	// `echo x > /a && echo y > /b && chmod 755 /a` — the chmod for /a breaks
+	// the /a block but its effect is purely on that slot's final mode, so we
+	// can attribute it to the /a slot and drop it from the standalone command
+	// stream. We only fold when the slot has no chmod yet; a chmod already
+	// in the block wins (last-write semantics) and a subsequent trailing
+	// chmod would contradict it, so skip the fold in that case.
+	absorbStandaloneChmods(commands, info, slotIndexByCmd, slotIndexByTarget)
 
 	// Emit a flat list of MultiAnalyzedCmd.
 	info.Commands = make([]MultiAnalyzedCmd, 0, len(commands))
@@ -676,6 +687,53 @@ func buildSlotFromBlock(
 			IsAppend:           allAppend,
 			HasUnsafeVariables: hasUnsafeVars,
 		},
+	}
+}
+
+// absorbStandaloneChmods folds `chmod <target>` commands that appear outside
+// any block (i.e. not captured by findCreationBlocks) back into the
+// matching slot when safe. This turns patterns like
+//
+//	echo x > /a && echo y > /b && chmod 755 /a
+//
+// into two clean `COPY --chmod=755 /a` / `COPY /b` heredocs instead of
+// emitting a standalone `RUN chmod 755 /a` after the /b COPY.
+//
+// Safety rules:
+//   - Only one block may exist for the target (guaranteed by the dedup pass
+//     at the callsite).
+//   - The slot must not already have a chmod: the in-block chmod wins by
+//     last-write semantics, and a *later* chmod contradicting it is the
+//     user's intent that we preserve verbatim rather than silently swap.
+//   - We walk all standalone chmod commands in source order, so the last
+//     trailing chmod for a target still wins over earlier trailing ones.
+func absorbStandaloneChmods(
+	commands []analyzedCmd,
+	info *MultiFileCreationInfo,
+	slotIndexByCmd map[int]int,
+	slotIndexByTarget map[string]int,
+) {
+	for i, cmd := range commands {
+		if cmd.cmdType != cmdTypeChmod {
+			continue
+		}
+		if _, inBlock := slotIndexByCmd[i]; inBlock {
+			continue
+		}
+		slotIdx, ok := slotIndexByTarget[cmd.chmodTarget]
+		if !ok {
+			continue
+		}
+		slot := &info.Slots[slotIdx]
+		if slot.Info.RawChmodMode != "" || slot.Info.ChmodMode != 0 {
+			// An in-block chmod already set the mode; a contradicting
+			// trailing chmod is the author's explicit intent — leave it
+			// as a standalone RUN rather than silently overwrite.
+			continue
+		}
+		slot.Info.RawChmodMode = cmd.chmodRawMode
+		slot.Info.ChmodMode = cmd.chmodMode
+		slotIndexByCmd[i] = slotIdx
 	}
 }
 

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -18,6 +18,7 @@ const (
 	cmdTee    = "tee"
 	cmdChmod  = "chmod"
 	cmdUmask  = "umask"
+	cmdMkdir  = "mkdir"
 )
 
 // FileCreationInfo describes a detected file creation pattern in a shell script.
@@ -296,6 +297,7 @@ const (
 	cmdTypeFileCreation
 	cmdTypeChmod
 	cmdTypeUmask
+	cmdTypeMkdirP
 )
 
 // analyzedCmd represents a command with its type and original text.
@@ -307,6 +309,7 @@ type analyzedCmd struct {
 	chmodRawMode string           // original mode string for cmdTypeChmod (e.g., "+x", "755")
 	chmodTarget  string           // non-empty for cmdTypeChmod
 	umaskValue   uint16           // non-zero for cmdTypeUmask (the mask value, e.g., 0o077)
+	mkdirTarget  string           // non-empty for cmdTypeMkdirP (absolute literal path)
 	hasUnsafe    bool
 }
 
@@ -532,15 +535,14 @@ func analyzeFileCreations(
 			switch cmd.cmdType {
 			case cmdTypeChmod:
 				entry.Kind = MultiCmdChmod
+			case cmdTypeMkdirP:
+				entry.Kind = MultiCmdMkdirP
+				entry.MkdirTarget = cmd.mkdirTarget
 			case cmdTypeFileCreation:
 				// Shouldn't happen: all creations are slot-mapped. Fall through.
 				entry.Kind = MultiCmdOther
 			default:
 				entry.Kind = MultiCmdOther
-				if target, ok := detectMkdirP(cmd.text); ok {
-					entry.Kind = MultiCmdMkdirP
-					entry.MkdirTarget = target
-				}
 			}
 		}
 		if cmd.hasUnsafe {
@@ -634,42 +636,6 @@ func buildSlotFromBlock(
 			HasUnsafeVariables: hasUnsafeVars,
 		},
 	}
-}
-
-// detectMkdirP reports whether text is `mkdir -p <absolute path>` with a
-// single literal target. Other forms (multiple targets, --mode, relative
-// paths, variables) return false because we can't safely elide them.
-func detectMkdirP(text string) (string, bool) {
-	fields := strings.Fields(text)
-	if len(fields) < 3 || fields[0] != "mkdir" {
-		return "", false
-	}
-	sawP := false
-	var target string
-	for _, f := range fields[1:] {
-		switch {
-		case f == "-p", f == "--parents":
-			sawP = true
-		case strings.HasPrefix(f, "-"):
-			return "", false
-		default:
-			if target != "" {
-				return "", false
-			}
-			target = f
-		}
-	}
-	if !sawP || target == "" {
-		return "", false
-	}
-	// Strip matching surrounding quotes, if any; otherwise reject.
-	if strings.ContainsAny(target, "\"'`$") {
-		return "", false
-	}
-	if !path.IsAbs(target) {
-		return "", false
-	}
-	return path.Clean(target), true
 }
 
 // umaskDerivedChmodMode computes the effective chmod mode from a umask value.
@@ -787,6 +753,18 @@ func analyzeCallExpr(
 	// Check for tee command (file target is in args, not redirects)
 	if cmdName == cmdTee {
 		return analyzeTeeCmd(stmt, call, text, options.ResolveTargetPath)
+	}
+
+	// Check for mkdir -p (for later absorption by COPY destinations)
+	if cmdName == cmdMkdir {
+		if target, ok := analyzeMkdirCmd(call); ok {
+			return analyzedCmd{
+				cmdType:     cmdTypeMkdirP,
+				text:        text,
+				mkdirTarget: target,
+			}
+		}
+		return analyzedCmd{cmdType: cmdTypeOther, text: text}
 	}
 
 	// Check for file creation commands
@@ -921,6 +899,65 @@ func parseTeeTarget(call *syntax.CallExpr) (target string, isAppend bool, ok boo
 		target = lit
 	}
 	return target, isAppend, true
+}
+
+// analyzeMkdirCmd parses a `mkdir` call and reports the single absolute
+// literal target when the form is `mkdir -p /abs/path` (or `--parents`).
+// Quoted paths work because the AST preserves the logical word regardless
+// of quoting. Returns ok=false for any form we can't safely absorb:
+//   - missing -p / --parents
+//   - additional flags (e.g. -m, --mode, -Z, -v)
+//   - multiple positional targets
+//   - non-literal target (variable, command substitution)
+//   - relative path
+func analyzeMkdirCmd(call *syntax.CallExpr) (string, bool) {
+	if call == nil || len(call.Args) < 3 {
+		return "", false
+	}
+	sawP := false
+	var target string
+	var targetSet bool
+	pastOptions := false
+	for i := 1; i < len(call.Args); i++ {
+		arg := call.Args[i]
+		lit := arg.Lit()
+
+		if !pastOptions && lit == "--" {
+			pastOptions = true
+			continue
+		}
+
+		// Flag tokens are always literal (they start with '-' before any quoting).
+		if !pastOptions && lit != "" && strings.HasPrefix(lit, "-") && lit != "-" {
+			switch lit {
+			case "-p", "--parents":
+				sawP = true
+			default:
+				// Unsupported flags (e.g. -m 0755, --mode=0755, -Z, -v) — skip fix.
+				return "", false
+			}
+			continue
+		}
+
+		// Positional: extract the logical word content, which expands quoted
+		// literals but still flags variable expansion / command substitution.
+		content, unsafeWord := extractWordContent(arg, nil)
+		if unsafeWord || content == "" {
+			return "", false
+		}
+		if targetSet {
+			return "", false
+		}
+		target = content
+		targetSet = true
+	}
+	if !sawP || !targetSet {
+		return "", false
+	}
+	if !path.IsAbs(target) {
+		return "", false
+	}
+	return path.Clean(target), true
 }
 
 // teeRedirectsAreCompatible reports whether the redirects on a tee statement
@@ -1136,8 +1173,9 @@ func findFileCreationBlock(commands []analyzedCmd) (int, int, string) {
 			} else {
 				return startIdx, endIdx, targetPath // Different target, stop
 			}
-		case cmdTypeOther, cmdTypeUmask:
-			// Other commands or umask after file creation don't affect the file
+		case cmdTypeOther, cmdTypeUmask, cmdTypeMkdirP:
+			// Other commands, umask, or mkdir after file creation don't
+			// affect the file we're building.
 			return startIdx, endIdx, targetPath
 		}
 	}

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -452,57 +452,9 @@ func analyzeFileCreations(
 		return nil
 	}
 
-	// Compute an effective umask at each index for proper mode derivation.
-	umaskAt := make([]uint16, len(commands))
-	umaskSeen := make([]bool, len(commands))
-	var curUmask uint16
-	var curSeen bool
-	for i, cmd := range commands {
-		if cmd.cmdType == cmdTypeUmask {
-			curUmask = cmd.umaskValue
-			curSeen = true
-		}
-		umaskAt[i] = curUmask
-		umaskSeen[i] = curSeen
-	}
+	umaskAt, umaskSeen := computeUmaskSnapshot(commands)
 
-	// Find contiguous creation blocks (file creations + chmod to same target).
-	// A new block starts whenever the target path differs from the previous
-	// creation, or a non-creation/non-matching-chmod command appears.
-	type blockRange struct {
-		start, end int
-		target     string
-	}
-	var blocks []blockRange
-	i := 0
-	for i < len(commands) {
-		cmd := commands[i]
-		if cmd.cmdType != cmdTypeFileCreation || cmd.creation == nil {
-			i++
-			continue
-		}
-		target := cmd.creation.targetPath
-		start := i
-		end := i
-		j := i + 1
-		for j < len(commands) {
-			next := commands[j]
-			switch {
-			case next.cmdType == cmdTypeFileCreation && next.creation != nil && next.creation.targetPath == target:
-				end = j
-				j++
-				continue
-			case next.cmdType == cmdTypeChmod && next.chmodTarget == target:
-				end = j
-				j++
-				continue
-			}
-			break
-		}
-		blocks = append(blocks, blockRange{start: start, end: end, target: target})
-		i = end + 1
-	}
-
+	blocks := findCreationBlocks(commands)
 	if len(blocks) == 0 {
 		return nil
 	}
@@ -560,7 +512,7 @@ func analyzeFileCreations(
 			case cmdTypeFileCreation:
 				// Shouldn't happen: all creations are slot-mapped. Fall through.
 				entry.Kind = MultiCmdOther
-			default:
+			case cmdTypeOther, cmdTypeUmask:
 				entry.Kind = MultiCmdOther
 			}
 		}
@@ -579,6 +531,68 @@ func analyzeFileCreations(
 	}
 
 	return info
+}
+
+// creationBlockRange describes a contiguous block of analyzedCmd entries that
+// all target the same file path (creation(s) optionally followed by chmod).
+type creationBlockRange struct {
+	start, end int
+	target     string
+}
+
+// computeUmaskSnapshot returns the effective umask value (and seen-flag) at
+// each command index, carrying forward the most recent `umask` call.
+func computeUmaskSnapshot(commands []analyzedCmd) ([]uint16, []bool) {
+	umaskAt := make([]uint16, len(commands))
+	umaskSeen := make([]bool, len(commands))
+	var curUmask uint16
+	var curSeen bool
+	for i, cmd := range commands {
+		if cmd.cmdType == cmdTypeUmask {
+			curUmask = cmd.umaskValue
+			curSeen = true
+		}
+		umaskAt[i] = curUmask
+		umaskSeen[i] = curSeen
+	}
+	return umaskAt, umaskSeen
+}
+
+// findCreationBlocks groups consecutive file-creation and matching-target
+// chmod commands into contiguous blocks. A new block starts whenever the
+// target path differs from the previous creation, or a non-creation /
+// non-matching-chmod command appears between them.
+func findCreationBlocks(commands []analyzedCmd) []creationBlockRange {
+	var blocks []creationBlockRange
+	i := 0
+	for i < len(commands) {
+		cmd := commands[i]
+		if cmd.cmdType != cmdTypeFileCreation || cmd.creation == nil {
+			i++
+			continue
+		}
+		target := cmd.creation.targetPath
+		start := i
+		end := i
+		j := i + 1
+		for j < len(commands) {
+			next := commands[j]
+			switch {
+			case next.cmdType == cmdTypeFileCreation && next.creation != nil && next.creation.targetPath == target:
+				end = j
+				j++
+				continue
+			case next.cmdType == cmdTypeChmod && next.chmodTarget == target:
+				end = j
+				j++
+				continue
+			}
+			break
+		}
+		blocks = append(blocks, creationBlockRange{start: start, end: end, target: target})
+		i = end + 1
+	}
+	return blocks
 }
 
 // buildSlotFromBlock constructs a MultiFileCreationSlot from a contiguous
@@ -734,8 +748,9 @@ func collectFromStatement(
 				cmdType: cmdTypeOther,
 				text:    stmtToString(stmt),
 			})
-		default:
-			// Other binary ops (||) - treat as single opaque command
+		case syntax.OrStmt:
+			// || chains are treated as a single opaque command (the
+			// fallback branch has different semantics from && splitting).
 			*commands = append(*commands, analyzedCmd{
 				cmdType: cmdTypeOther,
 				text:    stmtToString(stmt),
@@ -915,7 +930,7 @@ func analyzeTeeCmd(
 // parseTeeTarget parses tee's arguments and returns the single file target and
 // whether -a (append) was set. Returns ok=false if the form cannot be safely
 // converted to COPY (non-literal args, unknown flags, multiple output files).
-func parseTeeTarget(call *syntax.CallExpr) (target string, isAppend bool, ok bool) {
+func parseTeeTarget(call *syntax.CallExpr) (target string, isAppend, ok bool) {
 	pastOptions := false
 	for i := 1; i < len(call.Args); i++ {
 		lit := call.Args[i].Lit()
@@ -1146,11 +1161,11 @@ func flattenProducerStmts(stmt *syntax.Stmt) []*syntax.Stmt {
 	}
 	// A brace group can't carry its own redirects — the pipe already sinks
 	// the whole group's output.
-	if _, isBlock := stmt.Cmd.(*syntax.Block); isBlock {
+	if block, isBlock := stmt.Cmd.(*syntax.Block); isBlock {
 		if len(stmt.Redirs) > 0 {
 			return nil
 		}
-		return stmt.Cmd.(*syntax.Block).Stmts
+		return block.Stmts
 	}
 	return []*syntax.Stmt{stmt}
 }
@@ -1177,7 +1192,10 @@ func producerStmtContent(
 		switch redir.Op {
 		case syntax.Hdoc, syntax.DashHdoc:
 			// OK — handled below for cat.
-		default:
+		case syntax.RdrOut, syntax.AppOut,
+			syntax.RdrIn, syntax.RdrInOut, syntax.DplIn, syntax.DplOut,
+			syntax.RdrClob, syntax.AppClob, syntax.WordHdoc,
+			syntax.RdrAll, syntax.RdrAllClob, syntax.AppAll, syntax.AppAllClob:
 			return "", false, false
 		}
 	}

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -129,6 +129,11 @@ type MultiAnalyzedCmd struct {
 	// MkdirTarget, for Kind == MultiCmdMkdirP, is the absolute directory path
 	// that `mkdir -p` would create. Empty for non-mkdir commands.
 	MkdirTarget string
+	// IsShellStateOnly is true for commands that only mutate the current
+	// shell's options and don't cross RUN boundaries (e.g. `set -ex`,
+	// `shopt -s nullglob`). Fix builders can drop such commands when they
+	// would otherwise be left alone in a RUN that no longer hosts real work.
+	IsShellStateOnly bool
 }
 
 // MultiCmdKind identifies the role of a command within a MultiFileCreationInfo.
@@ -311,6 +316,11 @@ type analyzedCmd struct {
 	umaskValue   uint16           // non-zero for cmdTypeUmask (the mask value, e.g., 0o077)
 	mkdirTarget  string           // non-empty for cmdTypeMkdirP (absolute literal path)
 	hasUnsafe    bool
+	// isShellState is true for commands that only mutate the current shell's
+	// options (`set`, `shopt`). They have no effect across RUNs — each RUN
+	// starts a fresh shell — so fix builders can drop them when they'd end
+	// up alone in a leftover RUN buffer.
+	isShellState bool
 }
 
 // analyzeFileCreation performs detailed analysis of file creation patterns.
@@ -527,7 +537,7 @@ func analyzeFileCreations(
 	// Emit a flat list of MultiAnalyzedCmd.
 	info.Commands = make([]MultiAnalyzedCmd, 0, len(commands))
 	for k, cmd := range commands {
-		entry := MultiAnalyzedCmd{Text: cmd.text, SlotIndex: -1}
+		entry := MultiAnalyzedCmd{Text: cmd.text, SlotIndex: -1, IsShellStateOnly: cmd.isShellState}
 		if slotIdx, ok := slotIndexByCmd[k]; ok {
 			entry.Kind = MultiCmdCreation
 			entry.SlotIndex = slotIdx
@@ -769,7 +779,11 @@ func analyzeCallExpr(
 
 	// Check for file creation commands
 	if cmdName != cmdEcho && cmdName != cmdCat && cmdName != cmdPrintf {
-		return analyzedCmd{cmdType: cmdTypeOther, text: text}
+		return analyzedCmd{
+			cmdType:      cmdTypeOther,
+			text:         text,
+			isShellState: isShellStateOnlyCmd(cmdName),
+		}
 	}
 
 	// Validate redirects: allow exactly one stdout output redirect and
@@ -958,6 +972,19 @@ func analyzeMkdirCmd(call *syntax.CallExpr) (string, bool) {
 		return "", false
 	}
 	return path.Clean(target), true
+}
+
+// isShellStateOnlyCmd reports whether a command name is known to only
+// affect the current shell's options (e.g. `set -e`, `shopt -s nullglob`,
+// `trap -`). Such commands never cross RUN boundaries — each RUN starts a
+// fresh shell — so a leftover RUN that contains nothing but these can be
+// dropped entirely.
+func isShellStateOnlyCmd(name string) bool {
+	switch name {
+	case "set", "shopt", "trap":
+		return true
+	}
+	return false
 }
 
 // teeRedirectsAreCompatible reports whether the redirects on a tee statement

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -87,7 +87,15 @@ type FileCreationOptions struct {
 // chained script. Multiple slots can coexist when a RUN writes to several
 // distinct files in one && chain.
 type MultiFileCreationSlot struct {
-	// Info is the resolved creation for this slot (target, content, chmod, etc.).
+	// Info is the resolved creation for this slot: target, content, chmod,
+	// append flag, unsafe-variable flag, and home-path resolution flag.
+	//
+	// Note: Info.PrecedingCommands and Info.RemainingCommands are always
+	// empty on slots produced by the multi-target path (buildSlotFromBlock).
+	// Use MultiFileCreationInfo.Commands (the flattened command list) to
+	// reconstruct ordering between slots and non-creation commands. The
+	// preceding/remaining fields are only populated by the single-target
+	// entry point, DetectFileCreation.
 	Info FileCreationInfo
 	// CmdIndex is the index of the flattened command that produced this slot.
 	CmdIndex int

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -996,13 +996,18 @@ func analyzeMkdirCmd(call *syntax.CallExpr) (string, bool) {
 }
 
 // isShellStateOnlyCmd reports whether a command name is known to only
-// affect the current shell's options (e.g. `set -e`, `shopt -s nullglob`,
-// `trap -`). Such commands never cross RUN boundaries — each RUN starts a
-// fresh shell — so a leftover RUN that contains nothing but these can be
+// affect the current shell's options (e.g. `set -e`, `shopt -s nullglob`).
+// Such commands never cross RUN boundaries — each RUN starts a fresh
+// shell — so a leftover RUN that contains nothing but these can be
 // dropped entirely.
+//
+// `trap` is intentionally excluded: the registered handler body can run
+// within the same RUN (e.g. on EXIT) and can mutate the image. Dropping
+// the trap would silently lose that side effect. Preserving all `trap`
+// invocations is safer than trying to prove a particular form is inert.
 func isShellStateOnlyCmd(name string) bool {
 	switch name {
-	case "set", "shopt", "trap":
+	case "set", "shopt":
 		return true
 	}
 	return false

--- a/internal/shell/file_creation.go
+++ b/internal/shell/file_creation.go
@@ -1172,8 +1172,12 @@ func producerStmtContent(
 		return content, unsafe, true
 	case cmdCat:
 		if len(call.Args) > 1 {
-			// cat with file args or flags: content depends on files we can't inline.
-			return "", true, true
+			// `cat /some/file` (or `cat -flag`) reads from a source we
+			// can't inline at lint time, so the producer's content is
+			// statically unknown. Returning ok=false makes the whole
+			// pipe fall through as opaque rather than creating a
+			// file-creation slot with empty/misleading content.
+			return "", false, false
 		}
 		content, unsafe := extractCatHeredocContentFromStmt(stmt)
 		return content, unsafe, true

--- a/internal/shell/file_creation_test.go
+++ b/internal/shell/file_creation_test.go
@@ -1155,6 +1155,38 @@ func TestDetectFileCreationPipeToTee(t *testing.T) {
 	}
 }
 
+// TestDetectFileCreations_RepeatedTargetRejected locks in that a chain
+// which writes to the same target more than once across non-contiguous
+// blocks (e.g. `echo a > /a && echo b > /b && echo c > /a`) is rejected.
+// Emitting one COPY per slot would silently overwrite earlier content or
+// misrepresent append semantics.
+func TestDetectFileCreations_RepeatedTargetRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{
+			name:   "overwrite then append to earlier target",
+			script: `echo a > /a && echo b > /b && echo c >> /a`,
+		},
+		{
+			name:   "overwrite to earlier target via interleaved second target",
+			script: `echo a > /a && echo b > /b && echo c > /a`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := DetectFileCreations(tt.script, VariantBash, nil, FileCreationOptions{})
+			if got != nil {
+				t.Errorf("expected nil for repeated-target chain, got slots: %+v", got.Slots)
+			}
+		})
+	}
+}
+
 func TestDetectFileCreations_MultiTarget(t *testing.T) {
 	t.Parallel()
 

--- a/internal/shell/file_creation_test.go
+++ b/internal/shell/file_creation_test.go
@@ -1104,6 +1104,15 @@ func TestDetectFileCreationPipeToTee(t *testing.T) {
 			wantPath:    "/etc/config",
 			wantContent: "hello\nworld\n",
 		},
+		{
+			// Heredoc attached to tee on the pipe RHS redirects tee's stdin
+			// (last input redirect wins in bash), so the producer's output
+			// is discarded. We can't faithfully reconstruct COPY content
+			// from the producer in this case — reject the pattern.
+			name:    "producer piped to tee with heredoc on tee - skip",
+			script:  "echo ignored | tee /etc/config <<EOF\nactual heredoc\nEOF",
+			wantNil: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/shell/file_creation_test.go
+++ b/internal/shell/file_creation_test.go
@@ -1187,6 +1187,83 @@ func TestDetectFileCreations_RepeatedTargetRejected(t *testing.T) {
 	}
 }
 
+// TestDetectFileCreations_TrailingChmodFoldedBack covers the edge case
+// where a `chmod` for an earlier target appears after an intervening
+// creation of a *different* target — e.g. `echo x > /a && echo y > /b &&
+// chmod 755 /a`. The chmod should be folded back into the earlier /a
+// slot so the fix emits `COPY --chmod=755 /a` rather than a standalone
+// `RUN chmod 755 /a`.
+func TestDetectFileCreations_TrailingChmodFoldedBack(t *testing.T) {
+	t.Parallel()
+
+	script := `echo x > /a && echo y > /b && chmod 755 /a`
+	got := DetectFileCreations(script, VariantBash, nil, FileCreationOptions{})
+	if got == nil {
+		t.Fatal("expected non-nil MultiFileCreationInfo")
+	}
+
+	if len(got.Slots) != 2 {
+		t.Fatalf("got %d slots, want 2", len(got.Slots))
+	}
+	// Slot[0] is /a with the folded chmod.
+	if got.Slots[0].Info.TargetPath != "/a" {
+		t.Errorf("slot[0] TargetPath = %q, want /a", got.Slots[0].Info.TargetPath)
+	}
+	if got.Slots[0].Info.RawChmodMode != "755" {
+		t.Errorf("slot[0] RawChmodMode = %q, want 755 (chmod should be folded into the /a slot)",
+			got.Slots[0].Info.RawChmodMode)
+	}
+	// Slot[1] is /b, unchanged, no chmod.
+	if got.Slots[1].Info.TargetPath != "/b" {
+		t.Errorf("slot[1] TargetPath = %q, want /b", got.Slots[1].Info.TargetPath)
+	}
+	if got.Slots[1].Info.RawChmodMode != "" {
+		t.Errorf("slot[1] RawChmodMode = %q, want empty", got.Slots[1].Info.RawChmodMode)
+	}
+
+	// The trailing chmod should no longer appear as a standalone command.
+	for _, cmd := range got.Commands {
+		if cmd.Kind == MultiCmdChmod {
+			t.Errorf("chmod for a slot target should be absorbed, saw leftover Chmod command %q", cmd.Text)
+		}
+	}
+}
+
+// TestDetectFileCreations_TrailingChmodNotFoldedOverExisting verifies that
+// a trailing chmod for a slot that *already* has an in-block chmod is not
+// silently folded in (last-write semantics would be contradicted). It is
+// preserved as a standalone Chmod command so the author's intent surfaces
+// in the fix.
+func TestDetectFileCreations_TrailingChmodNotFoldedOverExisting(t *testing.T) {
+	t.Parallel()
+
+	// /a gets an in-block chmod 644, then later a standalone chmod 755.
+	script := `echo x > /a && chmod 644 /a && echo y > /b && chmod 755 /a`
+	got := DetectFileCreations(script, VariantBash, nil, FileCreationOptions{})
+	if got == nil {
+		t.Fatal("expected non-nil MultiFileCreationInfo")
+	}
+	if len(got.Slots) != 2 {
+		t.Fatalf("got %d slots, want 2", len(got.Slots))
+	}
+	// Slot[0] keeps the in-block chmod.
+	if got.Slots[0].Info.RawChmodMode != "644" {
+		t.Errorf("slot[0] RawChmodMode = %q, want 644 (in-block chmod must win)",
+			got.Slots[0].Info.RawChmodMode)
+	}
+	// The trailing chmod 755 /a must remain as a standalone command.
+	var sawStandaloneChmod bool
+	for _, cmd := range got.Commands {
+		if cmd.Kind == MultiCmdChmod {
+			sawStandaloneChmod = true
+			break
+		}
+	}
+	if !sawStandaloneChmod {
+		t.Error("expected the trailing chmod to remain as a standalone command (don't silently contradict the in-block chmod)")
+	}
+}
+
 func TestDetectFileCreations_MultiTarget(t *testing.T) {
 	t.Parallel()
 

--- a/internal/shell/file_creation_test.go
+++ b/internal/shell/file_creation_test.go
@@ -1204,17 +1204,24 @@ func TestDetectFileCreations_MultiTarget(t *testing.T) {
 		t.Errorf("HasUnsafeVariables = true, want false")
 	}
 
-	wantTargets := []string{"/etc/one.conf", "/var/app/config", "/etc/three.ini"}
-	if len(got.Slots) != len(wantTargets) {
-		t.Fatalf("got %d slots, want %d", len(got.Slots), len(wantTargets))
+	wantSlots := []struct {
+		target  string
+		content string
+	}{
+		{"/etc/one.conf", "a=1\nb=2\n"},
+		{"/var/app/config", "x\n"},
+		{"/etc/three.ini", "y\n"},
 	}
-	for i, want := range wantTargets {
-		if got.Slots[i].Info.TargetPath != want {
-			t.Errorf("slot[%d] TargetPath = %q, want %q", i, got.Slots[i].Info.TargetPath, want)
+	if len(got.Slots) != len(wantSlots) {
+		t.Fatalf("got %d slots, want %d", len(got.Slots), len(wantSlots))
+	}
+	for i, want := range wantSlots {
+		if got.Slots[i].Info.TargetPath != want.target {
+			t.Errorf("slot[%d] TargetPath = %q, want %q", i, got.Slots[i].Info.TargetPath, want.target)
 		}
-	}
-	if got := got.Slots[0].Info.Content; got != "a=1\nb=2\n" {
-		t.Errorf("slot[0] Content = %q, want %q", got, "a=1\nb=2\n")
+		if got.Slots[i].Info.Content != want.content {
+			t.Errorf("slot[%d] Content = %q, want %q", i, got.Slots[i].Info.Content, want.content)
+		}
 	}
 
 	// mkdir -p should be recognized so callers can elide it.

--- a/internal/shell/file_creation_test.go
+++ b/internal/shell/file_creation_test.go
@@ -1041,6 +1041,166 @@ func TestDetectFileCreationWithUmask(t *testing.T) {
 	}
 }
 
+func TestDetectFileCreationPipeToTee(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		script      string
+		wantNil     bool
+		wantPath    string
+		wantContent string
+		wantAppend  bool
+	}{
+		{
+			name:        "single echo piped to tee",
+			script:      `echo 'hello' | tee /etc/config`,
+			wantPath:    "/etc/config",
+			wantContent: "hello\n",
+		},
+		{
+			name:        "brace group of echos piped to tee",
+			script:      `{ echo 'a'; echo 'b'; echo 'c'; } | tee /etc/config`,
+			wantPath:    "/etc/config",
+			wantContent: "a\nb\nc\n",
+		},
+		{
+			name:        "brace group piped to tee -a",
+			script:      `{ echo 'a'; echo 'b'; } | tee -a /etc/config`,
+			wantPath:    "/etc/config",
+			wantContent: "a\nb\n",
+			wantAppend:  true,
+		},
+		{
+			name:        "pipe tee with stdout /dev/null",
+			script:      `{ echo 'x'; } | tee /etc/config > /dev/null`,
+			wantPath:    "/etc/config",
+			wantContent: "x\n",
+		},
+		{
+			name:    "pipe to tee with relative path - skip",
+			script:  `{ echo 'x'; } | tee config.txt`,
+			wantNil: true,
+		},
+		{
+			name:    "pipe to non-tee command",
+			script:  `{ echo 'x'; } | cat > /etc/config`,
+			wantNil: true,
+		},
+		{
+			name:        "brace group of printf piped to tee",
+			script:      `{ printf 'a\n'; printf 'b\n'; } | tee /etc/config`,
+			wantPath:    "/etc/config",
+			wantContent: "a\nb\n",
+		},
+		{
+			name:        "brace group mixing echo and printf",
+			script:      `{ echo 'a'; printf 'b\n'; echo 'c'; } | tee /etc/config`,
+			wantPath:    "/etc/config",
+			wantContent: "a\nb\nc\n",
+		},
+		{
+			name:        "cat heredoc piped to tee",
+			script:      "cat <<EOF | tee /etc/config\nhello\nworld\nEOF",
+			wantPath:    "/etc/config",
+			wantContent: "hello\nworld\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := DetectFileCreation(tt.script, VariantBash, nil)
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %+v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if result.TargetPath != tt.wantPath {
+				t.Errorf("TargetPath = %q, want %q", result.TargetPath, tt.wantPath)
+			}
+			if result.Content != tt.wantContent {
+				t.Errorf("Content = %q, want %q", result.Content, tt.wantContent)
+			}
+			if result.IsAppend != tt.wantAppend {
+				t.Errorf("IsAppend = %v, want %v", result.IsAppend, tt.wantAppend)
+			}
+		})
+	}
+}
+
+func TestDetectFileCreations_MultiTarget(t *testing.T) {
+	t.Parallel()
+
+	script := `set -ex ` +
+		`&& { echo 'a=1'; echo 'b=2'; } | tee /etc/one.conf ` +
+		`&& mkdir -p /var/app ` +
+		`&& { echo 'x'; } | tee /var/app/config ` +
+		`&& { echo 'y'; } | tee /etc/three.ini`
+
+	got := DetectFileCreations(script, VariantBash, nil, FileCreationOptions{})
+	if got == nil {
+		t.Fatal("expected non-nil MultiFileCreationInfo")
+	}
+	if got.HasUnsafeVariables {
+		t.Errorf("HasUnsafeVariables = true, want false")
+	}
+
+	wantTargets := []string{"/etc/one.conf", "/var/app/config", "/etc/three.ini"}
+	if len(got.Slots) != len(wantTargets) {
+		t.Fatalf("got %d slots, want %d", len(got.Slots), len(wantTargets))
+	}
+	for i, want := range wantTargets {
+		if got.Slots[i].Info.TargetPath != want {
+			t.Errorf("slot[%d] TargetPath = %q, want %q", i, got.Slots[i].Info.TargetPath, want)
+		}
+	}
+	if got := got.Slots[0].Info.Content; got != "a=1\nb=2\n" {
+		t.Errorf("slot[0] Content = %q, want %q", got, "a=1\nb=2\n")
+	}
+
+	// mkdir -p should be recognized so callers can elide it.
+	var sawMkdir bool
+	for _, c := range got.Commands {
+		if c.Kind == MultiCmdMkdirP && c.MkdirTarget == "/var/app" {
+			sawMkdir = true
+		}
+	}
+	if !sawMkdir {
+		t.Errorf("expected a MultiCmdMkdirP for /var/app in commands")
+	}
+}
+
+func TestDetectMkdirP(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		text       string
+		wantTarget string
+		wantOk     bool
+	}{
+		{"mkdir -p /var/app", "/var/app", true},
+		{"mkdir --parents /var/app", "/var/app", true},
+		{"mkdir /var/app", "", false},                // missing -p
+		{"mkdir -p /a /b", "", false},                // multiple targets
+		{"mkdir -p var/app", "", false},              // relative path
+		{"mkdir -p --mode=0755 /var/app", "", false}, // unsupported flag
+		{"mkdir -p \"/var/app\"", "", false},         // quoted arg
+		{"echo hi", "", false},                       // not mkdir
+	}
+	for _, tt := range tests {
+		t.Run(tt.text, func(t *testing.T) {
+			t.Parallel()
+			target, ok := detectMkdirP(tt.text)
+			if ok != tt.wantOk || target != tt.wantTarget {
+				t.Errorf("detectMkdirP(%q) = (%q, %v), want (%q, %v)", tt.text, target, ok, tt.wantTarget, tt.wantOk)
+			}
+		})
+	}
+}
+
 func TestParseUmask(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/shell/file_creation_test.go
+++ b/internal/shell/file_creation_test.go
@@ -1113,6 +1113,20 @@ func TestDetectFileCreationPipeToTee(t *testing.T) {
 			script:  "echo ignored | tee /etc/config <<EOF\nactual heredoc\nEOF",
 			wantNil: true,
 		},
+		{
+			// `cat /some/file` reads from a file we can't inline at lint
+			// time, so the producer content is statically unknown — the
+			// whole pipe must fall through as opaque.
+			name:    "cat file-arg piped to tee - skip",
+			script:  `cat /etc/hosts | tee /etc/config`,
+			wantNil: true,
+		},
+		{
+			// Same reasoning for cat with flags (`-n`, `-A`, etc.).
+			name:    "cat flag piped to tee - skip",
+			script:  `cat -n /etc/hosts | tee /etc/config`,
+			wantNil: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/shell/file_creation_test.go
+++ b/internal/shell/file_creation_test.go
@@ -1174,28 +1174,51 @@ func TestDetectFileCreations_MultiTarget(t *testing.T) {
 	}
 }
 
-func TestDetectMkdirP(t *testing.T) {
+func TestAnalyzeMkdirCmd(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		text       string
+		script     string
 		wantTarget string
 		wantOk     bool
 	}{
 		{"mkdir -p /var/app", "/var/app", true},
 		{"mkdir --parents /var/app", "/var/app", true},
+		// Quoted forms: the AST resolves to the logical word, so these
+		// should all succeed.
+		{`mkdir -p "/var/app"`, "/var/app", true},
+		{`mkdir -p '/var/app'`, "/var/app", true},
+		{`mkdir -p "/path with spaces/sub"`, "/path with spaces/sub", true},
+		{`mkdir -p '/var/app'/sub`, "/var/app/sub", true},
+		// -- ends option parsing, so target after is positional.
+		{"mkdir -p -- /var/app", "/var/app", true},
+
+		// Rejected forms
 		{"mkdir /var/app", "", false},                // missing -p
 		{"mkdir -p /a /b", "", false},                // multiple targets
 		{"mkdir -p var/app", "", false},              // relative path
 		{"mkdir -p --mode=0755 /var/app", "", false}, // unsupported flag
-		{"mkdir -p \"/var/app\"", "", false},         // quoted arg
-		{"echo hi", "", false},                       // not mkdir
+		{"mkdir -p -m 0755 /var/app", "", false},     // unsupported flag
+		{"mkdir -pv /var/app", "", false},            // combined flags: -pv not recognized as only -p
+		{"mkdir -p $HOME/app", "", false},            // variable expansion
+		{"mkdir -p $(dirname /foo/bar)", "", false},  // command substitution
 	}
 	for _, tt := range tests {
-		t.Run(tt.text, func(t *testing.T) {
+		t.Run(tt.script, func(t *testing.T) {
 			t.Parallel()
-			target, ok := detectMkdirP(tt.text)
-			if ok != tt.wantOk || target != tt.wantTarget {
-				t.Errorf("detectMkdirP(%q) = (%q, %v), want (%q, %v)", tt.text, target, ok, tt.wantTarget, tt.wantOk)
+			prog, err := parseScript(tt.script, VariantBash)
+			if err != nil {
+				t.Fatalf("parseScript failed: %v", err)
+			}
+			if len(prog.Stmts) == 0 {
+				t.Fatal("no statements parsed")
+			}
+			call, ok := prog.Stmts[0].Cmd.(*syntax.CallExpr)
+			if !ok {
+				t.Fatalf("expected CallExpr, got %T", prog.Stmts[0].Cmd)
+			}
+			target, gotOk := analyzeMkdirCmd(call)
+			if gotOk != tt.wantOk || target != tt.wantTarget {
+				t.Errorf("analyzeMkdirCmd(%q) = (%q, %v), want (%q, %v)", tt.script, target, gotOk, tt.wantTarget, tt.wantOk)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Recognize `{ echo ...; echo ...; } | tee /path` (and mixes of `echo` / `printf` / `cat <<EOF`) as a file creation, not an opaque pipe.
- Split a single RUN that creates multiple distinct files via an `&&` chain into one COPY heredoc per target (a single COPY can't address multiple destinations, so this is the cleanest shape available).
- Absorb leading `mkdir -p /parent` when a following COPY writes under `/parent` — BuildKit COPY auto-creates parent directories, so the `mkdir` is redundant and would just litter the RUN.
- Preserve leading non-creation commands (e.g. `set -ex`) as a surrounding `RUN`.

### Before

```Dockerfile
RUN set -ex \
    && { echo '[global]'; echo 'daemonize = no'; } | tee /usr/local/etc/php-fpm.d/www.conf \
    && mkdir -p /usr/local/php/php/auto_prepends \
    && { echo '<?php'; echo '?>'; } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
    && { echo 'FromLineOverride=YES'; echo 'UseTLS=NO'; } | tee /etc/ssmtp/ssmtp.conf \
    && { echo '[PHP]'; echo 'log_errors = On'; } | tee /usr/local/etc/php/conf.d/php.ini
```

### After

```Dockerfile
RUN set -ex
COPY <<EOF /usr/local/etc/php-fpm.d/www.conf
[global]
daemonize = no
EOF
COPY <<EOF /usr/local/php/php/auto_prepends/default_prepend.php
<?php
?>
EOF
COPY <<EOF /etc/ssmtp/ssmtp.conf
FromLineOverride=YES
UseTLS=NO
EOF
COPY <<EOF /usr/local/etc/php/conf.d/php.ini
[PHP]
log_errors = On
EOF
```

## Implementation notes
- New public shell API: `DetectFileCreations` / `MultiFileCreationInfo` / `MultiAnalyzedCmd`. The existing `DetectFileCreation` (singular) is unchanged so downstream callers in `facts/` keep their semantics.
- Producer detection for pipe→tee covers `echo`, `printf`, `cat <<EOF`, and brace-groups of those. Command substitution, unknown flags, stderr redirects, etc. fall through to "other" and skip the fix (same safety bar as the existing single-target path).
- mkdir-absorption uses the existing `isPathUnder` helper, so `mkdir -p /a/b` is absorbed when any COPY destination sits at or under `/a/b`.
- Fix-safety stays at `FixSuggestion` (or `FixUnsafe` if a slot used tilde expansion), matching the single-target path.

## Test plan
- [x] `go test ./internal/shell/... ./internal/rules/tally/...` — new + existing tests pass
- [x] `go vet ./internal/shell/ ./internal/rules/tally/` clean
- [ ] Integration tests & `make lint` (require `make shellcheck-wasm`, covered in CI)

New tests:
- `TestDetectFileCreationPipeToTee` — single/grouped/mixed producers, append, stdout suppression, relative-path skip
- `TestDetectFileCreations_MultiTarget` — end-to-end multi-target AST shape
- `TestDetectMkdirP` — flag handling
- `TestPreferCopyHeredocRule_PhpFpmStyleMultiTargetFix` & `..._PhpFpmStyleFullFix` — the real-world RUN from the feature request

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects multiple file creations in a single shell RUN and suggests splitting them into separate heredoc COPY blocks; handles tee/pipe producers and safe mkdir -p cases.

* **Bug Fixes / Formatting**
  * Suggested fixes collapse redundant mkdir/state-only commands, preserve intervening real commands, and ensure proper blank-line padding around emitted COPY heredocs.

* **Tests**
  * Expanded tests apply fixes and verify multi-target, tee/pipe, mkdir, chmod, and blank-line formatting behaviors.

* **Documentation**
  * Rule docs updated with motivation, examples, and multi-target heredoc guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->