### PR TITLE
feat(rules): add tally/prefer-nginx-sigquit

### DIFF
--- a/_docs/docs.json
+++ b/_docs/docs.json
@@ -88,6 +88,7 @@
               "rules/tally/curl-should-follow-redirects",
               "rules/tally/prefer-curl-config",
               "rules/tally/named-identity-in-passwdless-stage",
+              "rules/tally/prefer-nginx-sigquit",
               "rules/tally/prefer-systemd-sigrtmin-plus-3",
               "rules/tally/prefer-wget-config"
             ]

--- a/_docs/rules/tally/prefer-nginx-sigquit.mdx
+++ b/_docs/rules/tally/prefer-nginx-sigquit.mdx
@@ -1,0 +1,122 @@
+---
+title: "tally/prefer-nginx-sigquit"
+description: "nginx and openresty containers should use STOPSIGNAL SIGQUIT for graceful shutdown."
+---
+
+nginx and openresty containers should use STOPSIGNAL SIGQUIT for graceful shutdown.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info |
+| Category | Best-practice |
+| Default | Enabled |
+| Auto-fix | Yes — safe for missing `STOPSIGNAL`, suggestion (requires `--fix-unsafe`) for replacing an existing value |
+
+## Description
+
+When a container runs `nginx` or `openresty` as PID 1, the container runtime's
+default stop signal (`SIGTERM`, signal 15) triggers nginx's **fast shutdown**:
+active connections are dropped immediately. The correct signal for a
+container stop is `SIGQUIT`, which triggers nginx's **graceful shutdown**:
+workers finish in-flight requests, then exit.
+
+This rule fires when:
+
+- the stage's effective PID 1 is `nginx` or `openresty` (bare name or
+  absolute path such as `/usr/sbin/nginx`), **and**
+- `STOPSIGNAL` is either missing or set to a signal that normalizes to
+  anything other than `SIGQUIT`.
+
+### When the rule does not fire
+
+- **Shell-form** `ENTRYPOINT` or `CMD` — the shell becomes PID 1, not nginx,
+  so the signal mapping is unreliable.
+- **Opaque exec-form shell wrappers** (`["sh", "-c", ...]`, `["bash", "-c",
+  ...]`) — the first token is `sh` / `bash`, not nginx.
+- **Non-nginx executables** (postgres, php-fpm, systemd, etc.) — other
+  daemon-specific rules handle those.
+- **`nginx-debug`** and similar variants — the basename must be exactly
+  `nginx` or `openresty`.
+- **Windows stages** — `STOPSIGNAL` has no effect on Windows containers.
+- **Environment variable** signals (e.g. `STOPSIGNAL $MY_SIGNAL`) — the
+  value cannot be determined statically.
+
+## References
+
+- [Dockerfile reference -- STOPSIGNAL](https://docs.docker.com/reference/dockerfile/#stopsignal)
+- [nginx -- Controlling nginx](https://nginx.org/en/docs/control.html)
+
+## Examples
+
+### Bad
+
+```dockerfile
+FROM nginx:1.27
+# Default SIGTERM forces fast shutdown, dropping active connections
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+```dockerfile
+FROM nginx:1.27
+# SIGTERM is fast shutdown, not graceful
+STOPSIGNAL SIGTERM
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+```dockerfile
+FROM openresty/openresty:alpine
+# openresty inherits nginx's signal semantics
+CMD ["openresty", "-g", "daemon off;"]
+```
+
+### Good
+
+```dockerfile
+FROM nginx:1.27
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+```dockerfile
+FROM openresty/openresty:alpine
+STOPSIGNAL SIGQUIT
+CMD ["openresty", "-g", "daemon off;"]
+```
+
+## Auto-fix
+
+The rule provides two fix modes depending on the violation:
+
+**Missing STOPSIGNAL** — inserts `STOPSIGNAL SIGQUIT` before the
+ENTRYPOINT/CMD instruction. `FixSafe`: applied with plain `--fix`.
+
+```bash
+tally lint --fix Dockerfile
+```
+
+**Wrong STOPSIGNAL present** — replaces the signal token with `SIGQUIT`.
+`FixSuggestion`: requires `--fix-unsafe` because the user explicitly chose
+a signal and `SIGTERM` is still a valid (if not preferred) shutdown signal.
+
+```bash
+tally lint --fix --fix-unsafe Dockerfile
+```
+
+## Cross-rule interactions
+
+- **tally/prefer-canonical-stopsignal**: Normalizes tokens such as `QUIT` or
+  `3` into `SIGQUIT`. This rule checks the normalized value, so those
+  spellings are accepted as correct and only the canonical rule fires.
+- **tally/no-ungraceful-stopsignal**: On an nginx stage with `SIGKILL` or
+  `SIGSTOP`, both rules want to replace the signal. The fixer's
+  category-based conflict resolution ranks `correctness` above
+  `best-practice`, so `no-ungraceful-stopsignal` wins first and replaces
+  with `SIGTERM`. A subsequent `--fix-unsafe` pass then promotes `SIGTERM`
+  to `SIGQUIT` via this rule's wrong-signal fix.
+
+## Configuration
+
+```toml
+[rules.tally.prefer-nginx-sigquit]
+severity = "info"  # Options: "off", "error", "warning", "info", "style"
+```

--- a/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-cross-canonical_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-cross-canonical_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]

--- a/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-cross-no-ungraceful_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-cross-no-ungraceful_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27
+STOPSIGNAL SIGTERM
+CMD ["nginx", "-g", "daemon off;"]

--- a/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-missing_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-missing_1.snap.Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.27
-# [tally] SIGQUIT is the graceful shutdown signal for nginx
+# [tally] SIGQUIT is the graceful shutdown signal for nginx / openresty
 STOPSIGNAL SIGQUIT
 CMD ["nginx", "-g", "daemon off;"]

--- a/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-missing_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-missing_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.27
+# [tally] SIGQUIT is the graceful shutdown signal for nginx
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]

--- a/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-no-fix_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-no-fix_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]

--- a/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-non-nginx-no-fix_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-non-nginx-no-fix_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM postgres:16
+CMD ["postgres"]

--- a/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-wrong-signal-safe-no-fix_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-wrong-signal-safe-no-fix_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27
+STOPSIGNAL SIGTERM
+CMD ["nginx", "-g", "daemon off;"]

--- a/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-wrong-signal_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-nginx-sigquit-wrong-signal_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.27
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]

--- a/internal/integration/__snapshots__/TestLint_prefer-nginx-sigquit_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-nginx-sigquit_1.snap.json
@@ -77,7 +77,7 @@
                     "line": 8
                   }
                 },
-                "newText": "# [tally] SIGQUIT is the graceful shutdown signal for nginx\nSTOPSIGNAL SIGQUIT\n"
+                "newText": "# [tally] SIGQUIT is the graceful shutdown signal for nginx / openresty\nSTOPSIGNAL SIGQUIT\n"
               }
             ],
             "isPreferred": true,
@@ -117,7 +117,7 @@
                     "line": 12
                   }
                 },
-                "newText": "# [tally] SIGQUIT is the graceful shutdown signal for nginx\nSTOPSIGNAL SIGQUIT\n"
+                "newText": "# [tally] SIGQUIT is the graceful shutdown signal for nginx / openresty\nSTOPSIGNAL SIGQUIT\n"
               }
             ],
             "isPreferred": true,

--- a/internal/integration/__snapshots__/TestLint_prefer-nginx-sigquit_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-nginx-sigquit_1.snap.json
@@ -1,0 +1,140 @@
+{
+  "files": [
+    {
+      "file": "testdata/prefer-nginx-sigquit/Dockerfile",
+      "violations": [
+        {
+          "detail": "nginx treats SIGQUIT as graceful shutdown (workers drain in-flight requests) and SIGTERM as fast shutdown (active connections dropped)",
+          "docUrl": "https://tally.wharflab.com/rules/tally/prefer-nginx-sigquit/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 3
+            },
+            "file": "testdata/prefer-nginx-sigquit/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 3
+            }
+          },
+          "message": "STOPSIGNAL SIGTERM should be SIGQUIT for nginx / openresty containers",
+          "rule": "tally/prefer-nginx-sigquit",
+          "severity": "info",
+          "sourceCode": "STOPSIGNAL SIGTERM",
+          "suggestedFix": {
+            "description": "Replace with SIGQUIT for graceful nginx shutdown",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 18,
+                    "line": 3
+                  },
+                  "file": "testdata/prefer-nginx-sigquit/Dockerfile",
+                  "start": {
+                    "column": 11,
+                    "line": 3
+                  }
+                },
+                "newText": "SIGQUIT"
+              }
+            ],
+            "isPreferred": true,
+            "priority": -1,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Without STOPSIGNAL SIGQUIT, the container runtime sends SIGTERM which triggers nginx's fast shutdown — active connections are dropped instead of draining",
+          "docUrl": "https://tally.wharflab.com/rules/tally/prefer-nginx-sigquit/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 8
+            },
+            "file": "testdata/prefer-nginx-sigquit/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 8
+            }
+          },
+          "message": "nginx / openresty container is missing STOPSIGNAL SIGQUIT",
+          "rule": "tally/prefer-nginx-sigquit",
+          "severity": "info",
+          "sourceCode": "CMD [\"nginx\", \"-g\", \"daemon off;\"]",
+          "suggestedFix": {
+            "description": "Add STOPSIGNAL SIGQUIT for graceful nginx shutdown",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 8
+                  },
+                  "file": "testdata/prefer-nginx-sigquit/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 8
+                  }
+                },
+                "newText": "# [tally] SIGQUIT is the graceful shutdown signal for nginx\nSTOPSIGNAL SIGQUIT\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": -1
+          }
+        },
+        {
+          "detail": "Without STOPSIGNAL SIGQUIT, the container runtime sends SIGTERM which triggers nginx's fast shutdown — active connections are dropped instead of draining",
+          "docUrl": "https://tally.wharflab.com/rules/tally/prefer-nginx-sigquit/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 12
+            },
+            "file": "testdata/prefer-nginx-sigquit/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 12
+            }
+          },
+          "message": "nginx / openresty container is missing STOPSIGNAL SIGQUIT",
+          "rule": "tally/prefer-nginx-sigquit",
+          "severity": "info",
+          "sourceCode": "CMD [\"openresty\", \"-g\", \"daemon off;\"]",
+          "suggestedFix": {
+            "description": "Add STOPSIGNAL SIGQUIT for graceful nginx shutdown",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 12
+                  },
+                  "file": "testdata/prefer-nginx-sigquit/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 12
+                  }
+                },
+                "newText": "# [tally] SIGQUIT is the graceful shutdown signal for nginx\nSTOPSIGNAL SIGQUIT\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": -1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 3,
+    "style": 0,
+    "total": 3,
+    "warnings": 0
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "files_scanned": 1,
-  "rules_enabled": 100,
+  "rules_enabled": 101,
   "summary": {
     "errors": 0,
     "files": 0,

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -2183,6 +2183,75 @@ severity = "warning"
 			wantApplied: 1, // only canonical applies (RTMIN+3 → SIGRTMIN+3)
 		},
 
+		// Prefer nginx SIGQUIT: missing STOPSIGNAL → insert (FixSafe)
+		{
+			name:  "prefer-nginx-sigquit-missing",
+			input: "FROM nginx:1.27\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			args: append(
+				[]string{"--fix"},
+				mustSelectRules("tally/prefer-nginx-sigquit")...),
+			wantApplied: 1,
+		},
+		// Prefer nginx SIGQUIT: wrong signal under --fix — no apply (FixSuggestion)
+		{
+			name:  "prefer-nginx-sigquit-wrong-signal-safe-no-fix",
+			input: "FROM nginx:1.27\nSTOPSIGNAL SIGTERM\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			args: append(
+				[]string{"--fix"},
+				mustSelectRules("tally/prefer-nginx-sigquit")...),
+			wantApplied: 0,
+		},
+		// Prefer nginx SIGQUIT: wrong signal under --fix-unsafe → replace
+		{
+			name:  "prefer-nginx-sigquit-wrong-signal",
+			input: "FROM nginx:1.27\nSTOPSIGNAL SIGTERM\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules("tally/prefer-nginx-sigquit")...),
+			wantApplied: 1,
+		},
+		// Prefer nginx SIGQUIT: already correct — no fix
+		{
+			name:  "prefer-nginx-sigquit-no-fix",
+			input: "FROM nginx:1.27\nSTOPSIGNAL SIGQUIT\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			args: append(
+				[]string{"--fix"},
+				mustSelectRules("tally/prefer-nginx-sigquit")...),
+			wantApplied: 0,
+		},
+		// Prefer nginx SIGQUIT: non-nginx daemon — no fix
+		{
+			name:  "prefer-nginx-sigquit-non-nginx-no-fix",
+			input: "FROM postgres:16\nCMD [\"postgres\"]\n",
+			args: append(
+				[]string{"--fix"},
+				mustSelectRules("tally/prefer-nginx-sigquit")...),
+			wantApplied: 0,
+		},
+		// Cross-rule: nginx + no-ungraceful on SIGKILL. no-ungraceful
+		// (category: correctness) outranks prefer-nginx-sigquit (category:
+		// best-practice) in conflict resolution, so SIGKILL becomes SIGTERM,
+		// not SIGQUIT. A subsequent --fix-unsafe pass then triggers
+		// prefer-nginx-sigquit's wrong-signal fix (SIGTERM → SIGQUIT).
+		{
+			name:  "prefer-nginx-sigquit-cross-no-ungraceful",
+			input: "FROM nginx:1.27\nSTOPSIGNAL SIGKILL\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules("tally/prefer-nginx-sigquit", "tally/no-ungraceful-stopsignal")...),
+			wantApplied: 1, // no-ungraceful wins by category rank → SIGTERM
+		},
+		// Cross-rule: nginx + canonical on QUIT. Only canonical fires
+		// (normalizes QUIT → SIGQUIT); nginx sees correct signal after normalization.
+		{
+			name:  "prefer-nginx-sigquit-cross-canonical",
+			input: "FROM nginx:1.27\nSTOPSIGNAL QUIT\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			args: append(
+				[]string{"--fix"},
+				mustSelectRules("tally/prefer-nginx-sigquit", "tally/prefer-canonical-stopsignal")...),
+			wantApplied: 1, // only canonical applies (QUIT → SIGQUIT)
+		},
+
 		// User created but never used: insert USER before CMD (FixUnsafe)
 		{
 			name:  "user-created-but-never-used",

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -1145,6 +1145,14 @@ func lintCases(t *testing.T) []lintCase {
 			wantExit: 1,
 		},
 
+		// Prefer nginx SIGQUIT (isolated to prefer-nginx-sigquit rule)
+		{
+			name:     "prefer-nginx-sigquit",
+			dir:      "prefer-nginx-sigquit",
+			args:     append([]string{"--format", "json"}, mustSelectRules("tally/prefer-nginx-sigquit")...),
+			wantExit: 1,
+		},
+
 		// Stateful root runtime (isolated to stateful-root-runtime rule)
 		{
 			name:     "stateful-root-runtime",

--- a/internal/integration/testdata/prefer-nginx-sigquit/Dockerfile
+++ b/internal/integration/testdata/prefer-nginx-sigquit/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: nginx with wrong signal (violation — replacement fix, FixSuggestion)
+FROM nginx:1.27 AS wrong-signal
+STOPSIGNAL SIGTERM
+CMD ["nginx", "-g", "daemon off;"]
+
+# Stage 2: nginx CMD with missing STOPSIGNAL (violation — insertion fix, FixSafe)
+FROM nginx:1.27-alpine AS missing-signal
+CMD ["nginx", "-g", "daemon off;"]
+
+# Stage 3: openresty with missing STOPSIGNAL (violation — insertion fix, FixSafe)
+FROM openresty/openresty:alpine AS openresty-missing
+CMD ["openresty", "-g", "daemon off;"]
+
+# Stage 4: nginx with correct SIGQUIT (no violation)
+FROM nginx:1.27 AS correct
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]
+
+# Stage 5: shell-form CMD — PID 1 hidden (no violation)
+FROM nginx:1.27 AS shell-form
+CMD nginx -g 'daemon off;'
+
+# Stage 6: non-nginx daemon (no violation)
+FROM postgres:16 AS non-nginx
+STOPSIGNAL SIGINT
+CMD ["postgres"]
+
+# Stage 7: Windows stage — skipped (no violation)
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS windows
+CMD ["nginx", "-g", "daemon off;"]

--- a/internal/rules/tally/prefer_nginx_sigquit.go
+++ b/internal/rules/tally/prefer_nginx_sigquit.go
@@ -1,0 +1,91 @@
+package tally
+
+import (
+	"fmt"
+
+	"github.com/wharflab/tally/internal/rules"
+)
+
+// PreferNginxSigquitRuleCode is the full rule code.
+const PreferNginxSigquitRuleCode = rules.TallyRulePrefix + "prefer-nginx-sigquit"
+
+// PreferNginxSigquitRule detects stages where PID 1 is clearly nginx or
+// openresty but STOPSIGNAL is missing or not set to SIGQUIT.
+//
+// nginx treats SIGQUIT as graceful shutdown (workers finish in-flight
+// requests) and SIGTERM as fast shutdown (active connections dropped).
+// Containerized nginx images should therefore use SIGQUIT so that the
+// runtime's stop timeout window is spent draining connections rather than
+// killing them.
+//
+// Cross-rule interaction:
+//
+//   - tally/prefer-canonical-stopsignal handles QUIT → SIGQUIT. This rule
+//     checks the normalized value, so non-canonical spellings that resolve
+//     to SIGQUIT are treated as correct.
+//   - tally/no-ungraceful-stopsignal may fire on the same STOPSIGNAL (e.g.
+//     SIGKILL on an nginx stage). The fixer's category-based conflict
+//     resolution lets no-ungraceful (category: correctness) win over this
+//     rule (category: best-practice), so an ungraceful signal first becomes
+//     SIGTERM. A subsequent --fix-unsafe pass then promotes SIGTERM to
+//     SIGQUIT via this rule's wrong-signal fix.
+type PreferNginxSigquitRule struct{}
+
+// NewPreferNginxSigquitRule creates a new rule instance.
+func NewPreferNginxSigquitRule() *PreferNginxSigquitRule {
+	return &PreferNginxSigquitRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *PreferNginxSigquitRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            PreferNginxSigquitRuleCode,
+		Name:            "Prefer SIGQUIT for nginx / openresty",
+		Description:     "nginx and openresty containers should use STOPSIGNAL SIGQUIT for graceful shutdown",
+		DocURL:          rules.TallyDocURL(PreferNginxSigquitRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "best-practice",
+	}
+}
+
+// Check runs the prefer-nginx-sigquit rule.
+//
+// For each stage it determines whether PID 1 is nginx or openresty (exec
+// form only — shell form and opaque wrappers hide the real PID 1). If so,
+// it verifies that STOPSIGNAL is present and set to SIGQUIT.
+//
+// Windows stages are skipped because STOPSIGNAL has no effect on Windows
+// containers.
+func (r *PreferNginxSigquitRule) Check(input rules.LintInput) []rules.Violation {
+	return checkDaemonStopsignal(input, daemonStopsignalRule{
+		meta:         r.Metadata(),
+		isDaemon:     isNginxOrOpenResty,
+		targetSignal: signalSIGQUIT,
+		wrongFix: daemonStopsignalFixSpec{
+			Description: "Replace with SIGQUIT for graceful nginx shutdown",
+			// Wrong-signal replacement is gated behind --fix-unsafe: the user
+			// explicitly set a signal and SIGTERM is still a valid (if not
+			// preferred) shutdown signal for nginx.
+			Safety: rules.FixSuggestion,
+		},
+		missingFix: daemonStopsignalFixSpec{
+			Description: "Add STOPSIGNAL SIGQUIT for graceful nginx shutdown",
+			Safety:      rules.FixSafe,
+		},
+		wrongMessage: func(normalized string) string {
+			return fmt.Sprintf("STOPSIGNAL %s should be SIGQUIT for nginx / openresty containers", normalized)
+		},
+		wrongDetail: "nginx treats SIGQUIT as graceful shutdown (workers drain" +
+			" in-flight requests) and SIGTERM as fast shutdown (active" +
+			" connections dropped)",
+		missingMessage: "nginx / openresty container is missing STOPSIGNAL SIGQUIT",
+		missingDetail: "Without STOPSIGNAL SIGQUIT, the container runtime sends SIGTERM" +
+			" which triggers nginx's fast shutdown — active connections are" +
+			" dropped instead of draining",
+		insertText: "# [tally] SIGQUIT is the graceful shutdown signal for nginx\nSTOPSIGNAL SIGQUIT\n",
+	})
+}
+
+func init() {
+	rules.Register(NewPreferNginxSigquitRule())
+}

--- a/internal/rules/tally/prefer_nginx_sigquit.go
+++ b/internal/rules/tally/prefer_nginx_sigquit.go
@@ -82,7 +82,7 @@ func (r *PreferNginxSigquitRule) Check(input rules.LintInput) []rules.Violation 
 		missingDetail: "Without STOPSIGNAL SIGQUIT, the container runtime sends SIGTERM" +
 			" which triggers nginx's fast shutdown — active connections are" +
 			" dropped instead of draining",
-		insertText: "# [tally] SIGQUIT is the graceful shutdown signal for nginx\nSTOPSIGNAL SIGQUIT\n",
+		insertText: "# [tally] SIGQUIT is the graceful shutdown signal for nginx / openresty\nSTOPSIGNAL SIGQUIT\n",
 	})
 }
 

--- a/internal/rules/tally/prefer_nginx_sigquit_test.go
+++ b/internal/rules/tally/prefer_nginx_sigquit_test.go
@@ -255,7 +255,7 @@ func TestPreferNginxSigquitRule_InsertionFix(t *testing.T) {
 	}
 
 	edit := v.SuggestedFix.Edits[0]
-	wantText := "# [tally] SIGQUIT is the graceful shutdown signal for nginx\nSTOPSIGNAL SIGQUIT\n"
+	wantText := "# [tally] SIGQUIT is the graceful shutdown signal for nginx / openresty\nSTOPSIGNAL SIGQUIT\n"
 	if edit.NewText != wantText {
 		t.Errorf("NewText = %q, want %q", edit.NewText, wantText)
 	}

--- a/internal/rules/tally/prefer_nginx_sigquit_test.go
+++ b/internal/rules/tally/prefer_nginx_sigquit_test.go
@@ -1,0 +1,300 @@
+package tally
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestPreferNginxSigquitRule_Metadata(t *testing.T) {
+	t.Parallel()
+	r := NewPreferNginxSigquitRule()
+	meta := r.Metadata()
+
+	if meta.Code != PreferNginxSigquitRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, PreferNginxSigquitRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "best-practice" {
+		t.Errorf("Category = %q, want best-practice", meta.Category)
+	}
+}
+
+func TestPreferNginxSigquitRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewPreferNginxSigquitRule(), []testutil.RuleTestCase{
+		// --- Violations: wrong signal ---
+		{
+			Name:           "nginx with SIGTERM — violation",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL SIGTERM\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+			WantMessages:   []string{"STOPSIGNAL SIGTERM should be SIGQUIT"},
+		},
+		{
+			Name:           "openresty with SIGTERM — violation",
+			Content:        "FROM openresty/openresty:alpine\nSTOPSIGNAL SIGTERM\nCMD [\"openresty\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+			WantMessages:   []string{"should be SIGQUIT"},
+		},
+		{
+			Name:           "nginx with SIGINT — violation",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL SIGINT\nENTRYPOINT [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+			WantMessages:   []string{"STOPSIGNAL SIGINT should be SIGQUIT"},
+		},
+		{
+			Name:           "nginx with SIGKILL — violation",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL SIGKILL\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+			WantMessages:   []string{"STOPSIGNAL SIGKILL should be SIGQUIT"},
+		},
+		{
+			Name:           "absolute /usr/sbin/nginx with wrong signal — violation",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL SIGTERM\nCMD [\"/usr/sbin/nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+		},
+
+		// --- Violations: missing STOPSIGNAL ---
+		{
+			Name:           "nginx missing STOPSIGNAL — violation",
+			Content:        "FROM nginx:1.27\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+			WantMessages:   []string{"missing STOPSIGNAL SIGQUIT"},
+		},
+		{
+			Name:           "openresty missing STOPSIGNAL — violation",
+			Content:        "FROM openresty/openresty:alpine\nCMD [\"openresty\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+			WantMessages:   []string{"missing STOPSIGNAL SIGQUIT"},
+		},
+		{
+			Name:           "ENTRYPOINT nginx missing STOPSIGNAL — violation",
+			Content:        "FROM nginx:1.27\nENTRYPOINT [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+		},
+		{
+			Name: "ENTRYPOINT nginx + CMD args missing STOPSIGNAL — violation",
+			Content: "FROM nginx:1.27\n" +
+				"ENTRYPOINT [\"nginx\"]\n" +
+				"CMD [\"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+		},
+
+		// --- No violations: correct signal ---
+		{
+			Name:           "SIGQUIT correct — no violation",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL SIGQUIT\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 0,
+		},
+		{
+			Name:           "SIGQUIT correct on openresty — no violation",
+			Content:        "FROM openresty/openresty:alpine\nSTOPSIGNAL SIGQUIT\nCMD [\"openresty\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 0,
+		},
+		{
+			Name:           "numeric 3 normalizes to SIGQUIT — no violation",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL 3\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 0,
+		},
+		{
+			Name:           "QUIT normalizes to SIGQUIT — no violation",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL QUIT\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 0,
+		},
+
+		// --- No violations: shell form (PID 1 hidden) ---
+		{
+			Name:           "shell-form CMD — no violation",
+			Content:        "FROM nginx:1.27\nCMD nginx -g 'daemon off;'\n",
+			WantViolations: 0,
+		},
+		{
+			Name:           "shell-form ENTRYPOINT — no violation",
+			Content:        "FROM nginx:1.27\nENTRYPOINT nginx -g 'daemon off;'\n",
+			WantViolations: 0,
+		},
+		{
+			Name:           "sh -c wrapper — no violation (first token is sh, not nginx)",
+			Content:        "FROM nginx:1.27\nCMD [\"sh\", \"-c\", \"nginx -g 'daemon off;'\"]\n",
+			WantViolations: 0,
+		},
+
+		// --- No violations: non-nginx ---
+		{
+			Name:           "postgres — no violation",
+			Content:        "FROM postgres:16\nSTOPSIGNAL SIGTERM\nCMD [\"postgres\"]\n",
+			WantViolations: 0,
+		},
+		{
+			Name:           "systemd — no violation",
+			Content:        "FROM fedora:40\nSTOPSIGNAL SIGTERM\nENTRYPOINT [\"/sbin/init\"]\n",
+			WantViolations: 0,
+		},
+		{
+			Name:           "nginx-debug binary — no violation (name mismatch)",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL SIGTERM\nCMD [\"nginx-debug\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 0,
+		},
+		{
+			Name:           "no ENTRYPOINT or CMD — no violation",
+			Content:        "FROM nginx:1.27\nRUN echo hello\n",
+			WantViolations: 0,
+		},
+
+		// --- Skipped: env var ---
+		{
+			Name:           "env var in STOPSIGNAL — skipped",
+			Content:        "FROM nginx:1.27\nSTOPSIGNAL $MY_SIGNAL\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 0,
+		},
+
+		// --- Windows stage (skipped) ---
+		{
+			Name: "Windows stage with nginx — skipped",
+			Content: "FROM mcr.microsoft.com/windows/servercore:ltsc2022\n" +
+				"CMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 0,
+		},
+
+		// --- Multi-stage ---
+		{
+			Name: "multi-stage — violation only in nginx stage",
+			Content: "FROM alpine:3.20 AS builder\n" +
+				"RUN echo build\n" +
+				"\n" +
+				"FROM nginx:1.27\n" +
+				"CMD [\"nginx\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 1,
+		},
+		{
+			Name: "multi-stage — both wrong and missing",
+			Content: "FROM nginx:1.27 AS first\n" +
+				"STOPSIGNAL SIGTERM\n" +
+				"CMD [\"nginx\", \"-g\", \"daemon off;\"]\n" +
+				"\n" +
+				"FROM openresty/openresty:alpine AS second\n" +
+				"CMD [\"openresty\", \"-g\", \"daemon off;\"]\n",
+			WantViolations: 2,
+		},
+	})
+}
+
+func TestPreferNginxSigquitRule_ReplacementFix(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM nginx:1.27\nSTOPSIGNAL SIGTERM\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	r := NewPreferNginxSigquitRule()
+	violations := r.Check(input)
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a SuggestedFix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
+	}
+	if v.SuggestedFix.Priority != -1 {
+		t.Errorf("Priority = %d, want -1", v.SuggestedFix.Priority)
+	}
+	if !v.SuggestedFix.IsPreferred {
+		t.Error("expected IsPreferred = true")
+	}
+	if len(v.SuggestedFix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(v.SuggestedFix.Edits))
+	}
+
+	edit := v.SuggestedFix.Edits[0]
+	if edit.NewText != "SIGQUIT" {
+		t.Errorf("NewText = %q, want %q", edit.NewText, "SIGQUIT")
+	}
+	// "STOPSIGNAL " = 11 chars, "SIGTERM" starts at column 11, ends at 18
+	if edit.Location.Start.Line != 2 {
+		t.Errorf("edit Start.Line = %d, want 2", edit.Location.Start.Line)
+	}
+	if edit.Location.Start.Column != 11 {
+		t.Errorf("edit Start.Column = %d, want 11", edit.Location.Start.Column)
+	}
+	if edit.Location.End.Column != 18 {
+		t.Errorf("edit End.Column = %d, want 18", edit.Location.End.Column)
+	}
+}
+
+func TestPreferNginxSigquitRule_InsertionFix(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM nginx:1.27\nCMD [\"nginx\", \"-g\", \"daemon off;\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	r := NewPreferNginxSigquitRule()
+	violations := r.Check(input)
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a SuggestedFix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSafe {
+		t.Errorf("Safety = %v, want FixSafe", v.SuggestedFix.Safety)
+	}
+	if v.SuggestedFix.Priority != -1 {
+		t.Errorf("Priority = %d, want -1", v.SuggestedFix.Priority)
+	}
+	if len(v.SuggestedFix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(v.SuggestedFix.Edits))
+	}
+
+	edit := v.SuggestedFix.Edits[0]
+	wantText := "# [tally] SIGQUIT is the graceful shutdown signal for nginx\nSTOPSIGNAL SIGQUIT\n"
+	if edit.NewText != wantText {
+		t.Errorf("NewText = %q, want %q", edit.NewText, wantText)
+	}
+	// Zero-width insertion before line 2 (the CMD line).
+	if edit.Location.Start.Line != 2 {
+		t.Errorf("edit Start.Line = %d, want 2", edit.Location.Start.Line)
+	}
+	if edit.Location.Start.Column != 0 {
+		t.Errorf("edit Start.Column = %d, want 0", edit.Location.Start.Column)
+	}
+	if edit.Location.End.Line != 2 {
+		t.Errorf("edit End.Line = %d, want 2", edit.Location.End.Line)
+	}
+	if edit.Location.End.Column != 0 {
+		t.Errorf("edit End.Column = %d, want 0", edit.Location.End.Column)
+	}
+}
+
+func TestPreferNginxSigquitRule_InsertionFix_EntrypointPrecedence(t *testing.T) {
+	t.Parallel()
+
+	// ENTRYPOINT should anchor the insertion even when a preceding CMD exists.
+	content := "FROM nginx:1.27\nCMD [\"-g\", \"daemon off;\"]\nENTRYPOINT [\"nginx\"]\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	r := NewPreferNginxSigquitRule()
+	violations := r.Check(input)
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a SuggestedFix")
+	}
+
+	edit := v.SuggestedFix.Edits[0]
+	// Should insert before line 3 (the ENTRYPOINT), not line 2 (the CMD).
+	if edit.Location.Start.Line != 3 {
+		t.Errorf("edit Start.Line = %d, want 3 (ENTRYPOINT)", edit.Location.Start.Line)
+	}
+}

--- a/internal/rules/tally/prefer_systemd_sigrtmin_plus_3.go
+++ b/internal/rules/tally/prefer_systemd_sigrtmin_plus_3.go
@@ -2,10 +2,6 @@ package tally
 
 import (
 	"fmt"
-	"strings"
-
-	"github.com/moby/buildkit/frontend/dockerfile/instructions"
-	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/wharflab/tally/internal/rules"
 )
@@ -57,148 +53,29 @@ func (r *PreferSystemdSigrtminPlus3Rule) Metadata() rules.RuleMetadata {
 // Windows stages are skipped because STOPSIGNAL has no effect on Windows
 // containers.
 func (r *PreferSystemdSigrtminPlus3Rule) Check(input rules.LintInput) []rules.Violation {
-	meta := r.Metadata()
-	sem := input.Semantic
-	var violations []rules.Violation
-
-	for stageIdx, stage := range input.Stages {
-		if sem != nil {
-			if info := sem.StageInfo(stageIdx); info != nil && info.IsWindows() {
-				continue
-			}
-		}
-
-		executable := stageRuntimeExecutable(stage)
-		if executable == "" || !isSystemdInit(executable) {
-			continue
-		}
-
-		// Find the last STOPSIGNAL instruction in this stage.
-		var lastStopSig *instructions.StopSignalCommand
-		for _, cmd := range stage.Commands {
-			if ss, ok := cmd.(*instructions.StopSignalCommand); ok {
-				lastStopSig = ss
-			}
-		}
-
-		if lastStopSig == nil {
-			violations = append(violations, r.buildMissingViolation(meta, input, stage))
-			continue
-		}
-
-		raw := lastStopSig.Signal
-		if strings.Contains(raw, "$") {
-			continue
-		}
-
-		normalized := normalizeSignalName(raw)
-		if normalized == signalSIGRTMINPlus3 {
-			continue
-		}
-
-		violations = append(violations, r.buildWrongSignalViolation(meta, input, lastStopSig, normalized))
-	}
-
-	return violations
-}
-
-// buildWrongSignalViolation creates a violation for a STOPSIGNAL that is
-// present but set to the wrong value.
-func (r *PreferSystemdSigrtminPlus3Rule) buildWrongSignalViolation(
-	meta rules.RuleMetadata,
-	input rules.LintInput,
-	cmd *instructions.StopSignalCommand,
-	normalized string,
-) rules.Violation {
-	loc := rules.NewLocationFromRanges(input.File, cmd.Location())
-
-	msg := fmt.Sprintf(
-		"STOPSIGNAL %s should be SIGRTMIN+3 for systemd/init containers",
-		normalized,
-	)
-
-	v := rules.NewViolation(loc, meta.Code, msg, meta.DefaultSeverity).
-		WithDocURL(meta.DocURL).
-		WithDetail("systemd requires SIGRTMIN+3 to trigger a clean manager shutdown, analogous to systemctl halt")
-
-	if editLoc := signalEditLocation(input.File, input.Source, cmd); editLoc != nil {
-		v = v.WithSuggestedFix(&rules.SuggestedFix{
+	return checkDaemonStopsignal(input, daemonStopsignalRule{
+		meta:         r.Metadata(),
+		isDaemon:     isSystemdInit,
+		targetSignal: signalSIGRTMINPlus3,
+		wrongFix: daemonStopsignalFixSpec{
 			Description: "Replace with SIGRTMIN+3 for clean systemd shutdown",
 			Safety:      rules.FixSafe,
-			Priority:    -1,
-			IsPreferred: true,
-			Edits: []rules.TextEdit{
-				{Location: *editLoc, NewText: signalSIGRTMINPlus3},
-			},
-		})
-	}
-
-	return v
-}
-
-// buildMissingViolation creates a violation when no STOPSIGNAL is present in a
-// systemd/init stage. The fix inserts STOPSIGNAL SIGRTMIN+3 before the
-// ENTRYPOINT or CMD that defines the init process.
-func (r *PreferSystemdSigrtminPlus3Rule) buildMissingViolation(
-	meta rules.RuleMetadata,
-	input rules.LintInput,
-	stage instructions.Stage,
-) rules.Violation {
-	// Find the last ENTRYPOINT or CMD to determine the insertion point
-	// and the violation location. Track them separately so ENTRYPOINT
-	// always takes precedence, matching stageRuntimeExecutable semantics.
-	var lastEntrypointLoc, lastCmdLoc []parser.Range
-	for _, cmd := range stage.Commands {
-		switch c := cmd.(type) {
-		case *instructions.EntrypointCommand:
-			lastEntrypointLoc = c.Location()
-		case *instructions.CmdCommand:
-			lastCmdLoc = c.Location()
-		}
-	}
-
-	var runtimeLoc []parser.Range
-	if lastEntrypointLoc != nil {
-		runtimeLoc = lastEntrypointLoc
-	} else {
-		runtimeLoc = lastCmdLoc
-	}
-
-	var loc rules.Location
-	if len(runtimeLoc) > 0 {
-		loc = rules.NewLocationFromRanges(input.File, runtimeLoc)
-	} else {
-		loc = rules.NewLocationFromRanges(input.File, stage.Location)
-	}
-
-	v := rules.NewViolation(loc, meta.Code,
-		"systemd/init container is missing STOPSIGNAL SIGRTMIN+3",
-		meta.DefaultSeverity,
-	).
-		WithDocURL(meta.DocURL).
-		WithDetail(
-			"Without STOPSIGNAL SIGRTMIN+3, the container runtime sends SIGTERM" +
-				" which systemd interprets as an isolate-to-rescue-mode request, not a clean shutdown",
-		)
-
-	// Insert STOPSIGNAL before the runtime instruction.
-	if len(runtimeLoc) > 0 {
-		insertLine := runtimeLoc[0].Start.Line
-		v = v.WithSuggestedFix(&rules.SuggestedFix{
+		},
+		missingFix: daemonStopsignalFixSpec{
 			Description: "Add STOPSIGNAL SIGRTMIN+3 for clean systemd shutdown",
 			Safety:      rules.FixSafe,
-			Priority:    -1,
-			IsPreferred: true,
-			Edits: []rules.TextEdit{
-				{
-					Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
-					NewText:  "# [tally] SIGRTMIN+3 is the graceful shutdown signal for systemd/init\nSTOPSIGNAL SIGRTMIN+3\n",
-				},
-			},
-		})
-	}
-
-	return v
+		},
+		wrongMessage: func(normalized string) string {
+			return fmt.Sprintf("STOPSIGNAL %s should be SIGRTMIN+3 for systemd/init containers", normalized)
+		},
+		wrongDetail: "systemd requires SIGRTMIN+3 to trigger a clean manager" +
+			" shutdown, analogous to systemctl halt",
+		missingMessage: "systemd/init container is missing STOPSIGNAL SIGRTMIN+3",
+		missingDetail: "Without STOPSIGNAL SIGRTMIN+3, the container runtime sends" +
+			" SIGTERM which systemd interprets as an isolate-to-rescue-mode" +
+			" request, not a clean shutdown",
+		insertText: "# [tally] SIGRTMIN+3 is the graceful shutdown signal for systemd/init\nSTOPSIGNAL SIGRTMIN+3\n",
+	})
 }
 
 func init() {

--- a/internal/rules/tally/stopsignal.go
+++ b/internal/rules/tally/stopsignal.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/wharflab/tally/internal/rules"
 )
@@ -189,6 +190,170 @@ func isSystemdInit(executable string) bool {
 		return true
 	}
 	return path.Base(executable) == "systemd"
+}
+
+// isNginxOrOpenResty returns true if the executable's base name is "nginx"
+// or "openresty". Matching on the base name covers absolute paths such as
+// /usr/sbin/nginx and /usr/local/openresty/nginx/sbin/nginx.
+func isNginxOrOpenResty(executable string) bool {
+	base := path.Base(executable)
+	return base == "nginx" || base == "openresty"
+}
+
+// daemonStopsignalRule describes a daemon-specific STOPSIGNAL rule so that the
+// generic check/fix scaffolding can be shared. It captures the behavior that
+// varies between daemons: how to recognize the PID 1 binary, what the target
+// signal is, and how to build the violation messages and fixes.
+type daemonStopsignalRule struct {
+	meta           rules.RuleMetadata
+	isDaemon       func(executable string) bool
+	targetSignal   string
+	wrongFix       daemonStopsignalFixSpec
+	missingFix     daemonStopsignalFixSpec
+	missingMessage string
+	missingDetail  string
+	wrongDetail    string
+	wrongMessage   func(normalized string) string
+	insertText     string
+}
+
+// daemonStopsignalFixSpec captures the fix-kind metadata (safety level plus
+// description) for one of a daemon rule's two fix paths.
+type daemonStopsignalFixSpec struct {
+	Description string
+	Safety      rules.FixSafety
+}
+
+// checkDaemonStopsignal runs the shared STOPSIGNAL check loop for a
+// daemon-specific rule. It iterates stages, identifies the PID 1 binary via
+// stageRuntimeExecutable, and delegates to the daemon-specific predicates and
+// templates for message/fix construction.
+func checkDaemonStopsignal(input rules.LintInput, spec daemonStopsignalRule) []rules.Violation {
+	sem := input.Semantic
+	var violations []rules.Violation
+
+	for stageIdx, stage := range input.Stages {
+		if sem != nil {
+			if info := sem.StageInfo(stageIdx); info != nil && info.IsWindows() {
+				continue
+			}
+		}
+
+		executable := stageRuntimeExecutable(stage)
+		if executable == "" || !spec.isDaemon(executable) {
+			continue
+		}
+
+		var lastStopSig *instructions.StopSignalCommand
+		for _, cmd := range stage.Commands {
+			if ss, ok := cmd.(*instructions.StopSignalCommand); ok {
+				lastStopSig = ss
+			}
+		}
+
+		if lastStopSig == nil {
+			violations = append(violations, buildMissingStopsignalViolation(input, spec, stage))
+			continue
+		}
+
+		raw := lastStopSig.Signal
+		if strings.Contains(raw, "$") {
+			continue
+		}
+
+		normalized := normalizeSignalName(raw)
+		if normalized == spec.targetSignal {
+			continue
+		}
+
+		violations = append(violations, buildWrongStopsignalViolation(input, spec, lastStopSig, normalized))
+	}
+
+	return violations
+}
+
+// buildWrongStopsignalViolation emits a violation for a STOPSIGNAL set to a
+// signal other than the daemon's preferred value.
+func buildWrongStopsignalViolation(
+	input rules.LintInput,
+	spec daemonStopsignalRule,
+	cmd *instructions.StopSignalCommand,
+	normalized string,
+) rules.Violation {
+	loc := rules.NewLocationFromRanges(input.File, cmd.Location())
+
+	v := rules.NewViolation(loc, spec.meta.Code, spec.wrongMessage(normalized), spec.meta.DefaultSeverity).
+		WithDocURL(spec.meta.DocURL).
+		WithDetail(spec.wrongDetail)
+
+	if editLoc := signalEditLocation(input.File, input.Source, cmd); editLoc != nil {
+		v = v.WithSuggestedFix(&rules.SuggestedFix{
+			Description: spec.wrongFix.Description,
+			Safety:      spec.wrongFix.Safety,
+			Priority:    -1,
+			IsPreferred: true,
+			Edits: []rules.TextEdit{
+				{Location: *editLoc, NewText: spec.targetSignal},
+			},
+		})
+	}
+
+	return v
+}
+
+// buildMissingStopsignalViolation emits a violation for a daemon stage that
+// has no STOPSIGNAL at all, inserting the daemon's preferred value before the
+// ENTRYPOINT or CMD that defines PID 1.
+func buildMissingStopsignalViolation(
+	input rules.LintInput,
+	spec daemonStopsignalRule,
+	stage instructions.Stage,
+) rules.Violation {
+	var lastEntrypointLoc, lastCmdLoc []parser.Range
+	for _, cmd := range stage.Commands {
+		switch c := cmd.(type) {
+		case *instructions.EntrypointCommand:
+			lastEntrypointLoc = c.Location()
+		case *instructions.CmdCommand:
+			lastCmdLoc = c.Location()
+		}
+	}
+
+	var runtimeLoc []parser.Range
+	if lastEntrypointLoc != nil {
+		runtimeLoc = lastEntrypointLoc
+	} else {
+		runtimeLoc = lastCmdLoc
+	}
+
+	var loc rules.Location
+	if len(runtimeLoc) > 0 {
+		loc = rules.NewLocationFromRanges(input.File, runtimeLoc)
+	} else {
+		loc = rules.NewLocationFromRanges(input.File, stage.Location)
+	}
+
+	v := rules.NewViolation(loc, spec.meta.Code, spec.missingMessage, spec.meta.DefaultSeverity).
+		WithDocURL(spec.meta.DocURL).
+		WithDetail(spec.missingDetail)
+
+	if len(runtimeLoc) > 0 {
+		insertLine := runtimeLoc[0].Start.Line
+		v = v.WithSuggestedFix(&rules.SuggestedFix{
+			Description: spec.missingFix.Description,
+			Safety:      spec.missingFix.Safety,
+			Priority:    -1,
+			IsPreferred: true,
+			Edits: []rules.TextEdit{
+				{
+					Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
+					NewText:  spec.insertText,
+				},
+			},
+		})
+	}
+
+	return v
 }
 
 // stageRuntimeExecutable returns the effective PID 1 executable for a build

--- a/internal/rules/tally/stopsignal_test.go
+++ b/internal/rules/tally/stopsignal_test.go
@@ -76,6 +76,37 @@ func TestSignalColumnRange(t *testing.T) {
 	}
 }
 
+func TestIsNginxOrOpenResty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		executable string
+		want       bool
+	}{
+		{"nginx", true},
+		{"openresty", true},
+		{"/usr/sbin/nginx", true},
+		{"/usr/local/nginx/sbin/nginx", true},
+		{"/usr/local/openresty/nginx/sbin/nginx", true},
+		{"/usr/local/openresty/bin/openresty", true},
+		{"/sbin/init", false},
+		{"systemd", false},
+		{"postgres", false},
+		{"php-fpm", false},
+		{"nginx-debug", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.executable, func(t *testing.T) {
+			t.Parallel()
+			if got := isNginxOrOpenResty(tt.executable); got != tt.want {
+				t.Errorf("isNginxOrOpenResty(%q) = %v, want %v", tt.executable, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSignalEditLocation_CRLF(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Adds `tally/prefer-nginx-sigquit` (severity: info, category: best-practice). Fires when a Linux stage's exec-form PID 1 is `nginx` or `openresty` and `STOPSIGNAL` is missing or not `SIGQUIT`.
- Missing-value fix is `FixSafe` (inserts `STOPSIGNAL SIGQUIT` before the effective ENTRYPOINT/CMD); wrong-signal replacement is `FixSuggestion` so explicit operator intent is not overridden without `--fix-unsafe`.
- Extracts the daemon-STOPSIGNAL check/fix scaffolding shared with `tally/prefer-systemd-sigrtmin-plus-3` into a shared `daemonStopsignalRule` helper in `stopsignal.go` — both rules now delegate to the same loop, resolving the CPD flag.
- Implements design-doc §5 rule 5 (`design-docs/33-stopsignal-rules.md`).

## Rule surface
- Matches exec-form `nginx` / `openresty` by base name (bare or absolute path).
- Suppresses automatically when PID 1 is hidden: shell-form CMD/ENTRYPOINT, exec-form `sh -c` / `bash -c` wrappers, opaque scripts, non-nginx daemons (postgres, systemd, etc.), `nginx-debug`, env-var signal values, or Windows stages.
- Coordinates with `tally/prefer-canonical-stopsignal` (normalized compare — `QUIT`→`SIGQUIT` is accepted as correct).
- Coordinates with `tally/no-ungraceful-stopsignal` via fixer category ranking: on `SIGKILL`, the no-ungraceful fix (category: correctness) wins first and rewrites to `SIGTERM`; a subsequent `--fix-unsafe` pass then promotes `SIGTERM`→`SIGQUIT` via this rule's wrong-signal fix.

## Test plan
- [x] Unit tests (`internal/rules/tally/prefer_nginx_sigquit_test.go`, 26+ cases): wrong/missing/correct, shell-form and `sh -c` suppression, openresty and absolute paths, ENTRYPOINT-precedence insertion, Windows and env-var skip, fix safety levels, replacement + insertion edit positions. Coverage ≥94% on new functions.
- [x] Helper tests (`TestIsNginxOrOpenResty` in `internal/rules/tally/stopsignal_test.go`).
- [x] Integration fixture + lint case + 7 fix cases (isolated + cross-rule with `no-ungraceful-stopsignal` and `prefer-canonical-stopsignal`).
- [x] Snapshots generated and committed.
- [x] Docs page + `docs.json` entry under Correctness group; `npx mint validate` passes.
- [x] `go test ./...` all pass.
- [x] `make lint` → 0 issues.
- [x] `make cpd` → 0 duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)