### PR TITLE
feat(rules): add tally/user-explicit-group-drops-supplementary-groups

### DIFF
--- a/_docs/docs.json
+++ b/_docs/docs.json
@@ -63,6 +63,7 @@
               "rules/tally/require-secret-mounts",
               "rules/tally/stateful-root-runtime",
               "rules/tally/user-created-but-never-used",
+              "rules/tally/user-explicit-group-drops-supplementary-groups",
               "rules/tally/copy-after-user-without-chown",
               "rules/tally/prefer-add-git",
               "rules/tally/world-writable-state-path-workaround",

--- a/_docs/rules/tally/user-explicit-group-drops-supplementary-groups.mdx
+++ b/_docs/rules/tally/user-explicit-group-drops-supplementary-groups.mdx
@@ -1,0 +1,144 @@
+---
+title: "tally/user-explicit-group-drops-supplementary-groups"
+description: "USER name:group silently drops supplementary groups established earlier in the Dockerfile."
+---
+
+USER name:group silently drops supplementary groups established earlier in the Dockerfile.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning |
+| Category | Security |
+| Default  | Enabled |
+| Auto-fix | Yes (suggestion) |
+| Platforms | Linux + Windows |
+
+## Description
+
+Docker's [`USER`](https://docs.docker.com/reference/dockerfile/#user) reference
+is explicit about an easy-to-miss behavior:
+
+> Note that when specifying a group for the user, the user will have only the
+> specified group membership. Any other configured group memberships will be
+> ignored.
+
+This applies to both Linux and Windows containers. Any supplementary group
+the Dockerfile adds the user to via one of these commands is silently dropped
+the moment `USER name:group` takes effect:
+
+| Platform   | Commands                                                             |
+|------------|----------------------------------------------------------------------|
+| Linux      | `useradd -G`, `usermod -aG` / `-G`, `gpasswd -a`, `adduser USER GROUP`, `addgroup USER GROUP` |
+| Windows cmd | `net localgroup <GROUP> <USER> /add`                                |
+| Windows PS  | `Add-LocalGroupMember -Group <GROUP> -Member <USER>`                |
+
+The most common real-world symptom on Linux is a user added to the `docker`
+group then locked out of `/var/run/docker.sock` at runtime. On Windows, the
+corresponding symptom is a user added to a local group (for example a
+custom `app-writers` group) then unable to access files whose ACL only grants
+that group.
+
+## Examples
+
+### Bad — Linux
+
+```dockerfile
+FROM ubuntu:22.04
+RUN groupadd -r docker && \
+    useradd -r -g app -G docker,wheel app
+USER app:app
+```
+
+The `docker` and `wheel` supplementary groups are dropped at runtime.
+
+### Bad — Windows cmd
+
+```dockerfile
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN net user app password /add && net localgroup docker app /add
+USER app:docker
+```
+
+`app` is added to `docker` via `net localgroup /add`, but `USER app:docker`
+restricts the process to only the `docker` token — any other local-group
+membership is dropped.
+
+### Bad — Windows PowerShell
+
+```dockerfile
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+SHELL ["pwsh", "-Command"]
+RUN New-LocalUser -Name app -NoPassword -AccountNeverExpires ; \
+    Add-LocalGroupMember -Group docker -Member app
+USER app:docker
+```
+
+### Good — drop the explicit group
+
+```dockerfile
+FROM ubuntu:22.04
+RUN useradd -r -g app -G docker app
+USER app
+```
+
+Docker uses the user's primary group from `/etc/passwd` (or the Windows
+token) plus every supplementary group that was added.
+
+## Suppression
+
+The rule does not fire when:
+
+- The `USER` instruction uses no explicit group (`USER app` rather than `USER app:group`).
+- The user is root or UID 0.
+- The user specifier is numeric (`USER 1000:1000`). We do not correlate UIDs
+  to `useradd`-created accounts; the rule targets named identities.
+- The stage is passwd-less (scratch-rooted without a copied `/etc/passwd`).
+  That case belongs to `tally/named-identity-in-passwdless-stage`.
+
+## Suggested fix
+
+The rule proposes a `FixSuggestion` that removes the `:group` portion so
+the user's supplementary groups survive. Run with `--fix --fix-unsafe` to
+apply it.
+
+```dockerfile
+# Before
+USER app:app
+
+# After
+USER app
+```
+
+If the explicit group was an intentional primary-group override, keep the
+current form and resolve the rule via configuration:
+
+```toml
+[rules.tally.user-explicit-group-drops-supplementary-groups]
+severity = "off"
+```
+
+## Related rules
+
+- [`tally/named-identity-in-passwdless-stage`](./named-identity-in-passwdless-stage) —
+  fires in scratch-rooted stages where `/etc/passwd` is missing. Passwd-less
+  stages are explicitly skipped by this rule to avoid overlapping edits on
+  the same operand.
+- [`tally/user-created-but-never-used`](./user-created-but-never-used) —
+  fires when the final stage never switches to a non-root user.
+  Complementary; our rule requires an explicit non-root USER.
+- [`tally/copy-after-user-without-chown`](./copy-after-user-without-chown) —
+  targets COPY/ADD ownership, not USER. Complementary.
+
+## Configuration
+
+```toml
+[rules.tally.user-explicit-group-drops-supplementary-groups]
+severity = "warning"  # Options: "off", "error", "warning", "info", "style"
+```
+
+## References
+
+- Docker Dockerfile reference: [USER](https://docs.docker.com/reference/dockerfile/#user)
+- `setgroups(2)` (Linux) — the syscall whose effects are described above
+- [Microsoft Add-LocalGroupMember cmdlet](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/add-localgroupmember)
+- [Microsoft `net localgroup` reference](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc754051(v=ws.11))

--- a/internal/integration/__snapshots__/TestFix_user-explicit-group-drops-supplementary-groups-linux_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_user-explicit-group-drops-supplementary-groups-linux_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:22.04
+RUN useradd -G docker app
+USER app

--- a/internal/integration/__snapshots__/TestFix_user-explicit-group-drops-supplementary-groups-no-group-no-fix_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_user-explicit-group-drops-supplementary-groups-no-group-no-fix_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:22.04
+RUN useradd -G docker app
+USER app

--- a/internal/integration/__snapshots__/TestFix_user-explicit-group-drops-supplementary-groups-windows_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_user-explicit-group-drops-supplementary-groups-windows_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN net user app password /add && net localgroup docker app /add
+USER app

--- a/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "files_scanned": 1,
-  "rules_enabled": 101,
+  "rules_enabled": 102,
   "summary": {
     "errors": 0,
     "files": 0,

--- a/internal/integration/__snapshots__/TestLint_user-explicit-group-drops-supplementary-groups_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_user-explicit-group-drops-supplementary-groups_1.snap.json
@@ -1,0 +1,175 @@
+{
+  "files": [
+    {
+      "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+      "violations": [
+        {
+          "detail": "Docker's USER name:group sets ONLY the given group at runtime. Supplementary groups added earlier — via useradd -G / adduser / addgroup / usermod -aG / gpasswd on Linux, or net localgroup /add / Add-LocalGroupMember on Windows — are silently dropped. Drop the \":group\" portion to preserve supplementary group membership, or accept the explicit group as an intentional primary-group override.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/user-explicit-group-drops-supplementary-groups/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 5
+            },
+            "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 5
+            }
+          },
+          "message": "USER \"app\" specifies explicit group \"app\" but this user has supplementary groups (docker, wheel) that Docker will ignore",
+          "rule": "tally/user-explicit-group-drops-supplementary-groups",
+          "severity": "warning",
+          "sourceCode": "USER app:app",
+          "suggestedFix": {
+            "description": "Drop \":app\" from USER (Docker would otherwise drop supplementary groups)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 12,
+                    "line": 5
+                  },
+                  "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+                  "start": {
+                    "column": 5,
+                    "line": 5
+                  }
+                },
+                "newText": "app"
+              }
+            ],
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Docker's USER name:group sets ONLY the given group at runtime. Supplementary groups added earlier — via useradd -G / adduser / addgroup / usermod -aG / gpasswd on Linux, or net localgroup /add / Add-LocalGroupMember on Windows — are silently dropped. Drop the \":group\" portion to preserve supplementary group membership, or accept the explicit group as an intentional primary-group override.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/user-explicit-group-drops-supplementary-groups/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 15
+            },
+            "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 15
+            }
+          },
+          "message": "USER \"app\" specifies explicit group \"app\" but this user has supplementary groups (docker, wheel) that Docker will ignore",
+          "rule": "tally/user-explicit-group-drops-supplementary-groups",
+          "severity": "warning",
+          "sourceCode": "USER app:app",
+          "suggestedFix": {
+            "description": "Drop \":app\" from USER (Docker would otherwise drop supplementary groups)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 12,
+                    "line": 15
+                  },
+                  "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+                  "start": {
+                    "column": 5,
+                    "line": 15
+                  }
+                },
+                "newText": "app"
+              }
+            ],
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Docker's USER name:group sets ONLY the given group at runtime. Supplementary groups added earlier — via useradd -G / adduser / addgroup / usermod -aG / gpasswd on Linux, or net localgroup /add / Add-LocalGroupMember on Windows — are silently dropped. Drop the \":group\" portion to preserve supplementary group membership, or accept the explicit group as an intentional primary-group override.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/user-explicit-group-drops-supplementary-groups/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 21
+            },
+            "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 21
+            }
+          },
+          "message": "USER \"app\" specifies explicit group \"docker\" but this user has supplementary groups (docker) that Docker will ignore",
+          "rule": "tally/user-explicit-group-drops-supplementary-groups",
+          "severity": "warning",
+          "sourceCode": "USER app:docker",
+          "suggestedFix": {
+            "description": "Drop \":docker\" from USER (Docker would otherwise drop supplementary groups)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 15,
+                    "line": 21
+                  },
+                  "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+                  "start": {
+                    "column": 5,
+                    "line": 21
+                  }
+                },
+                "newText": "app"
+              }
+            ],
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Docker's USER name:group sets ONLY the given group at runtime. Supplementary groups added earlier — via useradd -G / adduser / addgroup / usermod -aG / gpasswd on Linux, or net localgroup /add / Add-LocalGroupMember on Windows — are silently dropped. Drop the \":group\" portion to preserve supplementary group membership, or accept the explicit group as an intentional primary-group override.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/user-explicit-group-drops-supplementary-groups/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 28
+            },
+            "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 28
+            }
+          },
+          "message": "USER \"app\" specifies explicit group \"docker\" but this user has supplementary groups (docker) that Docker will ignore",
+          "rule": "tally/user-explicit-group-drops-supplementary-groups",
+          "severity": "warning",
+          "sourceCode": "USER app:docker",
+          "suggestedFix": {
+            "description": "Drop \":docker\" from USER (Docker would otherwise drop supplementary groups)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 15,
+                    "line": 28
+                  },
+                  "file": "testdata/user-explicit-group-drops-supplementary-groups/Dockerfile",
+                  "start": {
+                    "column": 5,
+                    "line": 28
+                  }
+                },
+                "newText": "app"
+              }
+            ],
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 4,
+    "warnings": 4
+  }
+}

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -2262,6 +2262,36 @@ severity = "warning"
 			wantApplied: 1,
 		},
 
+		// user-explicit-group-drops-supplementary-groups: drop :group from USER
+		// (FixSuggestion — applies only with --fix-unsafe)
+		{
+			name:  "user-explicit-group-drops-supplementary-groups-linux",
+			input: "FROM ubuntu:22.04\nRUN useradd -G docker app\nUSER app:app\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/user-explicit-group-drops-supplementary-groups")...),
+			wantApplied: 1,
+		},
+		{
+			name: "user-explicit-group-drops-supplementary-groups-windows",
+			input: "FROM mcr.microsoft.com/windows/servercore:ltsc2022\n" +
+				"RUN net user app password /add && net localgroup docker app /add\n" +
+				"USER app:docker\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/user-explicit-group-drops-supplementary-groups")...),
+			wantApplied: 1,
+		},
+		// Bare USER (no explicit group) — no fix applied
+		{
+			name:  "user-explicit-group-drops-supplementary-groups-no-group-no-fix",
+			input: "FROM ubuntu:22.04\nRUN useradd -G docker app\nUSER app\n",
+			args: append(
+				[]string{"--fix", "--fix-unsafe"},
+				mustSelectRules("tally/user-explicit-group-drops-supplementary-groups")...),
+			wantApplied: 0,
+		},
+
 		// copy-after-user-without-chown: adds --chown flag (preferred fix)
 		{
 			name:  "copy-after-user-without-chown-basic",

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -1184,5 +1184,14 @@ func lintCases(t *testing.T) []lintCase {
 			args:     append([]string{"--format", "json"}, mustSelectRules("tally/copy-after-user-without-chown")...),
 			wantExit: 1,
 		},
+
+		// USER name:group drops supplementary groups (Linux + Windows)
+		{
+			name: "user-explicit-group-drops-supplementary-groups",
+			dir:  "user-explicit-group-drops-supplementary-groups",
+			args: append([]string{"--format", "json"},
+				mustSelectRules("tally/user-explicit-group-drops-supplementary-groups")...),
+			wantExit: 1,
+		},
 	}
 }

--- a/internal/integration/testdata/user-explicit-group-drops-supplementary-groups/Dockerfile
+++ b/internal/integration/testdata/user-explicit-group-drops-supplementary-groups/Dockerfile
@@ -1,0 +1,28 @@
+# Linux: useradd -G establishes supplementary groups; USER app:app drops them.
+FROM ubuntu:22.04 AS linux-fires
+RUN groupadd -r docker && \
+    useradd -r -g app -G docker,wheel app
+USER app:app
+
+# Linux no-fire: bare USER app preserves supplementary groups.
+FROM ubuntu:22.04 AS linux-clean
+RUN useradd -r -g app -G docker app
+USER app
+
+# Linux FROM-ancestry: supplementary groups established in parent stage,
+# explicit group specified in child stage.
+FROM linux-fires AS linux-ancestry
+USER app:app
+CMD ["app"]
+
+# Windows cmd: net localgroup /add establishes membership; USER drops it.
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS windows-cmd-fires
+RUN net user app password /add && net localgroup docker app /add
+USER app:docker
+
+# Windows PowerShell: Add-LocalGroupMember establishes membership;
+# USER app:docker drops it.
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS windows-ps-fires
+SHELL ["pwsh", "-Command"]
+RUN New-LocalUser -Name app -NoPassword -AccountNeverExpires ; Add-LocalGroupMember -Group docker -Member app
+USER app:docker

--- a/internal/rules/tally/__snapshots__/TestUserExplicitGroupDropsSupplementaryGroupsMetadata_1.snap.json
+++ b/internal/rules/tally/__snapshots__/TestUserExplicitGroupDropsSupplementaryGroupsMetadata_1.snap.json
@@ -1,0 +1,10 @@
+{
+ "Category": "security",
+ "Code": "tally/user-explicit-group-drops-supplementary-groups",
+ "DefaultSeverity": "warning",
+ "Description": "USER name:group drops supplementary groups the Dockerfile established via useradd -G / usermod / gpasswd / net localgroup / Add-LocalGroupMember",
+ "DocURL": "https://tally.wharflab.com/rules/tally/user-explicit-group-drops-supplementary-groups/",
+ "FixPriority": 0,
+ "IsExperimental": false,
+ "Name": "USER explicit group drops supplementary groups"
+}

--- a/internal/rules/tally/user_created_but_never_used.go
+++ b/internal/rules/tally/user_created_but_never_used.go
@@ -192,7 +192,11 @@ func (r *UserCreatedButNeverUsedRule) buildFix(
 }
 
 // collectUserCreations scans the final stage and its FROM ancestry chain
-// for user creation commands (useradd, adduser, net user /add, New-LocalUser).
+// for user-creation commands (useradd, adduser, net user /add, New-LocalUser).
+//
+// When evidence comes from an observable file (COPY heredoc, build context
+// script), the userCreation is attributed to the stage's first RUN as a
+// best-effort source position.
 func collectUserCreations(
 	input rules.LintInput,
 	fileFacts *facts.FileFacts,
@@ -200,140 +204,24 @@ func collectUserCreations(
 ) []userCreation {
 	var creations []userCreation
 
-	// Scan the final stage itself.
-	creations = append(creations, findStageUserCreations(fileFacts, finalIdx)...)
-
-	// Walk the FROM ancestry chain.
-	var model = input.Semantic
-	if model == nil {
-		return creations
-	}
-
-	visited := map[int]bool{finalIdx: true}
-	for idx := finalIdx; ; {
-		info := model.StageInfo(idx)
-		if info == nil || info.BaseImage == nil || !info.BaseImage.IsStageRef || info.BaseImage.StageIndex < 0 {
-			break
+	visitStageAndAncestryRunScripts(input, fileFacts, finalIdx, func(sv scriptVisit) {
+		run := sv.Run
+		if run == nil {
+			if sf := fileFacts.Stage(sv.StageIndex); sf != nil && len(sf.Runs) > 0 {
+				run = sf.Runs[0].Run
+			}
 		}
-
-		parentIdx := info.BaseImage.StageIndex
-		if visited[parentIdx] {
-			break
-		}
-		visited[parentIdx] = true
-
-		creations = append(creations, findStageUserCreations(fileFacts, parentIdx)...)
-		idx = parentIdx
-	}
-
-	return creations
-}
-
-// findStageUserCreations scans a single stage's RUN commands and observable
-// files for user creation commands.
-func findStageUserCreations(fileFacts *facts.FileFacts, stageIdx int) []userCreation {
-	sf := fileFacts.Stage(stageIdx)
-	if sf == nil {
-		return nil
-	}
-
-	var creations []userCreation
-
-	// Scan direct RUN commands.
-	for _, run := range sf.Runs {
-		cmds := findUserCreationCmds(run.CommandScript, run.Shell.Variant)
+		cmds := findUserCreationCmds(sv.Script, sv.Variant)
 		for i := range cmds {
 			creations = append(creations, userCreation{
 				username:   extractCreatedUsername(&cmds[i]),
-				stageIndex: stageIdx,
-				run:        run.Run,
+				stageIndex: sv.StageIndex,
+				run:        run,
 			})
 		}
-	}
-
-	// Scan observable files (COPY heredoc scripts, build context scripts).
-	for _, of := range sf.ObservableFiles {
-		if !looksLikeScript(of.Path) {
-			continue
-		}
-		content, ok := of.Content()
-		if !ok || content == "" {
-			continue
-		}
-		variant := shell.VariantFromScriptPath(of.Path)
-		cmds := findUserCreationCmds(content, variant)
-		if len(cmds) > 0 {
-			// Attribute to the first RUN in the stage as a best-effort location.
-			var run *instructions.RunCommand
-			if len(sf.Runs) > 0 {
-				run = sf.Runs[0].Run
-			}
-			for i := range cmds {
-				creations = append(creations, userCreation{
-					username:   extractCreatedUsername(&cmds[i]),
-					stageIndex: stageIdx,
-					run:        run,
-				})
-			}
-		}
-	}
+	})
 
 	return creations
-}
-
-// findUserCreationCmds finds user creation commands in a shell script.
-func findUserCreationCmds(script string, variant shell.Variant) []shell.CommandInfo {
-	var result []shell.CommandInfo
-
-	// Linux: useradd, adduser
-	result = append(result, shell.FindCommands(script, variant, "useradd", "adduser")...)
-
-	// Windows cmd: net user <name> /add
-	if variant == shell.VariantCmd {
-		for _, cmd := range shell.FindCommands(script, variant, "net") {
-			if !strings.EqualFold(cmd.Subcommand, "user") { //nolint:customlint // shell "user" subcommand, not Dockerfile USER
-				continue
-			}
-			if slices.ContainsFunc(cmd.Args, func(a string) bool {
-				return strings.EqualFold(a, "/add")
-			}) {
-				result = append(result, cmd)
-			}
-		}
-	}
-
-	// Windows PowerShell: New-LocalUser
-	if variant.IsPowerShell() {
-		result = append(result, shell.FindCommands(script, variant, "New-LocalUser")...)
-	}
-
-	return result
-}
-
-// extractCreatedUsername extracts the username from a user creation command.
-// For useradd/adduser: the last non-flag argument (LOGIN is always last positional).
-// For net user /add: the argument between "user" and "/add".
-// For New-LocalUser: the -Name parameter value.
-func extractCreatedUsername(cmd *shell.CommandInfo) string {
-	switch {
-	case cmd.Name == "useradd" || cmd.Name == "adduser":
-		return lastNonFlagArg(cmd.Args)
-
-	case strings.EqualFold(cmd.Name, "net"):
-		// net user <name> /add — find the positional arg that is the username.
-		for _, arg := range cmd.Args {
-			if strings.EqualFold(arg, "user") || strings.HasPrefix(arg, "/") { //nolint:customlint // shell subcommand
-				continue
-			}
-			// First non-"user", non-flag arg is the username.
-			return arg
-		}
-
-	case strings.EqualFold(cmd.Name, "New-LocalUser"):
-		return cmd.GetArgValue("-Name")
-	}
-
-	return ""
 }
 
 // lastNonFlagArg returns the last argument that doesn't start with "-".

--- a/internal/rules/tally/user_explicit_group_drops_supplementary_groups.go
+++ b/internal/rules/tally/user_explicit_group_drops_supplementary_groups.go
@@ -1,0 +1,268 @@
+package tally
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+// UserExplicitGroupDropsSupplementaryGroupsRuleCode is the full rule code.
+const UserExplicitGroupDropsSupplementaryGroupsRuleCode = rules.TallyRulePrefix +
+	"user-explicit-group-drops-supplementary-groups"
+
+// UserExplicitGroupDropsSupplementaryGroupsRule detects `USER name:group`
+// instructions that silently drop supplementary groups established earlier in
+// the Dockerfile via useradd -G / adduser / addgroup / usermod -aG / gpasswd
+// on Linux, or net localgroup /add / Add-LocalGroupMember on Windows.
+//
+// Docker's USER documentation is explicit:
+//
+//	"Note that when specifying a group for the user, the user will have only
+//	the specified group membership. Any other configured group memberships
+//	will be ignored."
+//
+// This applies to both Linux and Windows containers. The fix drops the
+// ":group" portion so Docker honors the user's supplementary group set.
+//
+// Cross-rule interaction:
+//
+//   - tally/named-identity-in-passwdless-stage: shares the USER operand span.
+//     Resolved by skipping passwd-less (scratch-rooted) stages in this rule —
+//     those are named-identity's territory.
+//   - tally/user-created-but-never-used: fires only when final effective user
+//     is root. Our rule requires an explicit USER name:group (non-root).
+//     Complementary.
+//   - tally/copy-after-user-without-chown: edits COPY/ADD. No overlap.
+type UserExplicitGroupDropsSupplementaryGroupsRule struct{}
+
+// NewUserExplicitGroupDropsSupplementaryGroupsRule creates a new rule instance.
+func NewUserExplicitGroupDropsSupplementaryGroupsRule() *UserExplicitGroupDropsSupplementaryGroupsRule {
+	return &UserExplicitGroupDropsSupplementaryGroupsRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *UserExplicitGroupDropsSupplementaryGroupsRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code: UserExplicitGroupDropsSupplementaryGroupsRuleCode,
+		Name: "USER explicit group drops supplementary groups",
+		Description: "USER name:group drops supplementary groups the Dockerfile " +
+			"established via useradd -G / usermod / gpasswd / net localgroup / Add-LocalGroupMember",
+		DocURL:          rules.TallyDocURL(UserExplicitGroupDropsSupplementaryGroupsRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "security",
+	}
+}
+
+// Check runs the rule across all stages.
+func (r *UserExplicitGroupDropsSupplementaryGroupsRule) Check(input rules.LintInput) []rules.Violation {
+	sem := input.Semantic
+	if sem == nil {
+		return nil
+	}
+	fileFacts := input.Facts
+	if fileFacts == nil {
+		return nil
+	}
+
+	meta := r.Metadata()
+	sm := input.SourceMap()
+
+	var violations []rules.Violation
+
+	for stageIdx := range sem.StageCount() {
+		sf := fileFacts.Stage(stageIdx)
+		if sf == nil || len(sf.UserCommands) == 0 {
+			continue
+		}
+
+		info := sem.StageInfo(stageIdx)
+		isWindows := info != nil && info.IsWindows()
+
+		// Defer to tally/named-identity-in-passwdless-stage for passwd-less
+		// Linux stages — it owns the USER operand span there and would rewrite
+		// to a numeric UID, which is a different intent from removing :group.
+		if !isWindows {
+			if _, _, passwdless := inheritedIdentityDBState(sem, fileFacts, stageIdx); passwdless {
+				continue
+			}
+		}
+
+		suppGroups := collectStageSupplementaryGroups(input, fileFacts, stageIdx, isWindows)
+		if len(suppGroups) == 0 {
+			continue
+		}
+
+		for _, userCmd := range sf.UserCommands {
+			if v := r.checkUserCmd(userCmd, stageIdx, suppGroups, isWindows, input.File, sm, meta); v != nil {
+				violations = append(violations, *v)
+			}
+		}
+	}
+
+	return violations
+}
+
+// checkUserCmd evaluates a single USER instruction and builds a violation if
+// it specifies an explicit group whose user has recorded supplementary groups.
+func (r *UserExplicitGroupDropsSupplementaryGroupsRule) checkUserCmd(
+	userCmd *instructions.UserCommand,
+	stageIdx int,
+	suppGroups map[string][]string,
+	isWindows bool,
+	file string,
+	sm *sourcemap.SourceMap,
+	meta rules.RuleMetadata,
+) *rules.Violation {
+	user, group := splitUserGroup(userCmd.User)
+	if group == "" || user == "" {
+		return nil
+	}
+	if facts.IsRootUser(user) {
+		return nil
+	}
+	if isNumericUser(user) {
+		return nil
+	}
+
+	key := user
+	if isWindows {
+		key = strings.ToLower(user)
+	}
+	groups, ok := suppGroups[key]
+	if !ok || len(groups) == 0 {
+		return nil
+	}
+
+	msg := fmt.Sprintf(
+		"USER %q specifies explicit group %q but this user has supplementary groups (%s) that Docker will ignore",
+		user, group, strings.Join(groups, ", "),
+	)
+
+	detail := "Docker's USER name:group sets ONLY the given group at runtime. Supplementary groups added earlier — " +
+		"via useradd -G / adduser / addgroup / usermod -aG / gpasswd on Linux, or net localgroup /add / " +
+		"Add-LocalGroupMember on Windows — are silently dropped. Drop the \":group\" portion to preserve " +
+		"supplementary group membership, or accept the explicit group as an intentional primary-group override."
+
+	loc := rules.NewLocationFromRanges(file, userCmd.Location())
+	v := rules.NewViolation(loc, meta.Code, msg, meta.DefaultSeverity).
+		WithDocURL(meta.DocURL).
+		WithDetail(detail)
+	v.StageIndex = stageIdx
+
+	if fix := r.buildFix(userCmd, user, group, file, sm); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+
+	return &v
+}
+
+// buildFix removes the ":group" portion of USER name:group, preserving
+// indentation, keyword casing, and any surrounding whitespace. The edit range
+// is narrow (operand only), so formatting rules compose cleanly.
+//
+// Safety is FixSuggestion because the explicit group may have been an
+// intentional primary-group override.
+func (r *UserExplicitGroupDropsSupplementaryGroupsRule) buildFix(
+	userCmd *instructions.UserCommand,
+	user, group, file string,
+	sm *sourcemap.SourceMap,
+) *rules.SuggestedFix {
+	locs := userCmd.Location()
+	if len(locs) == 0 || sm == nil {
+		return nil
+	}
+
+	originalOperand := userCmd.User
+	if originalOperand == "" {
+		return nil
+	}
+
+	startLine := locs[0].Start.Line
+	endLine := sm.ResolveEndLine(locs[0].End.Line)
+
+	// Scan the instruction's full physical-line span so continuation forms
+	// (USER \ on one line, operand on the next) land the edit on the correct
+	// physical line.
+	for lineNum := startLine; lineNum <= endLine; lineNum++ {
+		srcLine := sm.Line(lineNum - 1) // SourceMap is 0-based
+		idx := strings.Index(srcLine, originalOperand)
+		if idx < 0 {
+			continue
+		}
+
+		return &rules.SuggestedFix{
+			Description: fmt.Sprintf(
+				"Drop %q from USER (Docker would otherwise drop supplementary groups)",
+				":"+group,
+			),
+			Safety: rules.FixSuggestion,
+			Edits: []rules.TextEdit{{
+				Location: rules.NewRangeLocation(file, lineNum, idx, lineNum, idx+len(originalOperand)),
+				NewText:  user,
+			}},
+		}
+	}
+
+	return nil
+}
+
+// collectStageSupplementaryGroups walks the given stage and its FROM ancestry
+// chain, returning a map of username → sorted-unique supplementary groups.
+// When isWindows is true, usernames are lower-cased to make matching
+// case-insensitive (Windows account names are case-insensitive).
+func collectStageSupplementaryGroups(
+	input rules.LintInput,
+	fileFacts *facts.FileFacts,
+	stageIdx int,
+	isWindows bool,
+) map[string][]string {
+	sets := map[string]map[string]bool{}
+
+	visitStageAndAncestryRunScripts(input, fileFacts, stageIdx, func(sv scriptVisit) {
+		for _, m := range findUserMembershipCmds(sv.Script, sv.Variant) {
+			if m.User == "" || len(m.Groups) == 0 {
+				continue
+			}
+			key := m.User
+			if isWindows {
+				key = strings.ToLower(key)
+			}
+			set, ok := sets[key]
+			if !ok {
+				set = map[string]bool{}
+				sets[key] = set
+			}
+			for _, g := range m.Groups {
+				g = strings.TrimSpace(g)
+				if g != "" {
+					set[g] = true
+				}
+			}
+		}
+	})
+
+	if len(sets) == 0 {
+		return nil
+	}
+
+	out := make(map[string][]string, len(sets))
+	for user, set := range sets {
+		groups := make([]string, 0, len(set))
+		for g := range set {
+			groups = append(groups, g)
+		}
+		slices.Sort(groups)
+		out[user] = groups
+	}
+	return out
+}
+
+func init() {
+	rules.Register(NewUserExplicitGroupDropsSupplementaryGroupsRule())
+}

--- a/internal/rules/tally/user_explicit_group_drops_supplementary_groups_test.go
+++ b/internal/rules/tally/user_explicit_group_drops_supplementary_groups_test.go
@@ -1,0 +1,392 @@
+package tally
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+
+	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestUserExplicitGroupDropsSupplementaryGroupsMetadata(t *testing.T) {
+	t.Parallel()
+	snaps.MatchStandaloneJSON(t, NewUserExplicitGroupDropsSupplementaryGroupsRule().Metadata())
+}
+
+func TestUserExplicitGroupDropsSupplementaryGroupsCheck(t *testing.T) {
+	t.Parallel()
+
+	rule := NewUserExplicitGroupDropsSupplementaryGroupsRule()
+
+	testutil.RunRuleTests(t, rule, []testutil.RuleTestCase{
+		// --- Linux fires ---
+		{
+			Name: "useradd -G single group fires",
+			Content: `FROM ubuntu:22.04
+RUN useradd -G docker app
+USER app:app
+`,
+			WantViolations: 1,
+			WantMessages:   []string{`USER "app" specifies explicit group "app"`},
+		},
+		{
+			Name: "useradd -G comma list fires",
+			Content: `FROM ubuntu:22.04
+RUN useradd -G docker,wheel app
+USER app:app
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"(docker, wheel)"},
+		},
+		{
+			Name: "useradd --groups=value fires",
+			Content: `FROM ubuntu:22.04
+RUN useradd --groups=docker app
+USER app:app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "useradd -g primary and -G supplementary fires",
+			Content: `FROM ubuntu:22.04
+RUN useradd -g app -G docker app
+USER app:app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "usermod -aG fires",
+			Content: `FROM ubuntu:22.04
+RUN useradd app && usermod -aG docker app
+USER app:app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "usermod -a -G split fires",
+			Content: `FROM ubuntu:22.04
+RUN useradd app && usermod -a -G docker app
+USER app:app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "usermod -G replace form fires",
+			Content: `FROM ubuntu:22.04
+RUN useradd app && usermod -G docker app
+USER app:app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "gpasswd -a fires",
+			Content: `FROM ubuntu:22.04
+RUN useradd alice && gpasswd -a alice wheel
+USER alice:alice
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "adduser USER GROUP BusyBox membership fires",
+			Content: `FROM alpine:3.19
+RUN adduser -D alice && adduser alice wheel
+USER alice:alice
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "addgroup USER GROUP membership fires",
+			Content: `FROM alpine:3.19
+RUN adduser -D alice && addgroup alice docker
+USER alice:alice
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "FROM ancestry parent useradd -G child USER",
+			Content: `FROM ubuntu:22.04 AS base
+RUN useradd -G docker app
+
+FROM base AS final
+USER app:app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "heredoc useradd -G fires",
+			Content: `FROM ubuntu:22.04
+RUN <<EOF
+useradd -G docker app
+EOF
+USER app:app
+`,
+			WantViolations: 1,
+		},
+
+		// --- Linux no-fires ---
+		{
+			Name: "useradd -g primary only no fire",
+			Content: `FROM ubuntu:22.04
+RUN useradd -g app app
+USER app:app
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bare USER name no fire",
+			Content: `FROM ubuntu:22.04
+RUN useradd -G docker app
+USER app
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "different username in USER no fire",
+			Content: `FROM ubuntu:22.04
+RUN useradd -G docker app
+USER alice:alice
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "addgroup creation only no fire",
+			Content: `FROM alpine:3.19
+RUN addgroup -S docker && adduser -D alice
+USER alice:alice
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "numeric USER no fire",
+			Content: `FROM ubuntu:22.04
+RUN useradd -u 1000 -G docker app
+USER 1000:1000
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "root USER no fire",
+			Content: `FROM ubuntu:22.04
+RUN useradd -G docker app
+USER root:root
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "passwd-less scratch stage yields to named-identity rule",
+			Content: `FROM golang:1.22 AS builder
+RUN useradd -G docker app
+
+FROM scratch
+COPY --from=builder /myapp /myapp
+USER app:app
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "parent supplementary but child USER without group",
+			Content: `FROM ubuntu:22.04 AS base
+RUN useradd -G docker app
+
+FROM base AS final
+USER app
+`,
+			WantViolations: 0,
+		},
+
+		// --- Windows fires ---
+		{
+			Name: "windows cmd net localgroup fires",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN net user app password /add && net localgroup Administrators app /add
+USER app:Administrators
+`,
+			WantViolations: 1,
+			WantMessages:   []string{`USER "app" specifies explicit group "Administrators"`},
+		},
+		{
+			Name: "windows PowerShell Add-LocalGroupMember fires",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+SHELL ["pwsh", "-Command"]
+RUN New-LocalUser -Name app -NoPassword -AccountNeverExpires ; Add-LocalGroupMember -Group docker -Member app
+USER app:docker
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "windows case-insensitive matching fires",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+SHELL ["pwsh", "-Command"]
+RUN Add-LocalGroupMember -Group docker -Member App
+USER app:docker
+`,
+			WantViolations: 1,
+		},
+
+		// --- Windows no-fires ---
+		{
+			Name: "windows bare USER no fire",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN net user app password /add && net localgroup Administrators app /add
+USER app
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestUserExplicitGroupDropsSupplementaryGroupsCheckWithFixes(t *testing.T) {
+	t.Parallel()
+
+	rule := NewUserExplicitGroupDropsSupplementaryGroupsRule()
+
+	tests := []struct {
+		name           string
+		content        string
+		wantHasFix     bool
+		wantFixContain string
+		wantSafety     rules.FixSafety
+	}{
+		{
+			name: "linux USER name:group dropped to USER name",
+			content: `FROM ubuntu:22.04
+RUN useradd -G docker app
+USER app:app
+`,
+			wantHasFix:     true,
+			wantFixContain: "app",
+			wantSafety:     rules.FixSuggestion,
+		},
+		{
+			name: "linux USER name:different-group dropped",
+			content: `FROM ubuntu:22.04
+RUN useradd -g staff -G docker app
+USER app:docker
+`,
+			wantHasFix:     true,
+			wantFixContain: "app",
+			wantSafety:     rules.FixSuggestion,
+		},
+		{
+			name: "windows USER app:Administrators dropped",
+			content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN net user app pass /add && net localgroup Administrators app /add
+USER app:Administrators
+`,
+			wantHasFix:     true,
+			wantFixContain: "app",
+			wantSafety:     rules.FixSuggestion,
+		},
+		{
+			name: "continuation line USER operand on second line",
+			content: `FROM ubuntu:22.04
+RUN useradd -G docker app
+USER \
+  app:app
+`,
+			wantHasFix:     true,
+			wantFixContain: "app",
+			wantSafety:     rules.FixSuggestion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := testutil.MakeLintInput(t, "Dockerfile", tt.content)
+			violations := rule.Check(input)
+			if len(violations) == 0 {
+				t.Fatal("expected at least one violation")
+			}
+			v := violations[0]
+			hasFix := v.SuggestedFix != nil
+			if hasFix != tt.wantHasFix {
+				t.Errorf("hasFix = %v, want %v", hasFix, tt.wantHasFix)
+			}
+			if !hasFix {
+				return
+			}
+			if v.SuggestedFix.Safety != tt.wantSafety {
+				t.Errorf("safety = %v, want %v", v.SuggestedFix.Safety, tt.wantSafety)
+			}
+			found := false
+			for _, edit := range v.SuggestedFix.Edits {
+				if strings.Contains(edit.NewText, tt.wantFixContain) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("fix edits do not contain %q", tt.wantFixContain)
+				for _, edit := range v.SuggestedFix.Edits {
+					t.Logf("  edit: %q", edit.NewText)
+				}
+			}
+		})
+	}
+}
+
+func TestUserExplicitGroupDropsSupplementaryGroupsFixApplies(t *testing.T) {
+	t.Parallel()
+
+	rule := NewUserExplicitGroupDropsSupplementaryGroupsRule()
+
+	tests := []struct {
+		name   string
+		before string
+		after  string
+	}{
+		{
+			name: "linux simple drop",
+			before: `FROM ubuntu:22.04
+RUN useradd -G docker app
+USER app:app
+`,
+			after: `FROM ubuntu:22.04
+RUN useradd -G docker app
+USER app
+`,
+		},
+		{
+			name: "linux preserves indentation",
+			before: `FROM ubuntu:22.04
+RUN useradd -G docker app
+   USER app:docker
+`,
+			after: `FROM ubuntu:22.04
+RUN useradd -G docker app
+   USER app
+`,
+		},
+		{
+			name: "windows net localgroup",
+			before: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN net user app pass /add && net localgroup Administrators app /add
+USER app:Administrators
+`,
+			after: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN net user app pass /add && net localgroup Administrators app /add
+USER app
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := testutil.MakeLintInput(t, "Dockerfile", tt.before)
+			violations := rule.Check(input)
+			if len(violations) == 0 {
+				t.Fatal("expected at least one violation")
+			}
+			got := string(fix.ApplyFix([]byte(tt.before), violations[0].SuggestedFix))
+			if got != tt.after {
+				t.Errorf("after-fix mismatch\ngot:\n%s\nwant:\n%s", got, tt.after)
+			}
+		})
+	}
+}

--- a/internal/rules/tally/user_management_scan.go
+++ b/internal/rules/tally/user_management_scan.go
@@ -1,0 +1,512 @@
+package tally
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
+)
+
+// scriptVisit carries a single script exposure for visitStageAndAncestryRunScripts.
+// run is nil when the script originated from an observable file.
+type scriptVisit struct {
+	StageIndex int
+	Script     string
+	Variant    shell.Variant
+	Run        *instructions.RunCommand
+}
+
+// visitStageAndAncestryRunScripts iterates every RUN command script and every
+// observable script-like file across the given stage and its FROM ancestry
+// chain, calling visit in source order (stage first, then ancestors). The
+// visitor receives the stage that produced the script so rules can attribute
+// evidence correctly; run is nil when the script originated from an
+// observable file.
+//
+// Variant resolution:
+//   - RUN scripts use the stage's effective shell variant.
+//   - Observable files use shell.VariantFromScriptPath (extension-based).
+func visitStageAndAncestryRunScripts(
+	input rules.LintInput,
+	fileFacts *facts.FileFacts,
+	startStageIdx int,
+	visit func(v scriptVisit),
+) {
+	visitOneStage := func(stageIdx int) {
+		sf := fileFacts.Stage(stageIdx)
+		if sf == nil {
+			return
+		}
+		for _, run := range sf.Runs {
+			visit(scriptVisit{
+				StageIndex: stageIdx,
+				Script:     run.CommandScript,
+				Variant:    run.Shell.Variant,
+				Run:        run.Run,
+			})
+		}
+		for _, of := range sf.ObservableFiles {
+			if !looksLikeScript(of.Path) {
+				continue
+			}
+			content, ok := of.Content()
+			if !ok || content == "" {
+				continue
+			}
+			visit(scriptVisit{
+				StageIndex: stageIdx,
+				Script:     content,
+				Variant:    shell.VariantFromScriptPath(of.Path),
+				Run:        nil,
+			})
+		}
+	}
+
+	visitOneStage(startStageIdx)
+
+	model := input.Semantic
+	if model == nil {
+		return
+	}
+
+	visited := map[int]bool{startStageIdx: true}
+	for idx := startStageIdx; ; {
+		info := model.StageInfo(idx)
+		if info == nil || info.BaseImage == nil ||
+			!info.BaseImage.IsStageRef || info.BaseImage.StageIndex < 0 {
+			return
+		}
+		parentIdx := info.BaseImage.StageIndex
+		if visited[parentIdx] {
+			return
+		}
+		visited[parentIdx] = true
+		visitOneStage(parentIdx)
+		idx = parentIdx
+	}
+}
+
+// findUserCreationCmds finds user-creation commands in a shell script.
+// Linux: useradd, adduser.
+// Windows cmd: net user <name> /add.
+// PowerShell: New-LocalUser.
+func findUserCreationCmds(script string, variant shell.Variant) []shell.CommandInfo {
+	var result []shell.CommandInfo
+
+	result = append(result, shell.FindCommands(script, variant, "useradd", "adduser")...)
+
+	if variant == shell.VariantCmd {
+		for _, cmd := range shell.FindCommands(script, variant, "net") {
+			if !strings.EqualFold(cmd.Subcommand, "user") { //nolint:customlint // shell "user" subcommand, not Dockerfile USER
+				continue
+			}
+			if slices.ContainsFunc(cmd.Args, func(a string) bool {
+				return strings.EqualFold(a, "/add")
+			}) {
+				result = append(result, cmd)
+			}
+		}
+	}
+
+	if variant.IsPowerShell() {
+		result = append(result, shell.FindCommands(script, variant, "New-LocalUser")...)
+	}
+
+	return result
+}
+
+// extractCreatedUsername extracts the username from a user-creation command.
+// For useradd/adduser: the last non-flag argument (LOGIN is always last positional).
+// For net user /add: the argument between "user" and "/add".
+// For New-LocalUser: the -Name parameter value.
+func extractCreatedUsername(cmd *shell.CommandInfo) string {
+	switch {
+	case cmd.Name == "useradd" || cmd.Name == "adduser":
+		return lastNonFlagArg(cmd.Args)
+
+	case strings.EqualFold(cmd.Name, "net"):
+		for _, arg := range cmd.Args {
+			if strings.EqualFold(arg, "user") || strings.HasPrefix(arg, "/") { //nolint:customlint // shell subcommand
+				continue
+			}
+			return arg
+		}
+
+	case strings.EqualFold(cmd.Name, "New-LocalUser"):
+		return cmd.GetArgValue("-Name")
+	}
+
+	return ""
+}
+
+// membershipInfo is a single user-to-supplementary-group-assignment record
+// extracted from a shell command such as `useradd -G`, `usermod -aG`,
+// `gpasswd -a`, `net localgroup /add`, or `Add-LocalGroupMember`.
+type membershipInfo struct {
+	User   string
+	Groups []string
+}
+
+// findUserMembershipCmds returns every supplementary-group assignment found
+// in a shell script. Each returned membershipInfo records the assignment's
+// user and the groups it establishes.
+//
+// Linux (POSIX-family):
+//   - useradd -G g1,g2 user  / useradd --groups=g user  (NOT -g/--gid alone)
+//   - usermod -aG g user / usermod -a -G g user / usermod -G g user
+//   - gpasswd -a user group
+//   - adduser USER GROUP  (membership form: 2 positionals, no creation flags)
+//   - addgroup USER GROUP (membership form: 2 positionals, no creation flags)
+//
+// Windows cmd:
+//   - net localgroup <GROUP> <USER> /add
+//
+// Windows PowerShell:
+//   - Add-LocalGroupMember -Group <G> -Member <U>
+//   - Add-LocalGroupMember <G> <U>   (positional fallback)
+//
+// PowerShell -Member values that look like arrays (start with "@(") or
+// contain commas are conservatively skipped — false positives on those
+// shapes are more costly than the occasional missed catch.
+func findUserMembershipCmds(script string, variant shell.Variant) []membershipInfo {
+	var out []membershipInfo
+
+	if variant.SupportsPOSIXShellAST() {
+		out = append(out, findPOSIXMembershipCmds(script, variant)...)
+	}
+
+	if variant == shell.VariantCmd {
+		out = append(out, findCmdMembershipCmds(script, variant)...)
+	}
+
+	if variant.IsPowerShell() {
+		out = append(out, findPowerShellMembershipCmds(script, variant)...)
+	}
+
+	return out
+}
+
+func findPOSIXMembershipCmds(script string, variant shell.Variant) []membershipInfo {
+	var out []membershipInfo
+
+	for _, cmd := range shell.FindCommands(script, variant, "useradd") {
+		groups := commaSplitNonEmpty(firstNonEmptyArgValue(&cmd, "-G", "--groups"))
+		if len(groups) == 0 {
+			continue
+		}
+		user := lastNonFlagArg(cmd.Args)
+		if user == "" {
+			continue
+		}
+		out = append(out, membershipInfo{User: user, Groups: groups})
+	}
+
+	for _, cmd := range shell.FindCommands(script, variant, "usermod") {
+		rawGroups := usermodGroupsValue(&cmd)
+		groups := commaSplitNonEmpty(rawGroups)
+		if len(groups) == 0 {
+			continue
+		}
+		user := lastNonFlagArg(cmd.Args)
+		if user == "" {
+			continue
+		}
+		out = append(out, membershipInfo{User: user, Groups: groups})
+	}
+
+	for _, cmd := range shell.FindCommands(script, variant, "gpasswd") {
+		if !cmd.HasFlag("-a") && !cmd.HasFlag("--add") {
+			continue
+		}
+		user, group := gpasswdAddTarget(&cmd)
+		if user == "" || group == "" {
+			continue
+		}
+		out = append(out, membershipInfo{User: user, Groups: []string{group}})
+	}
+
+	for _, cmd := range shell.FindCommands(script, variant, "adduser") {
+		user, group, ok := twoPositionalMembership(&cmd, adduserCreationFlags)
+		if !ok {
+			continue
+		}
+		out = append(out, membershipInfo{User: user, Groups: []string{group}})
+	}
+
+	for _, cmd := range shell.FindCommands(script, variant, "addgroup") {
+		user, group, ok := twoPositionalMembership(&cmd, addgroupCreationFlags)
+		if !ok {
+			continue
+		}
+		out = append(out, membershipInfo{User: user, Groups: []string{group}})
+	}
+
+	return out
+}
+
+func findCmdMembershipCmds(script string, variant shell.Variant) []membershipInfo {
+	var out []membershipInfo
+
+	for _, cmd := range shell.FindCommands(script, variant, "net") {
+		if !strings.EqualFold(cmd.Subcommand, "localgroup") {
+			continue
+		}
+		if !slices.ContainsFunc(cmd.Args, func(a string) bool {
+			return strings.EqualFold(a, "/add")
+		}) {
+			continue
+		}
+		group, user := netLocalgroupAddTargets(&cmd)
+		if group == "" || user == "" {
+			continue
+		}
+		out = append(out, membershipInfo{User: user, Groups: []string{group}})
+	}
+
+	return out
+}
+
+func findPowerShellMembershipCmds(script string, variant shell.Variant) []membershipInfo {
+	var out []membershipInfo
+
+	for _, cmd := range shell.FindCommands(script, variant, "Add-LocalGroupMember") {
+		group := cmd.GetArgValue("-Group")
+		member := cmd.GetArgValue("-Member")
+
+		if group == "" || member == "" {
+			g, m, ok := twoPositionalValues(&cmd)
+			if !ok {
+				continue
+			}
+			if group == "" {
+				group = g
+			}
+			if member == "" {
+				member = m
+			}
+		}
+
+		if group == "" || member == "" {
+			continue
+		}
+		if strings.HasPrefix(member, "@(") || strings.Contains(member, ",") {
+			continue
+		}
+
+		out = append(out, membershipInfo{User: member, Groups: []string{group}})
+	}
+
+	return out
+}
+
+// twoPositionalMembership applies the "exactly 2 positionals, no creation
+// flags" heuristic used to distinguish adduser/addgroup membership form from
+// creation form.
+func twoPositionalMembership(cmd *shell.CommandInfo, creationFlags map[string]bool) (user, group string, ok bool) {
+	var positionals []string
+	for _, arg := range cmd.Args {
+		if strings.HasPrefix(arg, "-") {
+			if creationFlagsMatch(arg, creationFlags) {
+				return "", "", false
+			}
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+	if len(positionals) != 2 {
+		return "", "", false
+	}
+	return positionals[0], positionals[1], true
+}
+
+// creationFlagsMatch reports whether a flag token is a creation-ish flag
+// that disqualifies the membership interpretation.
+func creationFlagsMatch(flag string, creationFlags map[string]bool) bool {
+	bare, _, _ := strings.Cut(flag, "=")
+	if creationFlags[bare] {
+		return true
+	}
+	if strings.HasPrefix(bare, "--") || !strings.HasPrefix(bare, "-") {
+		return false
+	}
+	for _, r := range bare[1:] {
+		if creationFlags["-"+string(r)] {
+			return true
+		}
+	}
+	return false
+}
+
+// twoPositionalValues extracts exactly two non-flag arguments from a
+// PowerShell command. Returns ok=false if fewer or more than two exist.
+func twoPositionalValues(cmd *shell.CommandInfo) (first, second string, ok bool) {
+	var positionals []string
+	for i := 0; i < len(cmd.Args); i++ {
+		arg := cmd.Args[i]
+		if strings.HasPrefix(arg, "-") {
+			i++
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+	if len(positionals) != 2 {
+		return "", "", false
+	}
+	return positionals[0], positionals[1], true
+}
+
+// usermodGroupsValue returns the value of usermod's -G / --groups flag,
+// handling the combined short-flag form (e.g., `usermod -aG docker app`)
+// which cmd.GetArgValue does not understand because "-aG" != "-G".
+func usermodGroupsValue(cmd *shell.CommandInfo) string {
+	if v := firstNonEmptyArgValue(cmd, "-G", "--groups"); v != "" {
+		return v
+	}
+	for i, arg := range cmd.Args {
+		if !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
+			continue
+		}
+		// Short combined form: a single leading "-" followed by a run of
+		// boolean short flags, optionally ending with -G. The value for -G
+		// is the next positional arg.
+		body := arg[1:]
+		if !strings.ContainsRune(body, 'G') {
+			continue
+		}
+		for _, r := range body {
+			if r != 'G' && !isUsermodBooleanShortFlag(r) {
+				goto nextArg
+			}
+		}
+		if i+1 < len(cmd.Args) {
+			next := cmd.Args[i+1]
+			if !strings.HasPrefix(next, "-") {
+				return next
+			}
+		}
+	nextArg:
+	}
+	return ""
+}
+
+// isUsermodBooleanShortFlag reports whether a single-char flag of usermod
+// is a boolean (takes no value) and can therefore appear combined before -G
+// in the `-aG` / `-aUG` form.
+func isUsermodBooleanShortFlag(r rune) bool {
+	switch r {
+	case 'a', // --append
+		'l', // --lock
+		'm', // --move-home
+		'o', // --non-unique
+		'r', // --remove
+		'U': // --unlock
+		return true
+	}
+	return false
+}
+
+// gpasswdAddTarget extracts (user, group) from a `gpasswd -a USER GROUP`
+// invocation. Handles both `-a USER` and `-a=USER` flag forms.
+func gpasswdAddTarget(cmd *shell.CommandInfo) (user, group string) {
+	for i, arg := range cmd.Args {
+		if arg == "-a" || arg == "--add" {
+			if i+1 < len(cmd.Args) {
+				user = cmd.Args[i+1]
+			}
+			group = firstNonFlagAfter(cmd.Args, i+2)
+			return user, group
+		}
+		if value, found := strings.CutPrefix(arg, "-a="); found {
+			user = value
+			group = firstNonFlagAfter(cmd.Args, i+1)
+			return user, group
+		}
+		if value, found := strings.CutPrefix(arg, "--add="); found {
+			user = value
+			group = firstNonFlagAfter(cmd.Args, i+1)
+			return user, group
+		}
+	}
+	return "", ""
+}
+
+// netLocalgroupAddTargets extracts (group, user) from
+// `net localgroup <GROUP> <USER> /add`.
+func netLocalgroupAddTargets(cmd *shell.CommandInfo) (group, user string) {
+	var positionals []string
+	for _, arg := range cmd.Args {
+		if strings.HasPrefix(arg, "/") || strings.EqualFold(arg, "localgroup") {
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+	if len(positionals) < 2 {
+		return "", ""
+	}
+	return positionals[0], positionals[1]
+}
+
+// firstNonFlagAfter returns the first non-flag arg in args[from:], or "".
+func firstNonFlagAfter(args []string, from int) string {
+	for i := from; i < len(args); i++ {
+		if !strings.HasPrefix(args[i], "-") {
+			return args[i]
+		}
+	}
+	return ""
+}
+
+// firstNonEmptyArgValue returns the first non-empty value produced by
+// cmd.GetArgValue for any of the given flags.
+func firstNonEmptyArgValue(cmd *shell.CommandInfo, flags ...string) string {
+	for _, f := range flags {
+		if v := cmd.GetArgValue(f); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// commaSplitNonEmpty splits s on "," and returns trimmed, non-empty entries.
+func commaSplitNonEmpty(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// adduserCreationFlags lists flags whose presence means adduser is creating
+// a user, not adding an existing user to a supplementary group.
+var adduserCreationFlags = map[string]bool{
+	"-D": true, "-S": true, "-m": true, "-u": true, "-g": true, "-G": true,
+	"-h": true, "-H": true, "-s": true,
+	"--system":            true,
+	"--disabled-password": true,
+	"--disabled-login":    true,
+	"--ingroup":           true,
+	"--gecos":             true,
+	"--home":              true,
+	"--shell":             true,
+	"--uid":               true,
+	"--gid":               true,
+}
+
+// addgroupCreationFlags lists flags whose presence means addgroup is creating
+// a new group, not adding a user to an existing group.
+var addgroupCreationFlags = map[string]bool{
+	"-S": true, "-g": true,
+	"--system": true,
+	"--gid":    true,
+}

--- a/internal/rules/tally/user_management_scan.go
+++ b/internal/rules/tally/user_management_scan.go
@@ -426,7 +426,9 @@ func isUsermodBooleanShortFlag(r rune) bool {
 }
 
 // gpasswdAddTarget extracts (user, group) from a `gpasswd -a USER GROUP`
-// invocation. Handles both `-a USER` and `-a=USER` flag forms.
+// invocation. Handles the standalone `-a USER` / `--add USER` forms as well
+// as the attached forms `-a=USER`, `-aUSER` (POSIX getopt combined short
+// flag), and `--add=USER`.
 func gpasswdAddTarget(cmd *shell.CommandInfo) (user, group string) {
 	for i, arg := range cmd.Args {
 		if arg == "-a" || arg == "--add" {
@@ -436,13 +438,18 @@ func gpasswdAddTarget(cmd *shell.CommandInfo) (user, group string) {
 			group = firstNonFlagAfter(cmd.Args, i+2)
 			return user, group
 		}
-		if value, found := strings.CutPrefix(arg, "-a="); found {
+		if value, found := strings.CutPrefix(arg, "--add="); found {
 			user = value
 			group = firstNonFlagAfter(cmd.Args, i+1)
 			return user, group
 		}
-		if value, found := strings.CutPrefix(arg, "--add="); found {
-			user = value
+		// Attached short-flag form: `-a=USER` or `-aUSER`. Guard against
+		// spurious `--add` matches: args starting with `--` are handled above.
+		if strings.HasPrefix(arg, "--") {
+			continue
+		}
+		if value, found := strings.CutPrefix(arg, "-a"); found && value != "" {
+			user = strings.TrimPrefix(value, "=")
 			group = firstNonFlagAfter(cmd.Args, i+1)
 			return user, group
 		}

--- a/internal/rules/tally/user_management_scan.go
+++ b/internal/rules/tally/user_management_scan.go
@@ -341,14 +341,19 @@ func creationFlagsMatch(flag string, creationFlags map[string]bool) bool {
 	return false
 }
 
-// twoPositionalValues extracts exactly two non-flag arguments from a
-// PowerShell command. Returns ok=false if fewer or more than two exist.
+// twoPositionalValues extracts exactly two positional arguments from a
+// PowerShell command, using the tree-sitter-powershell-provided ArgKinds to
+// skip parameters (`-Verbose`, `-Group`, etc.) without guessing at their
+// value-arity. Returns ok=false if fewer or more than two positionals exist.
+//
+// Using the grammar's classification is strictly more correct than a textual
+// HasPrefix("-") check: the grammar recognises quoted tokens like `"-app"`
+// as value expressions rather than parameter tokens, and it never consumes
+// the arg after a switch (e.g. `-Verbose`) as its value.
 func twoPositionalValues(cmd *shell.CommandInfo) (first, second string, ok bool) {
 	var positionals []string
-	for i := 0; i < len(cmd.Args); i++ {
-		arg := cmd.Args[i]
-		if strings.HasPrefix(arg, "-") {
-			i++
+	for i, arg := range cmd.Args {
+		if isFlagArg(cmd, i) {
 			continue
 		}
 		positionals = append(positionals, arg)
@@ -357,6 +362,17 @@ func twoPositionalValues(cmd *shell.CommandInfo) (first, second string, ok bool)
 		return "", "", false
 	}
 	return positionals[0], positionals[1], true
+}
+
+// isFlagArg reports whether the i-th argument of cmd is a flag/parameter.
+// If the parser populated ArgKinds (PowerShell today), that classification
+// is authoritative. Otherwise the function falls back to a textual "-" prefix
+// check so POSIX callers still get the historical behavior.
+func isFlagArg(cmd *shell.CommandInfo, i int) bool {
+	if i < len(cmd.ArgKinds) && cmd.ArgKinds[i] != shell.ArgKindUnknown {
+		return cmd.ArgKinds[i] == shell.ArgKindFlag
+	}
+	return strings.HasPrefix(cmd.Args[i], "-")
 }
 
 // usermodGroupsValue returns the value of usermod's -G / --groups flag,

--- a/internal/rules/tally/user_management_scan.go
+++ b/internal/rules/tally/user_management_scan.go
@@ -387,16 +387,30 @@ func usermodGroupsValue(cmd *shell.CommandInfo) string {
 			continue
 		}
 		// Short combined form: a single leading "-" followed by a run of
-		// boolean short flags, optionally ending with -G. The value for -G
-		// is the next positional arg.
+		// boolean short flags ending with -G. Examples:
+		//   -G docker        (separate value)
+		//   -Gdocker         (attached value)
+		//   -aG docker       (combined switches + separate value)
+		//   -aGdocker        (combined switches + attached value)
+		// The characters before 'G' must all be boolean switches; any
+		// character after 'G' is the attached value.
 		body := arg[1:]
-		if !strings.ContainsRune(body, 'G') {
+		gIdx := strings.IndexRune(body, 'G')
+		if gIdx < 0 {
 			continue
 		}
-		for _, r := range body {
-			if r != 'G' && !isUsermodBooleanShortFlag(r) {
-				goto nextArg
+		allBoolean := true
+		for _, r := range body[:gIdx] {
+			if !isUsermodBooleanShortFlag(r) {
+				allBoolean = false
+				break
 			}
+		}
+		if !allBoolean {
+			continue
+		}
+		if attached := body[gIdx+1:]; attached != "" {
+			return attached
 		}
 		if i+1 < len(cmd.Args) {
 			next := cmd.Args[i+1]
@@ -404,7 +418,6 @@ func usermodGroupsValue(cmd *shell.CommandInfo) string {
 				return next
 			}
 		}
-	nextArg:
 	}
 	return ""
 }

--- a/internal/rules/tally/user_management_scan.go
+++ b/internal/rules/tally/user_management_scan.go
@@ -137,7 +137,18 @@ func extractCreatedUsername(cmd *shell.CommandInfo) string {
 		}
 
 	case strings.EqualFold(cmd.Name, "New-LocalUser"):
-		return cmd.GetArgValue("-Name")
+		// -Name is Position 0, so `New-LocalUser alice -NoPassword` is a
+		// valid positional invocation. Prefer the named form, fall back to
+		// the first positional arg (using the PowerShell grammar's
+		// flag-vs-value classification surfaced via isFlagArg).
+		if v := cmd.GetArgValue("-Name"); v != "" {
+			return v
+		}
+		for i := range cmd.Args {
+			if !isFlagArg(cmd, i) {
+				return cmd.Args[i]
+			}
+		}
 	}
 
 	return ""

--- a/internal/rules/tally/user_management_scan_test.go
+++ b/internal/rules/tally/user_management_scan_test.go
@@ -369,6 +369,31 @@ func TestFindUserMembershipCmdsEdgeCases(t *testing.T) {
 			variant: shell.VariantPowerShell,
 			want:    nil,
 		},
+		// Regression for PR #551: PowerShell common-parameter switches
+		// (e.g. -Verbose, -WhatIf) take no value. The positional fallback
+		// must not consume the next arg after a switch.
+		{
+			name:    "Add-LocalGroupMember -Verbose then positional pair",
+			script:  "Add-LocalGroupMember -Verbose docker app",
+			variant: shell.VariantPowerShell,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "Add-LocalGroupMember -WhatIf then positional pair",
+			script:  "Add-LocalGroupMember -WhatIf docker app",
+			variant: shell.VariantPowerShell,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		// Quoted positional whose text starts with "-": the PowerShell
+		// grammar parses it as a string_literal (value), not a
+		// command_parameter. A textual HasPrefix("-") check would
+		// misclassify it as a flag.
+		{
+			name:    "Add-LocalGroupMember quoted dashed positional",
+			script:  `Add-LocalGroupMember docker "-app"`,
+			variant: shell.VariantPowerShell,
+			want:    []membershipInfo{{User: `"-app"`, Groups: []string{"docker"}}},
+		},
 		{
 			name:    "usermod no -G flag no fire",
 			script:  "usermod -L app",

--- a/internal/rules/tally/user_management_scan_test.go
+++ b/internal/rules/tally/user_management_scan_test.go
@@ -140,6 +140,8 @@ func TestFindUserCreationCmds(t *testing.T) {
 		{"cmd net user add", "net user alice pass /add", shell.VariantCmd, 1},
 		{"cmd net user delete not matched", "net user alice /delete", shell.VariantCmd, 0},
 		{"cmd net share /add not matched", "net share foo /add", shell.VariantCmd, 0},
+		{"pwsh New-LocalUser named", "New-LocalUser -Name alice -NoPassword", shell.VariantPowerShell, 1},
+		{"pwsh New-LocalUser positional", "New-LocalUser alice -NoPassword", shell.VariantPowerShell, 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -164,6 +166,9 @@ func TestExtractCreatedUsername(t *testing.T) {
 		{"useradd with flags", "useradd -r --home-dir /opt/app app", shell.VariantBash, "app"},
 		{"adduser disabled-password", "adduser -D alice", shell.VariantBash, "alice"},
 		{"net user /add", "net user alice pass /add", shell.VariantCmd, "alice"},
+		{"pwsh New-LocalUser -Name", "New-LocalUser -Name alice -NoPassword", shell.VariantPowerShell, "alice"},
+		{"pwsh New-LocalUser positional", "New-LocalUser alice -NoPassword", shell.VariantPowerShell, "alice"},
+		{"pwsh New-LocalUser positional with -Description", "New-LocalUser alice -Description 'test'", shell.VariantPowerShell, "alice"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/rules/tally/user_management_scan_test.go
+++ b/internal/rules/tally/user_management_scan_test.go
@@ -364,6 +364,14 @@ func TestFindUserMembershipCmdsEdgeCases(t *testing.T) {
 			want:    []membershipInfo{{User: "alice", Groups: []string{"wheel"}}},
 		},
 		{
+			// POSIX getopt combined-short-flag form: -a immediately glued
+			// to the value with no separator. Valid for shadow-utils gpasswd.
+			name:    "gpasswd -aUSER positional GROUP",
+			script:  "gpasswd -aalice wheel",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "alice", Groups: []string{"wheel"}}},
+		},
+		{
 			name:    "Add-LocalGroupMember with three positionals skipped",
 			script:  "Add-LocalGroupMember docker app extra",
 			variant: shell.VariantPowerShell,

--- a/internal/rules/tally/user_management_scan_test.go
+++ b/internal/rules/tally/user_management_scan_test.go
@@ -414,6 +414,26 @@ func TestFindUserMembershipCmdsEdgeCases(t *testing.T) {
 			variant: shell.VariantBash,
 			want:    nil,
 		},
+		// POSIX getopt attached-value forms for -G: value glued directly to
+		// the option with no separator. Valid for shadow-utils usermod.
+		{
+			name:    "usermod -Gdocker attached value",
+			script:  "usermod -Gdocker app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "usermod -aGdocker combined attached value",
+			script:  "usermod -aGdocker app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "usermod -aGdocker,wheel comma list attached",
+			script:  "usermod -aGdocker,wheel app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker", "wheel"}}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/rules/tally/user_management_scan_test.go
+++ b/internal/rules/tally/user_management_scan_test.go
@@ -1,0 +1,409 @@
+package tally
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestVisitStageAndAncestryRunScripts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single stage single RUN", func(t *testing.T) {
+		t.Parallel()
+		input := testutil.MakeLintInput(t, "Dockerfile", `FROM ubuntu:22.04
+RUN echo hello
+`)
+		var visits []scriptVisit
+		visitStageAndAncestryRunScripts(input, input.Facts, 0, func(v scriptVisit) {
+			visits = append(visits, v)
+		})
+		if len(visits) != 1 {
+			t.Fatalf("got %d visits, want 1", len(visits))
+		}
+		if visits[0].StageIndex != 0 || visits[0].Script != "echo hello" || visits[0].Run == nil {
+			t.Errorf("visit = %+v", visits[0])
+		}
+	})
+
+	t.Run("multiple RUN in source order", func(t *testing.T) {
+		t.Parallel()
+		input := testutil.MakeLintInput(t, "Dockerfile", `FROM ubuntu:22.04
+RUN echo first
+RUN echo second
+`)
+		var scripts []string
+		visitStageAndAncestryRunScripts(input, input.Facts, 0, func(v scriptVisit) {
+			scripts = append(scripts, v.Script)
+		})
+		want := []string{"echo first", "echo second"}
+		if !slices.Equal(scripts, want) {
+			t.Errorf("scripts = %v, want %v", scripts, want)
+		}
+	})
+
+	t.Run("FROM ancestry walks parent then grandparent", func(t *testing.T) {
+		t.Parallel()
+		input := testutil.MakeLintInput(t, "Dockerfile", `FROM ubuntu:22.04 AS base
+RUN echo grandparent
+
+FROM base AS mid
+RUN echo parent
+
+FROM mid AS final
+RUN echo final
+`)
+		var perStage []int
+		visitStageAndAncestryRunScripts(input, input.Facts, 2, func(v scriptVisit) {
+			perStage = append(perStage, v.StageIndex)
+		})
+		// Order: final stage (2), then parent (1), then grandparent (0).
+		want := []int{2, 1, 0}
+		if !slices.Equal(perStage, want) {
+			t.Errorf("stage order = %v, want %v", perStage, want)
+		}
+	})
+
+	t.Run("cycle guard via visited map", func(t *testing.T) {
+		t.Parallel()
+		// No Dockerfile syntax allows a true FROM cycle; the visited map is a
+		// belt-and-suspenders defense. Confirm that calling on the last stage
+		// of a linear chain terminates, as the cycle-guard logic exercises
+		// the same code path.
+		input := testutil.MakeLintInput(t, "Dockerfile", `FROM ubuntu:22.04 AS a
+FROM a AS b
+FROM b AS c
+RUN echo ok
+`)
+		called := 0
+		visitStageAndAncestryRunScripts(input, input.Facts, 2, func(v scriptVisit) {
+			called++
+			if called > 100 {
+				t.Fatal("infinite loop")
+			}
+		})
+	})
+
+	t.Run("observable script file visited with extension variant", func(t *testing.T) {
+		t.Parallel()
+		input := testutil.MakeLintInput(t, "Dockerfile", `FROM ubuntu:22.04
+COPY <<EOF /entrypoint.sh
+#!/bin/sh
+echo hello
+EOF
+`)
+		var found bool
+		var variant shell.Variant
+		visitStageAndAncestryRunScripts(input, input.Facts, 0, func(v scriptVisit) {
+			if v.Run == nil {
+				found = true
+				variant = v.Variant
+			}
+		})
+		if !found {
+			t.Fatal("observable script not visited")
+		}
+		if variant != shell.VariantBash {
+			t.Errorf("variant = %v, want VariantBash (VariantFromScriptPath default)", variant)
+		}
+	})
+
+	t.Run("semantic model nil returns after startStage", func(t *testing.T) {
+		t.Parallel()
+		input := testutil.MakeLintInput(t, "Dockerfile", `FROM ubuntu:22.04
+RUN echo hi
+`)
+		input.Semantic = nil
+		called := 0
+		visitStageAndAncestryRunScripts(input, input.Facts, 0, func(v scriptVisit) {
+			called++
+		})
+		if called != 1 {
+			t.Errorf("got %d visits, want 1", called)
+		}
+	})
+}
+
+func TestFindUserCreationCmds(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		script  string
+		variant shell.Variant
+		wantLen int
+	}{
+		{"bash useradd", "useradd alice", shell.VariantBash, 1},
+		{"bash adduser", "adduser -D alice", shell.VariantBash, 1},
+		{"bash non-creation", "echo nothing", shell.VariantBash, 0},
+		{"cmd net user add", "net user alice pass /add", shell.VariantCmd, 1},
+		{"cmd net user delete not matched", "net user alice /delete", shell.VariantCmd, 0},
+		{"cmd net share /add not matched", "net share foo /add", shell.VariantCmd, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := findUserCreationCmds(tt.script, tt.variant)
+			if len(got) != tt.wantLen {
+				t.Errorf("got %d cmds, want %d — %+v", len(got), tt.wantLen, got)
+			}
+		})
+	}
+}
+
+func TestExtractCreatedUsername(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		script  string
+		variant shell.Variant
+		want    string
+	}{
+		{"useradd simple", "useradd alice", shell.VariantBash, "alice"},
+		{"useradd with flags", "useradd -r --home-dir /opt/app app", shell.VariantBash, "app"},
+		{"adduser disabled-password", "adduser -D alice", shell.VariantBash, "alice"},
+		{"net user /add", "net user alice pass /add", shell.VariantCmd, "alice"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmds := findUserCreationCmds(tt.script, tt.variant)
+			if len(cmds) != 1 {
+				t.Fatalf("got %d cmds, want 1", len(cmds))
+			}
+			got := extractCreatedUsername(&cmds[0])
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindUserMembershipCmds(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		script  string
+		variant shell.Variant
+		want    []membershipInfo
+	}{
+		// POSIX useradd
+		{
+			name:    "useradd -G single",
+			script:  "useradd -G docker app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "useradd -G comma list",
+			script:  "useradd -G docker,wheel app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker", "wheel"}}},
+		},
+		{
+			name:    "useradd --groups=value",
+			script:  "useradd --groups=docker app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "useradd -g primary only no fire",
+			script:  "useradd -g app app",
+			variant: shell.VariantBash,
+			want:    nil,
+		},
+		{
+			name:    "useradd -g and -G",
+			script:  "useradd -g app -G docker app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+
+		// POSIX usermod
+		{
+			name:    "usermod -aG",
+			script:  "usermod -aG docker app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "usermod -a -G",
+			script:  "usermod -a -G docker app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "usermod -G without -a (replace)",
+			script:  "usermod -G docker app",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+
+		// POSIX gpasswd
+		{
+			name:    "gpasswd -a user group",
+			script:  "gpasswd -a alice wheel",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "alice", Groups: []string{"wheel"}}},
+		},
+		{
+			name:    "gpasswd --add user group",
+			script:  "gpasswd --add alice wheel",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "alice", Groups: []string{"wheel"}}},
+		},
+		{
+			name:    "gpasswd without -a no fire",
+			script:  "gpasswd -d alice wheel",
+			variant: shell.VariantBash,
+			want:    nil,
+		},
+
+		// POSIX adduser / addgroup membership forms
+		{
+			name:    "adduser USER GROUP membership",
+			script:  "adduser alice wheel",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "alice", Groups: []string{"wheel"}}},
+		},
+		{
+			name:    "adduser -D alice creation no fire",
+			script:  "adduser -D alice",
+			variant: shell.VariantBash,
+			want:    nil,
+		},
+		{
+			name:    "addgroup USER GROUP membership",
+			script:  "addgroup alice docker",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "alice", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "addgroup group-creation single positional no fire",
+			script:  "addgroup docker",
+			variant: shell.VariantBash,
+			want:    nil,
+		},
+		{
+			name:    "addgroup -S system group creation no fire",
+			script:  "addgroup -S docker",
+			variant: shell.VariantBash,
+			want:    nil,
+		},
+
+		// Windows cmd
+		{
+			name:    "net localgroup /add",
+			script:  "net localgroup Administrators app /add",
+			variant: shell.VariantCmd,
+			want:    []membershipInfo{{User: "app", Groups: []string{"Administrators"}}},
+		},
+		{
+			name:    "net localgroup /delete not matched",
+			script:  "net localgroup Administrators app /delete",
+			variant: shell.VariantCmd,
+			want:    nil,
+		},
+
+		// Windows PowerShell
+		{
+			name:    "Add-LocalGroupMember -Group -Member",
+			script:  "Add-LocalGroupMember -Group docker -Member app",
+			variant: shell.VariantPowerShell,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "Add-LocalGroupMember positional",
+			script:  "Add-LocalGroupMember docker app",
+			variant: shell.VariantPowerShell,
+			want:    []membershipInfo{{User: "app", Groups: []string{"docker"}}},
+		},
+		{
+			name:    "Add-LocalGroupMember array member skipped",
+			script:  `Add-LocalGroupMember -Group docker -Member @("u1","u2")`,
+			variant: shell.VariantPowerShell,
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := findUserMembershipCmds(tt.script, tt.variant)
+			if !equalMembershipInfos(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindUserMembershipCmdsEdgeCases(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		script  string
+		variant shell.Variant
+		want    []membershipInfo
+	}{
+		{
+			name:    "adduser with combined short -Dm no fire",
+			script:  "adduser -Dm alice",
+			variant: shell.VariantBash,
+			want:    nil,
+		},
+		{
+			name:    "gpasswd --add=USER positional GROUP",
+			script:  "gpasswd --add=alice wheel",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "alice", Groups: []string{"wheel"}}},
+		},
+		{
+			name:    "gpasswd -a=USER positional GROUP",
+			script:  "gpasswd -a=alice wheel",
+			variant: shell.VariantBash,
+			want:    []membershipInfo{{User: "alice", Groups: []string{"wheel"}}},
+		},
+		{
+			name:    "Add-LocalGroupMember with three positionals skipped",
+			script:  "Add-LocalGroupMember docker app extra",
+			variant: shell.VariantPowerShell,
+			want:    nil,
+		},
+		{
+			name:    "usermod no -G flag no fire",
+			script:  "usermod -L app",
+			variant: shell.VariantBash,
+			want:    nil,
+		},
+		{
+			name:    "usermod combined short with non-boolean flag skips",
+			script:  "usermod -zG docker app",
+			variant: shell.VariantBash,
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := findUserMembershipCmds(tt.script, tt.variant)
+			if !equalMembershipInfos(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func equalMembershipInfos(a, b []membershipInfo) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].User != b[i].User {
+			return false
+		}
+		if !slices.Equal(a[i].Groups, b[i].Groups) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/shell/command.go
+++ b/internal/shell/command.go
@@ -40,6 +40,16 @@ type CommandInfo struct {
 	// evaluation. The slice is aligned with Args.
 	ArgLiteral []bool
 
+	// ArgKinds reports the parser-derived semantic kind of each arg (flag vs
+	// value). Aligned with Args. For PowerShell the kind is driven by the
+	// tree-sitter `command_parameter` vs value-expression distinction, so
+	// switch parameters, quoted values starting with "-", and similar edge
+	// cases are classified correctly. For POSIX shells every arg is reported
+	// as ArgKindUnknown because the sh parser does not separate flags from
+	// values at the AST level; callers that need that for POSIX should keep
+	// using HasPrefix("-") or cmd.HasFlag.
+	ArgKinds []ArgKind
+
 	// ArgRanges reports the script-relative source range for each arg. Aligned
 	// with Args; empty when the underlying parser didn't preserve positions.
 	// Positions are 0-based (line, column byte offset).
@@ -80,6 +90,24 @@ type ArgRange struct {
 	StartCol int
 	EndCol   int
 }
+
+// ArgKind is the parser-derived semantic role of an argument. Only
+// CommandInfos produced by parsers that distinguish parameters from values
+// (e.g. the PowerShell tree-sitter grammar) populate this beyond
+// ArgKindUnknown.
+type ArgKind uint8
+
+const (
+	// ArgKindUnknown means the parser did not classify this arg. Callers
+	// should fall back to textual heuristics (e.g. HasPrefix("-")).
+	ArgKindUnknown ArgKind = iota
+	// ArgKindFlag means the parser identified this arg as a flag/parameter
+	// token (e.g. PowerShell `command_parameter` like `-Verbose`, `-Group`).
+	ArgKindFlag
+	// ArgKindValue means the parser identified this arg as a value/positional
+	// expression (e.g. PowerShell `generic_token`, `string_literal`).
+	ArgKindValue
+)
 
 // CommandSourceKind describes how a command was discovered in the shell AST.
 type CommandSourceKind string

--- a/internal/shell/powershell_parser.go
+++ b/internal/shell/powershell_parser.go
@@ -97,8 +97,10 @@ func findPowerShellCommands(script string, names ...string) []CommandInfo {
 		for _, arg := range powerShellCommandArgs(node, source) {
 			argStart := arg.node.StartPosition()
 			argEnd := arg.node.EndPosition()
+			kind := powerShellArgKind(arg.node.Kind())
 			info.Args = append(info.Args, arg.text)
 			info.ArgLiteral = append(info.ArgLiteral, isPlainPowerShellLiteralArg(arg.text))
+			info.ArgKinds = append(info.ArgKinds, kind)
 			info.ArgRanges = append(info.ArgRanges, ArgRange{
 				Line:     int(argStart.Row),
 				StartCol: int(argStart.Column),
@@ -106,7 +108,7 @@ func findPowerShellCommands(script string, names ...string) []CommandInfo {
 			})
 			info.CommandEndLine = int(argEnd.Row)
 			info.CommandEndCol = int(argEnd.Column)
-			if info.Subcommand == "" && !strings.HasPrefix(arg.text, "-") {
+			if info.Subcommand == "" && kind != ArgKindFlag {
 				info.Subcommand = arg.text
 				info.SubcommandLine = int(argStart.Row)
 				info.SubcommandStartCol = int(argStart.Column)
@@ -169,6 +171,23 @@ func powerShellCommandArgs(node *sitter.Node, source []byte) []powerShellArg {
 		args = append(args, powerShellArg{text: text, node: child})
 	}
 	return args
+}
+
+// powerShellArgKind maps a tree-sitter node kind from the PowerShell grammar
+// onto the parser-agnostic ArgKind enum.
+//
+// The grammar defines `command_parameter` as a dedicated token for
+// parameter tokens (`-Verbose`, `-Group`, `--`). Every other kind that can
+// appear inside `command_elements` (generic tokens, string literals, array
+// literals, script blocks, etc.) is a value/positional. This is strictly
+// more accurate than inspecting the argument text: a quoted value like
+// `"-quoted"` has text starting with `-` but parses as `string_literal`,
+// not `command_parameter`.
+func powerShellArgKind(nodeKind string) ArgKind {
+	if nodeKind == tspowershell.NodeCommandParameter {
+		return ArgKindFlag
+	}
+	return ArgKindValue
 }
 
 func isPlainPowerShellLiteralArg(text string) bool {


### PR DESCRIPTION
## Summary

- New rule **`tally/user-explicit-group-drops-supplementary-groups`** (severity warning, security category): detects `USER name:group` instructions that silently drop supplementary groups the Dockerfile already established.
- Covers **Linux and Windows containers** from day one:
  - Linux: `useradd -G`, `usermod -aG / -G`, `gpasswd -a`, `adduser USER GROUP`, `addgroup USER GROUP`.
  - Windows cmd: `net localgroup <GROUP> <USER> /add`.
  - Windows PowerShell: `Add-LocalGroupMember -Group -Member` (and positional form).
- Sync `FixSuggestion` narrowly removes the `:group` operand so Docker honors the user's supplementary set; fixture-based integration tests verify both Linux and Windows auto-fix end-to-end under `--fix --fix-unsafe`.
- Refactor: lifts the "walk RUN scripts + observable files across stage + FROM ancestry" idiom out of `tally/user-created-but-never-used` into a shared helper `internal/rules/tally/user_management_scan.go`, and refactors that rule to consume it. Behavior-preserving; existing snapshot + integration tests guard the change.

## Why

Docker's [`USER` reference](https://docs.docker.com/reference/dockerfile/#user) is explicit but easy to miss:

> Note that when specifying a group for the user, the user will have only the specified group membership. Any other configured group memberships will be ignored.

The typical Linux symptom is a user added to `docker` then locked out of `/var/run/docker.sock` at runtime; the equivalent Windows symptom is a local-group membership (e.g., `Administrators`) being silently dropped. The rule fills the gap between `hadolint/DL3002` (which only asks "is last USER root?") and `tally/named-identity-in-passwdless-stage` (which owns the scratch/passwd-less stages); the three rules now cover the USER-operand space without overlap.

See `design-docs/34-user-instructions.md` §7.1 #6 for the design rationale.

## Coordination

- **`tally/named-identity-in-passwdless-stage`** — passwd-less scratch stages are deferred to that rule (it would rewrite to numeric UIDs; we'd drop `:group` — different intent, same span).
- **`tally/user-created-but-never-used`** — fires only when effective USER is root; ours requires a non-root explicit `USER name:group`. Complementary.
- **Formatting rules** — edits land strictly inside the operand span, so adjacency composition is clean.

## Test plan

- [x] `go test ./internal/rules/tally/...` (30+ new subtests; includes Linux + Windows fires, 7 no-fires, continuation-line fix, FROM-ancestry, heredoc)
- [x] `go test ./internal/integration/...` (Linux + Windows lint + fix cases; snapshots)
- [x] `go test ./...` repo-wide
- [x] `make lint` / `make cpd`
- [x] `npx mint validate` for docs
- [x] Coverage: rule file 95.5% avg, shared helper 91.4% avg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for Docker USER instructions that explicitly specify a group, which causes supplementary group memberships configured earlier to be dropped at runtime on both Linux and Windows platforms.
  * Includes fix suggestions to preserve supplementary groups and detailed documentation of detected patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->