### PR TITLE
refactor(php): canonical package-manager helpers + fix cache-mounts conflict eviction

### DIFF
--- a/internal/fix/fixer_precedence_test.go
+++ b/internal/fix/fixer_precedence_test.go
@@ -1,10 +1,15 @@
-package fix
+// This file lives in package fix_test (external test package) so it can
+// import internal/rules/all — which transitively pulls in internal/rules/tally,
+// some of whose rules register post-sync FixResolvers back into internal/fix.
+// Placing it in package fix would form an import cycle.
+package fix_test
 
 import (
 	"bytes"
 	"context"
 	"testing"
 
+	"github.com/wharflab/tally/internal/fix"
 	"github.com/wharflab/tally/internal/rules"
 	_ "github.com/wharflab/tally/internal/rules/all"
 )
@@ -64,7 +69,7 @@ func TestFixer_Apply_ConflictPrefersPerformanceOverStyle(t *testing.T) {
 		},
 	}
 
-	fixer := &Fixer{SafetyThreshold: FixSafe}
+	fixer := &fix.Fixer{SafetyThreshold: fix.FixSafe}
 	result, err := fixer.Apply(context.Background(), violations, sources)
 	if err != nil {
 		t.Fatalf("Apply error: %v", err)
@@ -92,7 +97,7 @@ func TestFixer_Apply_ConflictPrefersPerformanceOverStyle(t *testing.T) {
 
 	foundStyleConflict := false
 	for _, skip := range fc.FixesSkipped {
-		if skip.RuleCode == "tally/consistent-indentation" && skip.Reason == SkipConflict {
+		if skip.RuleCode == "tally/consistent-indentation" && skip.Reason == fix.SkipConflict {
 			foundStyleConflict = true
 			break
 		}

--- a/internal/integration/__snapshots__/TestFixPowerShellAlpine_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixPowerShellAlpine_1.snap.Dockerfile
@@ -38,7 +38,7 @@ EOF
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-RUN --mount=type=cache,target=/var/cache/apk,id=apk,sharing=locked apk add bind-tools gnupg git tini
+RUN --mount=type=cache,target=/var/cache/apk,id=apk,sharing=locked apk add bind-tools git gnupg tini
 RUN <<EOF
 set -e
 set -o pipefail

--- a/internal/integration/__snapshots__/TestFixPowerShellAlpine_1.snap.md
+++ b/internal/integration/__snapshots__/TestFixPowerShellAlpine_1.snap.md
@@ -1,14 +1,13 @@
-Fixed 9 issues
-Skipped 2 fixes
+Fixed 10 issues
+Skipped 1 fixes
 note: 1 AI fix(es) failed (see details below)
 note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registered: ai-autofix
-**5 issues** in `<stdin>`
+**4 issues** in `<stdin>`
 
 | Line | Issue |
 |------|-------|
 | 16 | ⚠️ both wget and curl are used; standardize on wget |
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 8 | 💅 RUN instruction with chained commands can use heredoc syntax |
-| 14 | 💅 packages in apk add are not sorted alphabetically |
 | 16 | 💅 unexpected blank line between RUN and RUN |
 

--- a/internal/integration/__snapshots__/TestFixRealWorldPHPFPM56_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorldPHPFPM56_1.snap.Dockerfile
@@ -1,0 +1,114 @@
+FROM php:5.6-fpm AS builder
+
+RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked --mount=type=cache,target=/var/lib/apt,id=aptlib,sharing=locked <<EOF
+set -e
+set -o pipefail
+set -ex
+apt-get update
+apt-get install -y autoconf build-essential libbsd-dev libbz2-dev libc-client2007e-dev libc6-dev libcurl3 libcurl4-openssl-dev libedit-dev libedit2 libgmp-dev libgpgme11-dev libicu-dev libjpeg-dev libkrb5-dev libldap2-dev libldb-dev libmagick++-dev libmagickwand-dev libmcrypt-dev libmemcached-dev libpcre3-dev libpng-dev libsqlite3-0 libsqlite3-dev libssh2-1-dev libssl-dev libtinfo-dev libtool libvpx-dev libwebp-dev libxml2 libxml2-dev libxpm-dev libxslt1-dev
+ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include
+docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu
+docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-freetype-dir=/usr --with-xpm-dir=/usr --with-vpx-dir=/usr
+docker-php-ext-configure gmp --with-libdir=lib/x86_64-linux-gnu
+docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+docker-php-ext-install bcmath bz2 calendar dba exif gd gettext gmp imap intl ldap mcrypt mysql mysqli opcache pdo_mysql shmop soap sockets sysvmsg sysvsem sysvshm wddx xmlrpc xsl zip
+pecl install gnupg-1.4.0 igbinary-2.0.1 imagick-3.4.3 memcached-2.2.0 msgpack-0.5.7 redis-3.1.3 runkit-1.0.4
+echo "\n" | pecl install ssh2-0.13
+docker-php-ext-enable --ini-name pecl.ini gnupg igbinary imagick memcached msgpack redis runkit ssh2
+curl --connect-timeout 10 -o ioncube.tar.gz -kfSL "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"
+tar -zxvf ioncube.tar.gz
+cp ioncube/ioncube_loader_lin_5.6.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ioncube.so
+rm -Rf ioncube*
+NR_VERSION="$(curl --location --connect-timeout 10 -skS https://download.newrelic.com/php_agent/release/ | sed -n 's/.*>\(.*linux\).tar.gz<.*/\1/p')"
+curl --connect-timeout 10 -o nr.tar.gz -kfSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"
+tar -xf nr.tar.gz
+cp "$NR_VERSION"/agent/x64/newrelic-20131226.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/newrelic.so
+rm -rf newrelic-php5* nr.tar.gz
+echo "zend_extension=ioncube.so" >/usr/local/etc/php/conf.d/01-ioncube.ini
+echo "extension=newrelic.so" >/usr/local/etc/php/conf.d/10-newrelic.ini
+echo "runkit.internal_override=1" >/usr/local/etc/php/conf.d/10-runkit.ini
+EOF
+
+# Now that all the modules are built/downloaded, use the original php:5.6-fpm image and
+# install only the runtime dependencies with the new modules and config files.
+FROM php:5.6-fpm
+
+WORKDIR /
+
+RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked --mount=type=cache,target=/var/lib/apt,id=aptlib,sharing=locked <<EOF
+set -e
+set -o pipefail
+set -ex
+apt-get update
+apt-get install -y --no-install-recommends libc-client2007e libgpgme11 libicu57 libmagickwand-6.q16-3 libmcrypt4 libmemcached11 libmemcachedutil2 libpng16-16 libvpx4 libwebp6 libxpm4 libxslt1.1 ssmtp
+rm -rf /tmp/pear /usr/share/doc /usr/share/man /var/lib/apt/lists/*
+cd /usr/local/etc/php
+php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 >php_version.txt
+EOF
+
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ /usr/local/lib/php/extensions/no-debug-non-zts-20131226/
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+
+RUN pear install --alldeps \
+        Auth_SASL \
+        Auth_SASL2-beta \
+        Benchmark \
+        pear.php.net/Console_Color2-0.1.2 \
+        Console_Table \
+        HTTP_OAuth-0.3.1 \
+        HTTP_Request2 \
+        Log \
+        Mail \
+        MDB2 \
+        Net_GeoIP \
+        Net_SMTP \
+        Net_Socket \
+        XML_RPC2 \
+        pear.symfony.com/YAML \
+    ;
+
+COPY <<EOF /usr/local/etc/php-fpm.d/www.conf
+[global]
+daemonize = no
+error_log = /proc/self/fd/2
+
+[www]
+listen = [::]:9000
+listen.owner = www-data
+listen.group = www-data
+
+user = www-data
+group = www-data
+
+access.log = /proc/self/fd/2
+
+pm = static
+pm.max_children = 1
+pm.start_servers = 1
+request_terminate_timeout = 65s
+pm.max_requests = 1000
+catch_workers_output = yes
+EOF
+COPY <<EOF /usr/local/php/php/auto_prepends/default_prepend.php
+<?php
+if (function_exists("uopz_allow_exit")) {
+    uopz_allow_exit(true);
+}
+?>
+EOF
+COPY <<EOF /etc/ssmtp/ssmtp.conf
+FromLineOverride=YES
+mailhub=127.0.0.1
+UseTLS=NO
+UseSTARTTLS=NO
+EOF
+COPY <<EOF /usr/local/etc/php/conf.d/php.ini
+[PHP]
+log_errors = On
+error_log = /dev/stderr
+auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php
+EOF
+
+EXPOSE 9000
+
+CMD ["php-fpm"]

--- a/internal/integration/__snapshots__/TestFixRealWorldPHPFPM56_1.snap.md
+++ b/internal/integration/__snapshots__/TestFixRealWorldPHPFPM56_1.snap.md
@@ -1,0 +1,16 @@
+Fixed 11 issues
+**10 issues** in `<stdin>`
+
+| Line | Issue |
+|------|-------|
+| 51 | ❌ file has 200 lines, maximum allowed is 50 |
+| 3 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
+| 122 | ⚠️ use WORKDIR to switch to a directory |
+| 122 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
+| 164 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
+| - | ℹ️ `HEALTHCHECK` instruction missing |
+| 3 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
+| 92 | ℹ️ echo may not expand escape sequences. Use printf. |
+| 164 | 💅 RUN instruction with chained commands can use heredoc syntax |
+| 210 | 💅 expected blank line between EXPOSE and CMD |
+

--- a/internal/integration/__snapshots__/TestFixRealWorld_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorld_1.snap.Dockerfile
@@ -82,21 +82,15 @@ EOF
 
 ARG TRITON_VERSION
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install -U smclarify "sagemaker>=2,<3" sagemaker-experiments==0.* sagemaker-pytorch-training triton==${TRITON_VERSION}
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install -U "bokeh>=3.0.1,<4" "imageio>=2.22,<3" "opencv-python>=4.6,<5" "plotly>=5.11,<6" "seaborn>=0.12,<1" "numba>=0.56.4,<0.57" "shap>=0.41,<1"
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install -U "sagemaker>=2,<3" sagemaker-experiments==0.* sagemaker-pytorch-training smclarify triton==${TRITON_VERSION}
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install -U "bokeh>=3.0.1,<4" "imageio>=2.22,<3" "numba>=0.56.4,<0.57" "opencv-python>=4.6,<5" "plotly>=5.11,<6" "seaborn>=0.12,<1" "shap>=0.41,<1"
 RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked --mount=type=cache,target=/var/lib/apt,id=aptlib,sharing=locked apt-get update && apt-get install -y build-essential
 
 ARG DATASETS_VERSION
 ARG DIFFUSERS_VERSION
 ARG TRANSFORMERS_VERSION
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install kenlm==0.1 transformers[sklearn,sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} datasets==${DATASETS_VERSION} diffusers==${DIFFUSERS_VERSION} $PT_TORCHAUDIO_URL multiprocess==0.70.14 dill==0.3.6 sagemaker==2.132.0 evaluate gevent~=23.9.0 pyarrow~=14.0.1
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install setuptools==69.5.1
-
-WORKDIR /app
-
-COPY requirements1.txt .
-
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install dill==0.3.6 evaluate gevent~=23.9.0 kenlm==0.1 multiprocess==0.70.14 pyarrow~=14.0.1 sagemaker==2.132.0 transformers[sklearn,sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} datasets==${DATASETS_VERSION} diffusers==${DIFFUSERS_VERSION} "$PT_TORCHAUDIO_URL"
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install -r requirements1.txt
 
 ARG SMD_MODEL_PARALLEL_URL
@@ -371,7 +365,7 @@ RUN echo $PATH
 RUN echo $LD_LIBRARY_PATH
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip <<EOF
 set -e
-pip install -U --force-reinstall wheel==0.43.0 setuptools==70.1.0
+pip install -U --force-reinstall setuptools==70.1.0 wheel==0.43.0
 pip install --force-reinstall setuptools==69.5.1
 git clone https://github.com/NVIDIA/apex
 cd apex

--- a/internal/integration/__snapshots__/TestFix_php-no-xdebug-in-final-image-apt-get-comment-out_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_php-no-xdebug-in-final-image-apt-get-comment-out_1.snap.Dockerfile
@@ -1,0 +1,2 @@
+FROM php:8.4-fpm AS app
+# RUN apt-get install -y php-xdebug=3.1.6-1+deb12u1

--- a/internal/integration/__snapshots__/TestLint_prefer-package-cache-mounts_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-package-cache-mounts_1.snap.json
@@ -143,51 +143,9 @@
           "sourceCode": "RUN apk add --no-cache curl \u0026\u0026 rm -rf /var/cache/apk/*",
           "suggestedFix": {
             "description": "Add package cache mount(s) and remove cache cleanup commands",
-            "edits": [
-              {
-                "location": {
-                  "end": {
-                    "column": 4,
-                    "line": 8
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 8
-                  }
-                },
-                "newText": "--mount=type=cache,target=/var/cache/apk,id=apk,sharing=locked "
-              },
-              {
-                "location": {
-                  "end": {
-                    "column": 27,
-                    "line": 8
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 8
-                  }
-                },
-                "newText": "apk add curl"
-              },
-              {
-                "location": {
-                  "end": {
-                    "column": 54,
-                    "line": 8
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 27,
-                    "line": 8
-                  }
-                },
-                "newText": ""
-              }
-            ],
+            "needsResolve": true,
             "priority": 90,
+            "resolverId": "prefer-package-cache-mounts",
             "safety": 1
           }
         },
@@ -481,51 +439,9 @@
           "sourceCode": "RUN pip install --no-cache-dir -r requirements.txt \u0026\u0026 pip cache purge",
           "suggestedFix": {
             "description": "Add package cache mount(s) and remove cache cleanup commands",
-            "edits": [
-              {
-                "location": {
-                  "end": {
-                    "column": 4,
-                    "line": 14
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 14
-                  }
-                },
-                "newText": "--mount=type=cache,target=/root/.cache/pip,id=pip "
-              },
-              {
-                "location": {
-                  "end": {
-                    "column": 50,
-                    "line": 14
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 14
-                  }
-                },
-                "newText": "pip install -r requirements.txt"
-              },
-              {
-                "location": {
-                  "end": {
-                    "column": 69,
-                    "line": 14
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 50,
-                    "line": 14
-                  }
-                },
-                "newText": ""
-              }
-            ],
+            "needsResolve": true,
             "priority": 90,
+            "resolverId": "prefer-package-cache-mounts",
             "safety": 1
           }
         },
@@ -751,51 +667,9 @@
           "sourceCode": "RUN uv sync --no-cache --frozen \u0026\u0026 uv cache clean",
           "suggestedFix": {
             "description": "Add package cache mount(s) and remove cache cleanup commands",
-            "edits": [
-              {
-                "location": {
-                  "end": {
-                    "column": 4,
-                    "line": 20
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 20
-                  }
-                },
-                "newText": "--mount=type=cache,target=/root/.cache/uv,id=uv "
-              },
-              {
-                "location": {
-                  "end": {
-                    "column": 31,
-                    "line": 20
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 20
-                  }
-                },
-                "newText": "uv sync --frozen"
-              },
-              {
-                "location": {
-                  "end": {
-                    "column": 49,
-                    "line": 20
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 31,
-                    "line": 20
-                  }
-                },
-                "newText": ""
-              }
-            ],
+            "needsResolve": true,
             "priority": 90,
+            "resolverId": "prefer-package-cache-mounts",
             "safety": 1
           }
         },
@@ -859,51 +733,9 @@
           "sourceCode": "RUN bun install --no-cache \u0026\u0026 bun pm cache rm",
           "suggestedFix": {
             "description": "Add package cache mount(s) and remove cache cleanup commands",
-            "edits": [
-              {
-                "location": {
-                  "end": {
-                    "column": 4,
-                    "line": 22
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 22
-                  }
-                },
-                "newText": "--mount=type=cache,target=/root/.bun/install/cache,id=bun "
-              },
-              {
-                "location": {
-                  "end": {
-                    "column": 26,
-                    "line": 22
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 22
-                  }
-                },
-                "newText": "bun install"
-              },
-              {
-                "location": {
-                  "end": {
-                    "column": 45,
-                    "line": 22
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 26,
-                    "line": 22
-                  }
-                },
-                "newText": ""
-              }
-            ],
+            "needsResolve": true,
             "priority": 90,
+            "resolverId": "prefer-package-cache-mounts",
             "safety": 1
           }
         },

--- a/internal/integration/__snapshots__/TestLint_prefer-package-cache-mounts_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_prefer-package-cache-mounts_1.snap.json
@@ -117,23 +117,9 @@
           "sourceCode": "RUN --mount=type=secret,id=aptcfg,target=/etc/apt/auth.conf \\",
           "suggestedFix": {
             "description": "Add package cache mount(s) and remove cache cleanup commands",
-            "edits": [
-              {
-                "location": {
-                  "end": {
-                    "column": 61,
-                    "line": 7
-                  },
-                  "file": "testdata/prefer-package-cache-mounts/Dockerfile",
-                  "start": {
-                    "column": 4,
-                    "line": 5
-                  }
-                },
-                "newText": "--mount=type=secret,id=aptcfg,target=/etc/apt/auth.conf --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked --mount=type=cache,target=/var/lib/apt,id=aptlib,sharing=locked apt-get update \u0026\u0026 apt-get install -y gcc"
-              }
-            ],
+            "needsResolve": true,
             "priority": 90,
+            "resolverId": "prefer-package-cache-mounts",
             "safety": 1
           }
         },

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1452,6 +1452,19 @@ severity = "warning"
 				mustSelectRules("tally/php/no-xdebug-in-final-image")...),
 			wantApplied: 1,
 		},
+		// PHP: no-xdebug-in-final-image apt-get flavor. Exercises the OS
+		// package-manager detection path (shell.InstallCommand +
+		// shell.StripPackageVersion) with a versioned package name. The RUN
+		// contains only an xdebug install so the preferred comment-out fix
+		// applies.
+		{
+			name: "php-no-xdebug-in-final-image-apt-get-comment-out",
+			input: "FROM php:8.4-fpm AS app\n" +
+				"RUN apt-get install -y php-xdebug=3.1.6-1+deb12u1\n",
+			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules("tally/php/no-xdebug-in-final-image")...),
+			wantApplied: 1,
+		},
 		// PHP: enable-opcache-in-production inserts
 		// `RUN docker-php-ext-install opcache` after the final FROM for official
 		// php:*fpm*/*apache* images. Fix is FixSuggestion safety, so --fix-unsafe

--- a/internal/integration/fix_scenarios_test.go
+++ b/internal/integration/fix_scenarios_test.go
@@ -587,6 +587,40 @@ func TestFixRealWorldBoostMSVCWindowsContainer(t *testing.T) {
 	}
 }
 
+// TestFixRealWorldPHPFPM56 tests the full fix pipeline on a real-world
+// php:5.6-fpm builder+runtime Dockerfile via stdin, snapshotting both the
+// fixed Dockerfile (stdout) and the markdown violation report (stderr).
+// This fixture exercises heavy apt-get/pecl/docker-php-ext usage and
+// many-package RUNs, overlapping with the PHP rule family
+// (no-xdebug-in-final-image, enable-opcache-in-production,
+// composer-no-dev-in-production) plus broader tally rules.
+// Source: https://github.com/irvin-s/docker_repair/blob/6e3d43423b58a2631ff6850f64b11226f081bb4b/binacle_data/sources/456933631.Dockerfile
+func TestFixRealWorldPHPFPM56(t *testing.T) {
+	t.Parallel()
+
+	input, err := os.ReadFile(filepath.Join("testdata", "real-world-fix-php-fpm-56", "Dockerfile"))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	stdout, stderr, exitCode := runTallyStdin(t, string(input),
+		"lint", "--format", "markdown", "--fix", "--fix-unsafe", "--slow-checks=on", "-",
+	)
+
+	t.Logf("exit=%d\nstdout length=%d\nstderr:\n%s", exitCode, len(stdout), stderr)
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	snaps.WithConfig(snaps.Raw(), snaps.Ext(".Dockerfile")).MatchStandaloneSnapshot(t, stdout)
+	snaps.WithConfig(snaps.Ext(".md")).MatchStandaloneSnapshot(t, stderr)
+
+	if !strings.Contains(stderr, "Fixed") {
+		t.Errorf("expected 'Fixed' in stderr, got: %s", stderr)
+	}
+}
+
 // TestFixPowerShellPreferShellInstruction exercises the end-to-end auto-fix path
 // for tally/powershell/prefer-shell-instruction using a PowerShell-on-Linux image.
 func TestFixPowerShellPreferShellInstruction(t *testing.T) {

--- a/internal/integration/testdata/real-world-fix-php-fpm-56/Dockerfile
+++ b/internal/integration/testdata/real-world-fix-php-fpm-56/Dockerfile
@@ -1,0 +1,210 @@
+FROM php:5.6-fpm as builder
+
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y \
+        autoconf \
+        build-essential \
+        libbsd-dev \
+        libbz2-dev \
+        libc-client2007e-dev \
+        libc6-dev \
+        libcurl3 \
+        libcurl4-openssl-dev \
+        libedit-dev \
+        libedit2 \
+        libgmp-dev \
+        libgpgme11-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libkrb5-dev \
+        libldap2-dev \
+        libldb-dev \
+        libmagick++-dev \
+        libmagickwand-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpcre3-dev \
+        libpng-dev \
+        libsqlite3-0 \
+        libsqlite3-dev \
+        libssh2-1-dev \
+        libssl-dev \
+        libtinfo-dev \
+        libtool \
+        libvpx-dev \
+        libwebp-dev \
+        libxml2 \
+        libxml2-dev \
+        libxpm-dev \
+        libxslt1-dev \
+    ; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*; \
+    ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include; \
+    docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
+    docker-php-ext-configure gd \
+        --with-png-dir=/usr \
+        --with-jpeg-dir=/usr \
+        --with-freetype-dir=/usr \
+        --with-xpm-dir=/usr \
+        --with-vpx-dir=/usr; \
+    docker-php-ext-configure gmp --with-libdir=lib/x86_64-linux-gnu; \
+    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
+    docker-php-ext-install \
+        bcmath \
+        bz2 \
+        calendar \
+        dba \
+        exif \
+        gd \
+        gettext \
+        gmp \
+        imap \
+        intl \
+        ldap \
+        mcrypt \
+        mysql \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        shmop \
+        soap \
+        sockets \
+        sysvmsg \
+        sysvsem \
+        sysvshm \
+        wddx \
+        xmlrpc \
+        xsl \
+        zip \
+    ; \
+    pecl install \
+        gnupg-1.4.0 \
+        igbinary-2.0.1 \
+        imagick-3.4.3 \
+        memcached-2.2.0 \
+        msgpack-0.5.7 \
+        redis-3.1.3 \
+        runkit-1.0.4 \
+    ; \
+    echo "\n" | pecl install ssh2-0.13; \
+    docker-php-ext-enable --ini-name pecl.ini \
+        gnupg \
+        igbinary \
+        imagick \
+        memcached \
+        msgpack \
+        redis \
+        runkit \
+        ssh2 \
+    ; \
+    curl --connect-timeout 10 -o ioncube.tar.gz -kfSL "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"; \
+    tar -zxvf ioncube.tar.gz; \
+    cp ioncube/ioncube_loader_lin_5.6.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ioncube.so; \
+    rm -Rf ioncube*; \
+    NR_VERSION="$( curl --connect-timeout 10 -skS https://download.newrelic.com/php_agent/release/ | sed -n 's/.*>\(.*linux\).tar.gz<.*/\1/p')"; \
+    curl --connect-timeout 10 -o nr.tar.gz -kfSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+    tar -xf nr.tar.gz; \
+    cp $NR_VERSION/agent/x64/newrelic-20131226.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/newrelic.so; \
+    rm -rf newrelic-php5* nr.tar.gz; \
+    echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini; \
+    echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/10-newrelic.ini; \
+    echo "runkit.internal_override=1" > /usr/local/etc/php/conf.d/10-runkit.ini;
+
+# Now that all the modules are built/downloaded, use the original php:5.6-fpm image and
+# install only the runtime dependencies with the new modules and config files.
+FROM php:5.6-fpm
+
+WORKDIR /
+
+RUN set -ex ; \
+    \
+    apt-get update && apt-get install -y --no-install-recommends \
+        libc-client2007e \
+        libgpgme11 \
+        libicu57 \
+        libmagickwand-6.q16-3 \
+        libmcrypt4 \
+        libmemcached11 \
+        libmemcachedutil2 \
+        libpng16-16 \
+        libvpx4 \
+        libwebp6 \
+        libxpm4 \
+        libxslt1.1 \
+        ssmtp \
+        ; \
+    rm -rf /tmp/pear /usr/share/doc /usr/share/man /var/lib/apt/lists/*; \
+    cd /usr/local/etc/php; \
+    php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
+
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ /usr/local/lib/php/extensions/no-debug-non-zts-20131226/
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+
+RUN pear install --alldeps \
+        Auth_SASL \
+        Auth_SASL2-beta \
+        Benchmark \
+        pear.php.net/Console_Color2-0.1.2 \
+        Console_Table \
+        HTTP_OAuth-0.3.1 \
+        HTTP_Request2 \
+        Log \
+        Mail \
+        MDB2 \
+        Net_GeoIP \
+        Net_SMTP \
+        Net_Socket \
+        XML_RPC2 \
+        pear.symfony.com/YAML \
+    ;
+
+RUN set -ex \
+    && { \
+        echo '[global]'; \
+        echo 'daemonize = no'; \
+        echo 'error_log = /proc/self/fd/2'; \
+        echo; \
+        echo '[www]'; \
+        echo 'listen = [::]:9000'; \
+        echo 'listen.owner = www-data'; \
+        echo 'listen.group = www-data'; \
+        echo; \
+        echo 'user = www-data'; \
+        echo 'group = www-data'; \
+        echo; \
+        echo 'access.log = /proc/self/fd/2'; \
+        echo; \
+        echo 'pm = static'; \
+        echo 'pm.max_children = 1'; \
+        echo 'pm.start_servers = 1'; \
+        echo 'request_terminate_timeout = 65s'; \
+        echo 'pm.max_requests = 1000'; \
+        echo 'catch_workers_output = yes'; \
+    } | tee /usr/local/etc/php-fpm.d/www.conf \
+    && mkdir -p /usr/local/php/php/auto_prepends \
+    && { \
+        echo '<?php'; \
+        echo 'if (function_exists("uopz_allow_exit")) {'; \
+        echo '    uopz_allow_exit(true);'; \
+        echo '}'; \
+        echo '?>'; \
+    } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
+    && { \
+        echo 'FromLineOverride=YES'; \
+        echo 'mailhub=127.0.0.1'; \
+        echo 'UseTLS=NO'; \
+        echo 'UseSTARTTLS=NO'; \
+    } | tee /etc/ssmtp/ssmtp.conf \
+    && { \
+        echo '[PHP]'; \
+        echo 'log_errors = On'; \
+        echo 'error_log = /dev/stderr'; \
+        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php'; \
+    } | tee /usr/local/etc/php/conf.d/php.ini \
+    ;
+
+EXPOSE 9000
+CMD ["php-fpm"]

--- a/internal/rules/cache_mounts_data.go
+++ b/internal/rules/cache_mounts_data.go
@@ -22,4 +22,34 @@ type CacheMountsResolveData struct {
 	// within its stage. Stable across earlier sync fixes that insert
 	// non-RUN instructions (e.g., SHELL) before it.
 	RunOrdinal int
+
+	// RunSignature is a whitespace-normalized representation of the original
+	// RUN script. The resolver uses it as a stable fingerprint when earlier
+	// sync fixes delete or reorder other RUN instructions in the same stage.
+	RunSignature string
+
+	// CommandNames is the exact sequence of parsed command names observed in
+	// the original RUN script. The resolver uses it to avoid matching a
+	// different package-manager RUN that happens to require the same cache
+	// mount targets.
+	CommandNames []string
+
+	// RequiredTargets is the exact set of cache mount targets detected for the
+	// original RUN. The resolver re-runs detection on post-sync content and
+	// only emits edits when the matched RUN still requires the same targets.
+	RequiredTargets []string
+
+	// CacheEnvSelections identifies the specific cache-disabling ENV bindings
+	// consumed during sync analysis for this RUN. Async resolution re-selects
+	// only these bindings so repeated ENV keys are removed at most once across
+	// multiple RUN fixes in the same stage.
+	CacheEnvSelections []CacheMountsEnvSelection
+}
+
+// CacheMountsEnvSelection identifies a cache-disabling ENV binding by its
+// position in the sorted active binding list for a RUN plus the key name it
+// must still match after post-sync reparsing.
+type CacheMountsEnvSelection struct {
+	BindingIndex int
+	Key          string
 }

--- a/internal/rules/cache_mounts_data.go
+++ b/internal/rules/cache_mounts_data.go
@@ -1,0 +1,25 @@
+package rules
+
+// CacheMountsResolverID is the unique identifier for the cache-mounts
+// post-sync fix resolver. The resolver runs after sync fixes (e.g.,
+// shellcheck/SC2086 quoting, curl-should-follow-redirects flag insertion)
+// and produces a whole-RUN tail rewrite that preserves those narrow edits.
+//
+// Only emitted when prefer-package-cache-mounts needs a tail rewrite
+// (mount flags mutated, or script cleanup needed but targeted edits
+// unavailable). Targeted edits still go out as plain sync edits.
+const CacheMountsResolverID = "prefer-package-cache-mounts"
+
+// CacheMountsResolveData carries the information the cache-mounts resolver
+// needs to re-find the target RUN instruction in post-sync content and
+// emit a fresh tail rewrite. The resolver re-runs the mount detection on
+// the updated script so narrow sync fixes on that RUN are preserved.
+type CacheMountsResolveData struct {
+	// StageIndex is the 0-based index of the stage containing the RUN.
+	StageIndex int
+
+	// RunOrdinal is the 1-based ordinal of the target RUN instruction
+	// within its stage. Stable across earlier sync fixes that insert
+	// non-RUN instructions (e.g., SHELL) before it.
+	RunOrdinal int
+}

--- a/internal/rules/tally/php/enable_opcache_in_production.go
+++ b/internal/rules/tally/php/enable_opcache_in_production.go
@@ -69,7 +69,7 @@ func (r *EnableOpcacheInProductionRule) Check(input rules.LintInput) []rules.Vio
 		return nil
 	}
 
-	if stageHasOpcacheSignal(stageFacts) {
+	if stageHasOpcacheSignal(stageFacts, info, input.Facts, input.Semantic) {
 		return nil
 	}
 
@@ -261,11 +261,11 @@ func buildOpcachePackageManagerFix(
 }
 
 // osPackageManagersForPHP is the set of install-command managers whose
-// packages follow the phpNN-opcache naming convention. Only installs from
-// these managers can be mapped to a matching OPcache system package;
-// application-level managers (composer, npm, pip, ...) may happen to
-// ship a package called "php-fpm" but it would not come with a
-// companion system OPcache extension.
+// packages follow PHP distro naming conventions (phpNN-opcache, php-xdebug,
+// etc.). Only installs from these managers can be mapped to a matching
+// companion system package; application-level managers (composer, npm,
+// pip, ...) may happen to ship a package called "php-fpm" but it would
+// not come with a matching system extension.
 var osPackageManagersForPHP = map[string]bool{
 	"apt":      true,
 	"apt-get":  true,
@@ -274,6 +274,13 @@ var osPackageManagersForPHP = map[string]bool{
 	"microdnf": true,
 	"yum":      true,
 	"zypper":   true,
+}
+
+// osPackageManagersForPHPSorted is the same set in a stable order, used to
+// seed runcheck.FindCommands when searching for OS-package-manager installs
+// in a RUN instruction.
+var osPackageManagersForPHPSorted = []string{
+	"apt", "apt-get", "apk", "dnf", "microdnf", "yum", "zypper",
 }
 
 // derivePHPOpcachePackage maps a PHP FPM package name to the matching OPcache
@@ -432,8 +439,30 @@ func isPHPWebRuntimeCommand(name string) bool {
 }
 
 // stageHasOpcacheSignal reports whether the stage has any signal that OPcache
-// is installed, enabled, or configured.
-func stageHasOpcacheSignal(sf *facts.StageFacts) bool {
+// is installed, enabled, or configured. Signals include:
+//
+//   - PHP_OPCACHE_* environment variables
+//   - RUN commands that install or enable opcache (docker-php-ext-*, pecl,
+//     OS package-manager installs of php*-opcache)
+//   - Observable ini files referencing opcache
+//   - COPY --from=<stage> of PHP extension or conf.d directories when the
+//     source stage itself has an opcache signal (multi-stage builder pattern)
+func stageHasOpcacheSignal(
+	sf *facts.StageFacts,
+	info *semantic.StageInfo,
+	ff *facts.FileFacts,
+	sem *semantic.Model,
+) bool {
+	return stageHasOpcacheSignalWithVisited(sf, info, ff, sem, map[int]bool{})
+}
+
+func stageHasOpcacheSignalWithVisited(
+	sf *facts.StageFacts,
+	info *semantic.StageInfo,
+	ff *facts.FileFacts,
+	sem *semantic.Model,
+	visited map[int]bool,
+) bool {
 	if sf == nil {
 		return false
 	}
@@ -445,7 +474,86 @@ func stageHasOpcacheSignal(sf *facts.StageFacts) bool {
 			return true
 		}
 	}
-	return slices.ContainsFunc(sf.ObservableFiles, observableFileHasOpcacheSignal)
+	if slices.ContainsFunc(sf.ObservableFiles, observableFileHasOpcacheSignal) {
+		return true
+	}
+	return inheritedOpcacheSignalFromCopyFrom(info, ff, sem, visited)
+}
+
+// inheritedOpcacheSignalFromCopyFrom reports whether this stage inherits an
+// opcache install via COPY --from=<builder> of PHP extension or conf.d
+// directories. The source stage is inspected recursively so transitive
+// builder chains are handled.
+func inheritedOpcacheSignalFromCopyFrom(
+	info *semantic.StageInfo,
+	ff *facts.FileFacts,
+	sem *semantic.Model,
+	visited map[int]bool,
+) bool {
+	if info == nil || ff == nil || sem == nil {
+		return false
+	}
+	for _, ref := range info.CopyFromRefs {
+		if !ref.IsStageRef || ref.StageIndex < 0 || ref.Command == nil {
+			continue
+		}
+		if visited[ref.StageIndex] {
+			continue
+		}
+		if !copyCarriesPHPExtension(ref.Command) {
+			continue
+		}
+		visited[ref.StageIndex] = true
+		srcFacts := ff.Stage(ref.StageIndex)
+		srcInfo := sem.StageInfo(ref.StageIndex)
+		if stageHasOpcacheSignalWithVisited(srcFacts, srcInfo, ff, sem, visited) {
+			return true
+		}
+	}
+	return false
+}
+
+// phpExtensionCopyPathPrefixes are destination-path prefixes whose contents
+// include the opcache extension and/or its enabling ini file on official
+// php:* base images:
+//
+//   - /usr/local/lib/php/extensions/ — the .so lives under an ABI-suffixed
+//     subdirectory here (e.g., no-debug-non-zts-20131226/opcache.so)
+//   - /usr/local/etc/php/conf.d/ — docker-php-ext-enable writes the ini here
+//     (e.g., docker-php-ext-opcache.ini)
+var phpExtensionCopyPathPrefixes = []string{
+	"/usr/local/lib/php/extensions/",
+	"/usr/local/etc/php/conf.d/",
+}
+
+// copyCarriesPHPExtension reports whether a COPY command copies PHP
+// extension artifacts (the .so under /usr/local/lib/php/extensions/ or the
+// enabling ini under /usr/local/etc/php/conf.d/).
+func copyCarriesPHPExtension(cmd *instructions.CopyCommand) bool {
+	if cmd == nil {
+		return false
+	}
+	if pathTargetsPHPExtensions(cmd.DestPath) {
+		return true
+	}
+	return slices.ContainsFunc(cmd.SourcePaths, pathTargetsPHPExtensions)
+}
+
+func pathTargetsPHPExtensions(p string) bool {
+	normalized := strings.TrimRight(p, "/")
+	if normalized == "" {
+		return false
+	}
+	for _, prefix := range phpExtensionCopyPathPrefixes {
+		trimmedPrefix := strings.TrimRight(prefix, "/")
+		if normalized == trimmedPrefix {
+			return true
+		}
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func envHasOpcacheSignal(env facts.EnvFacts) bool {

--- a/internal/rules/tally/php/enable_opcache_in_production.go
+++ b/internal/rules/tally/php/enable_opcache_in_production.go
@@ -536,11 +536,62 @@ func copyCarriesPHPExtension(cmd *instructions.CopyCommand) bool {
 	if pathTargetsPHPExtensions(cmd.DestPath) {
 		return true
 	}
-	return slices.ContainsFunc(cmd.SourcePaths, pathTargetsPHPExtensions)
+	return slices.ContainsFunc(cmd.SourcePaths, func(src string) bool {
+		return destinationPreservesPHPExtensionTree(src, cmd.DestPath)
+	})
+}
+
+func destinationPreservesPHPExtensionTree(src, dest string) bool {
+	srcPath := normalizeContainerPath(src)
+	destPath := normalizeContainerPath(dest)
+	if srcPath == "" || destPath == "" {
+		return false
+	}
+
+	for _, prefix := range phpExtensionCopyPathPrefixes {
+		mapped, ok := remapCopiedPath(srcPath, destPath, prefix)
+		if ok && pathTargetsPHPExtensions(mapped) {
+			return true
+		}
+	}
+	return false
+}
+
+func remapCopiedPath(src, dest, target string) (string, bool) {
+	srcPath := normalizeContainerPath(src)
+	destPath := normalizeContainerPath(dest)
+	targetPath := normalizeContainerPath(target)
+	if srcPath == "" || destPath == "" || targetPath == "" {
+		return "", false
+	}
+
+	switch {
+	case srcPath == targetPath:
+		return destPath, true
+	case strings.HasPrefix(srcPath, targetPath+"/"):
+		rel := strings.TrimPrefix(srcPath, targetPath+"/")
+		return path.Join(destPath, rel), true
+	case strings.HasPrefix(targetPath+"/", srcPath+"/"):
+		rel := strings.TrimPrefix(targetPath, srcPath)
+		return path.Join(destPath, strings.TrimPrefix(rel, "/")), true
+	default:
+		return "", false
+	}
+}
+
+func normalizeContainerPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	cleaned := strings.TrimRight(path.Clean(p), "/")
+	if cleaned == "." {
+		return ""
+	}
+	return cleaned
 }
 
 func pathTargetsPHPExtensions(p string) bool {
-	normalized := strings.TrimRight(p, "/")
+	normalized := normalizeContainerPath(p)
 	if normalized == "" {
 		return false
 	}

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -241,6 +241,61 @@ RUN echo done
 `,
 			WantViolations: 0,
 		},
+		// --- COPY --from inheritance: final stage inherits opcache from builder ---
+		{
+			Name: "final stage copies ext dir from builder with opcache no violation",
+			Content: `FROM php:5.6-fpm AS builder
+RUN docker-php-ext-install opcache
+
+FROM php:5.6-fpm
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ /usr/local/lib/php/extensions/no-debug-non-zts-20131226/
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "final stage copies conf.d from builder with opcache no violation",
+			Content: `FROM php:8.4-fpm AS builder
+RUN docker-php-ext-install opcache
+
+FROM php:8.4-fpm
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "final stage copies unrelated files from builder with opcache still violates",
+			Content: `FROM php:8.4-fpm AS builder
+RUN docker-php-ext-install opcache
+
+FROM php:8.4-fpm
+COPY --from=builder /app /app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "final stage copies ext dir from builder without opcache still violates",
+			Content: `FROM php:8.4-fpm AS builder
+RUN docker-php-ext-install gd
+
+FROM php:8.4-fpm
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20230831/ /usr/local/lib/php/extensions/no-debug-non-zts-20230831/
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "transitive COPY --from chain preserves opcache inheritance",
+			Content: `FROM php:8.4-fpm AS base-ext
+RUN docker-php-ext-install opcache
+
+FROM php:8.4-fpm AS intermediate
+COPY --from=base-ext /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
+
+FROM php:8.4-fpm
+COPY --from=intermediate /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
+COPY --from=intermediate /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+`,
+			WantViolations: 0,
+		},
 	})
 }
 

--- a/internal/rules/tally/php/enable_opcache_in_production_test.go
+++ b/internal/rules/tally/php/enable_opcache_in_production_test.go
@@ -263,12 +263,32 @@ COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
 			WantViolations: 0,
 		},
 		{
+			Name: "final stage copies parent php tree from builder with opcache no violation",
+			Content: `FROM php:8.4-fpm AS builder
+RUN docker-php-ext-install opcache
+
+FROM php:8.4-fpm
+COPY --from=builder /usr/local/ /usr/local/
+`,
+			WantViolations: 0,
+		},
+		{
 			Name: "final stage copies unrelated files from builder with opcache still violates",
 			Content: `FROM php:8.4-fpm AS builder
 RUN docker-php-ext-install opcache
 
 FROM php:8.4-fpm
 COPY --from=builder /app /app
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "final stage copies php conf to inactive destination still violates",
+			Content: `FROM php:8.4-fpm AS builder
+RUN docker-php-ext-install opcache
+
+FROM php:8.4-fpm
+COPY --from=builder /usr/local/etc/php/conf.d/ /tmp/conf.d/
 `,
 			WantViolations: 1,
 		},

--- a/internal/rules/tally/php/helpers.go
+++ b/internal/rules/tally/php/helpers.go
@@ -136,18 +136,13 @@ func findXdebugCommands(
 		return nil, 0
 	}
 
-	installsByName := make(map[string][]shell.InstallCommand, len(runFacts.InstallCommands))
-	for _, ic := range runFacts.InstallCommands {
-		installsByName[ic.Manager] = append(installsByName[ic.Manager], ic)
-	}
-
 	filtered := make([]shell.CommandInfo, 0, len(cmds))
 	for _, cmd := range cmds {
 		if phpExtensionReferencesXdebug(cmd) {
 			filtered = append(filtered, cmd)
 			continue
 		}
-		if commandInstallsXdebugPackage(cmd, installsByName) {
+		if commandInstallsXdebugPackage(cmd, runFacts.InstallCommands) {
 			filtered = append(filtered, cmd)
 		}
 	}
@@ -168,14 +163,69 @@ func phpExtensionReferencesXdebug(cmd shell.CommandInfo) bool {
 }
 
 // commandInstallsXdebugPackage reports whether a CommandInfo matching an OS
-// package manager corresponds to an InstallCommand whose package list
-// contains an Xdebug-bearing package. Defers package-name normalization to
-// shell.StripPackageVersion via installCommandInstallsXdebug.
-func commandInstallsXdebugPackage(cmd shell.CommandInfo, installsByName map[string][]shell.InstallCommand) bool {
+// package manager corresponds to the exact InstallCommand occurrence whose
+// package list contains an Xdebug-bearing package. Defers package-name
+// normalization to shell.StripPackageVersion via installCommandInstallsXdebug.
+func commandInstallsXdebugPackage(cmd shell.CommandInfo, installs []shell.InstallCommand) bool {
 	if !osPackageManagersForPHP[strings.ToLower(cmd.Name)] {
 		return false
 	}
-	return slices.ContainsFunc(installsByName[cmd.Name], installCommandInstallsXdebug)
+	return slices.ContainsFunc(installs, func(ic shell.InstallCommand) bool {
+		return installCommandMatchesCommand(cmd, ic) && installCommandInstallsXdebug(ic)
+	})
+}
+
+func installCommandMatchesCommand(cmd shell.CommandInfo, ic shell.InstallCommand) bool {
+	if !strings.EqualFold(cmd.Name, ic.Manager) {
+		return false
+	}
+	if cmd.Subcommand != ic.Subcommand {
+		return false
+	}
+	if len(ic.Packages) == 0 {
+		return false
+	}
+
+	packages := make([]string, 0, len(ic.Packages))
+	for _, pkg := range ic.Packages {
+		packages = append(packages, pkg.Normalized)
+	}
+	return slices.Equal(packageArgsForPHPManager(cmd.Name, argsAfterSubcommand(cmd.Args, cmd.Subcommand)), packages)
+}
+
+func packageArgsForPHPManager(manager string, args []string) []string {
+	var got []string
+	skipNext := false
+	for _, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			if phpManagerFlagConsumesValue(manager, arg) {
+				skipNext = true
+			}
+			continue
+		}
+		got = append(got, arg)
+	}
+	return got
+}
+
+func phpManagerFlagConsumesValue(manager, flag string) bool {
+	switch strings.ToLower(manager) {
+	case "apt", "apt-get":
+		switch flag {
+		case "-o", "--option", "-t", "--target-release":
+			return true
+		}
+	case "dnf", "microdnf", "yum":
+		switch flag {
+		case "--root", "--installroot", "--releasever", "--repo":
+			return true
+		}
+	}
+	return false
 }
 
 // installCommandInstallsXdebug reports whether a normalized package-manager

--- a/internal/rules/tally/php/helpers.go
+++ b/internal/rules/tally/php/helpers.go
@@ -15,17 +15,20 @@ import (
 
 const (
 	subcommandInstall = "install"
-	subcommandAdd     = "add" //nolint:customlint // apk subcommand, not Dockerfile ADD instruction
 
 	cmdDockerPHPExtInstall = "docker-php-ext-install"
 	cmdDockerPHPExtEnable  = "docker-php-ext-enable"
 	cmdPecl                = "pecl"
-	cmdApk                 = "apk"
-	cmdApt                 = "apt"
-	cmdAptGet              = "apt-get"
-	cmdDnf                 = "dnf"
-	cmdYum                 = "yum"
 )
+
+// phpExtensionCommandNames are the PHP-specific extension commands that
+// can install or enable a PHP extension. General OS package-manager
+// installs are handled separately via facts.RunFacts.InstallCommands.
+var phpExtensionCommandNames = []string{
+	cmdDockerPHPExtInstall,
+	cmdDockerPHPExtEnable,
+	cmdPecl,
+}
 
 var nonProductionStageTokens = []string{"dev", "development", "test", "testing", "ci", "debug"}
 
@@ -109,55 +112,106 @@ func phpCommandLocation(
 	return rules.NewRangeLocation(file, cmdLine, cmd.StartCol, cmdLine, cmd.EndCol)
 }
 
-// xdebugCommandNames are the command names that can install or enable Xdebug.
-var xdebugCommandNames = []string{
-	"docker-php-ext-install",
-	"docker-php-ext-enable",
-	"pecl",
-	"apt-get", "apt",
-	"apk",
-	"dnf", "yum",
-}
-
-// findXdebugCommands returns commands that install or enable Xdebug in a RUN instruction.
+// findXdebugCommands returns RUN commands that install or enable Xdebug,
+// covering both PHP-specific extension commands (docker-php-ext-install,
+// docker-php-ext-enable, pecl install) and OS package-manager installs
+// (apt/apt-get/apk/dnf/microdnf/yum/zypper) whose package list contains
+// an Xdebug-bearing package.
+//
+// Positions come from runcheck.FindCommands so they map back to the
+// Dockerfile source; OS package-manager detection defers to
+// facts.RunFacts.InstallCommands + shell.StripPackageVersion for
+// version/arch-tolerant package-name comparison.
 func findXdebugCommands(
-	run *instructions.RunCommand,
+	runFacts *facts.RunFacts,
 	shellVariant shell.Variant,
 	sm *sourcemap.SourceMap,
 ) ([]shell.CommandInfo, int) {
-	cmds, runStartLine := runcheck.FindCommands(run, shellVariant, sm, xdebugCommandNames...)
+	names := make([]string, 0, len(phpExtensionCommandNames)+len(osPackageManagersForPHPSorted))
+	names = append(names, phpExtensionCommandNames...)
+	names = append(names, osPackageManagersForPHPSorted...)
+
+	cmds, runStartLine := runcheck.FindCommands(runFacts.Run, shellVariant, sm, names...)
 	if len(cmds) == 0 {
 		return nil, 0
 	}
 
+	installsByName := make(map[string][]shell.InstallCommand, len(runFacts.InstallCommands))
+	for _, ic := range runFacts.InstallCommands {
+		installsByName[ic.Manager] = append(installsByName[ic.Manager], ic)
+	}
+
 	filtered := make([]shell.CommandInfo, 0, len(cmds))
 	for _, cmd := range cmds {
-		if commandReferencesXdebug(cmd) {
+		if phpExtensionReferencesXdebug(cmd) {
+			filtered = append(filtered, cmd)
+			continue
+		}
+		if commandInstallsXdebugPackage(cmd, installsByName) {
 			filtered = append(filtered, cmd)
 		}
 	}
 	return filtered, runStartLine
 }
 
-// commandReferencesXdebug checks whether a parsed command installs or enables Xdebug.
-func commandReferencesXdebug(cmd shell.CommandInfo) bool {
+// phpExtensionReferencesXdebug checks whether a docker-php-ext-* or pecl
+// command installs or enables Xdebug.
+func phpExtensionReferencesXdebug(cmd shell.CommandInfo) bool {
 	switch cmd.Name {
-	case "docker-php-ext-install", "docker-php-ext-enable":
+	case cmdDockerPHPExtInstall, cmdDockerPHPExtEnable:
 		return argsContainXdebug(cmd.Args)
-	case "pecl":
+	case cmdPecl:
 		return cmd.Subcommand == subcommandInstall && argsContainXdebug(cmd.Args)
-	case "apt-get", "apt":
-		return cmd.Subcommand == subcommandInstall && argsContainXdebugSubstring(cmd.Args)
-	case "apk":
-		return cmd.Subcommand == subcommandAdd && argsContainXdebugSubstring(cmd.Args)
-	case "dnf", "yum":
-		return cmd.Subcommand == subcommandInstall && argsContainXdebugSubstring(cmd.Args)
 	default:
 		return false
 	}
 }
 
-// argsContainXdebug checks if any non-flag arg is "xdebug" or starts with "xdebug-" (versioned pecl).
+// commandInstallsXdebugPackage reports whether a CommandInfo matching an OS
+// package manager corresponds to an InstallCommand whose package list
+// contains an Xdebug-bearing package. Defers package-name normalization to
+// shell.StripPackageVersion via installCommandInstallsXdebug.
+func commandInstallsXdebugPackage(cmd shell.CommandInfo, installsByName map[string][]shell.InstallCommand) bool {
+	if !osPackageManagersForPHP[strings.ToLower(cmd.Name)] {
+		return false
+	}
+	return slices.ContainsFunc(installsByName[cmd.Name], installCommandInstallsXdebug)
+}
+
+// installCommandInstallsXdebug reports whether a normalized package-manager
+// install references an Xdebug package (e.g., php-xdebug, php8.3-xdebug,
+// php83-pecl-xdebug). Only OS-level package managers are considered; an
+// npm/pip/composer package with "xdebug" in its name does not imply the PHP
+// Xdebug extension is installed in the image.
+func installCommandInstallsXdebug(ic shell.InstallCommand) bool {
+	if !osPackageManagersForPHP[strings.ToLower(ic.Manager)] {
+		return false
+	}
+	return slices.ContainsFunc(ic.Packages, packageNameContainsXdebug)
+}
+
+// packagesOnlyXdebug reports whether every package in an install command is
+// an Xdebug package. Returns false for empty package lists.
+func packagesOnlyXdebug(ic shell.InstallCommand) bool {
+	if !osPackageManagersForPHP[strings.ToLower(ic.Manager)] || len(ic.Packages) == 0 {
+		return false
+	}
+	for _, pkg := range ic.Packages {
+		if !packageNameContainsXdebug(pkg) {
+			return false
+		}
+	}
+	return true
+}
+
+func packageNameContainsXdebug(pkg shell.PackageArg) bool {
+	name := strings.ToLower(shell.StripPackageVersion(pkg.Normalized))
+	return strings.Contains(name, "xdebug")
+}
+
+// argsContainXdebug checks if any non-flag arg is "xdebug" or starts with
+// "xdebug-" (used by docker-php-ext-* and `pecl install`, where args are
+// PHP extension names, not distro package names).
 func argsContainXdebug(args []string) bool {
 	for _, arg := range args {
 		if strings.HasPrefix(arg, "-") {
@@ -165,20 +219,6 @@ func argsContainXdebug(args []string) bool {
 		}
 		lower := strings.ToLower(arg)
 		if lower == "xdebug" || strings.HasPrefix(lower, "xdebug-") {
-			return true
-		}
-	}
-	return false
-}
-
-// argsContainXdebugSubstring checks if any non-flag arg contains "xdebug" as a substring.
-// Used for package-manager installs where package names vary (php-xdebug, php8.3-xdebug, etc.).
-func argsContainXdebugSubstring(args []string) bool {
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "-") {
-			continue
-		}
-		if strings.Contains(strings.ToLower(arg), "xdebug") {
 			return true
 		}
 	}

--- a/internal/rules/tally/php/helpers_test.go
+++ b/internal/rules/tally/php/helpers_test.go
@@ -32,7 +32,7 @@ func TestStageLooksLikeDev(t *testing.T) {
 	}
 }
 
-func TestCommandReferencesXdebug(t *testing.T) {
+func TestPHPExtensionReferencesXdebug(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -71,31 +71,6 @@ func TestCommandReferencesXdebug(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "apt-get install php-xdebug",
-			cmd:  shell.CommandInfo{Name: "apt-get", Subcommand: "install", Args: []string{"install", "-y", "php-xdebug"}},
-			want: true,
-		},
-		{
-			name: "apt-get install versioned php8.3-xdebug",
-			cmd:  shell.CommandInfo{Name: "apt-get", Subcommand: "install", Args: []string{"install", "php8.3-xdebug"}},
-			want: true,
-		},
-		{
-			name: "apk add php-pecl-xdebug",
-			cmd:  shell.CommandInfo{Name: "apk", Subcommand: "add", Args: []string{"add", "--no-cache", "php83-pecl-xdebug"}},
-			want: true,
-		},
-		{
-			name: "dnf install php-pecl-xdebug",
-			cmd:  shell.CommandInfo{Name: "dnf", Subcommand: "install", Args: []string{"install", "php-pecl-xdebug"}},
-			want: true,
-		},
-		{
-			name: "yum install php-pecl-xdebug",
-			cmd:  shell.CommandInfo{Name: "yum", Subcommand: "install", Args: []string{"install", "php-pecl-xdebug"}},
-			want: true,
-		},
-		{
 			name: "docker-php-ext-install gd only",
 			cmd:  shell.CommandInfo{Name: "docker-php-ext-install", Subcommand: "gd", Args: []string{"gd"}},
 			want: false,
@@ -106,13 +81,15 @@ func TestCommandReferencesXdebug(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "apt-get update",
-			cmd:  shell.CommandInfo{Name: "apt-get", Subcommand: "update", Args: []string{"update"}},
+			name: "unrelated command",
+			cmd:  shell.CommandInfo{Name: "echo", Subcommand: "hello", Args: []string{"hello"}},
 			want: false,
 		},
 		{
-			name: "unrelated command",
-			cmd:  shell.CommandInfo{Name: "echo", Subcommand: "hello", Args: []string{"hello"}},
+			// OS package manager installs are handled via InstallCommand,
+			// not phpExtensionReferencesXdebug.
+			name: "apt-get install php-xdebug ignored by ext matcher",
+			cmd:  shell.CommandInfo{Name: "apt-get", Subcommand: "install", Args: []string{"install", "-y", "php-xdebug"}},
 			want: false,
 		},
 	}
@@ -120,8 +97,8 @@ func TestCommandReferencesXdebug(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := commandReferencesXdebug(tt.cmd); got != tt.want {
-				t.Errorf("commandReferencesXdebug(%v) = %v, want %v", tt.cmd.Name, got, tt.want)
+			if got := phpExtensionReferencesXdebug(tt.cmd); got != tt.want {
+				t.Errorf("phpExtensionReferencesXdebug(%v) = %v, want %v", tt.cmd.Name, got, tt.want)
 			}
 		})
 	}
@@ -155,28 +132,80 @@ func TestArgsContainXdebug(t *testing.T) {
 	}
 }
 
-func TestArgsContainXdebugSubstring(t *testing.T) {
+func TestInstallCommandInstallsXdebug(t *testing.T) {
 	t.Parallel()
+
+	makeIC := func(manager string, names ...string) shell.InstallCommand {
+		pkgs := make([]shell.PackageArg, 0, len(names))
+		for _, n := range names {
+			pkgs = append(pkgs, shell.PackageArg{Normalized: n})
+		}
+		return shell.InstallCommand{Manager: manager, Packages: pkgs}
+	}
 
 	tests := []struct {
 		name string
-		args []string
+		ic   shell.InstallCommand
 		want bool
 	}{
-		{name: "php-xdebug", args: []string{"php-xdebug"}, want: true},
-		{name: "php8.3-xdebug", args: []string{"php8.3-xdebug"}, want: true},
-		{name: "php-pecl-xdebug", args: []string{"php-pecl-xdebug"}, want: true},
-		{name: "php83-pecl-xdebug", args: []string{"php83-pecl-xdebug"}, want: true},
-		{name: "skip flags", args: []string{"-y", "php-xdebug"}, want: true},
-		{name: "no xdebug", args: []string{"php-gd", "php-intl"}, want: false},
-		{name: "empty", args: nil, want: false},
+		{name: "apt php-xdebug", ic: makeIC("apt-get", "php-xdebug"), want: true},
+		{name: "apt php8.3-xdebug", ic: makeIC("apt-get", "php8.3-xdebug"), want: true},
+		{name: "apt php-xdebug with version spec", ic: makeIC("apt-get", "php-xdebug=3.1.6-1+deb12u1"), want: true},
+		{name: "apt php-xdebug with arch", ic: makeIC("apt-get", "php-xdebug:amd64"), want: true},
+		{name: "apk php83-pecl-xdebug", ic: makeIC("apk", "php83-pecl-xdebug"), want: true},
+		{name: "dnf php-pecl-xdebug", ic: makeIC("dnf", "php-pecl-xdebug"), want: true},
+		{name: "yum mixed packages", ic: makeIC("yum", "php-gd", "php-pecl-xdebug", "php-intl"), want: true},
+		{name: "microdnf php-pecl-xdebug", ic: makeIC("microdnf", "php-pecl-xdebug"), want: true},
+		{name: "zypper php-xdebug", ic: makeIC("zypper", "php-xdebug"), want: true},
+		{name: "apt no xdebug", ic: makeIC("apt-get", "php-gd", "php-intl"), want: false},
+		{name: "empty", ic: shell.InstallCommand{}, want: false},
+		// Non-OS package managers must not count: an npm/pip/composer package
+		// whose name happens to contain "xdebug" is not the PHP extension.
+		{name: "npm fake xdebug package", ic: makeIC("npm", "xdebug"), want: false},
+		{name: "pip fake xdebug package", ic: makeIC("pip", "php-xdebug"), want: false},
+		{name: "composer fake xdebug package", ic: makeIC("composer", "php-xdebug"), want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := argsContainXdebugSubstring(tt.args); got != tt.want {
-				t.Errorf("argsContainXdebugSubstring(%v) = %v, want %v", tt.args, got, tt.want)
+			if got := installCommandInstallsXdebug(tt.ic); got != tt.want {
+				t.Errorf("installCommandInstallsXdebug(%v) = %v, want %v", tt.ic.Packages, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPackagesOnlyXdebug(t *testing.T) {
+	t.Parallel()
+
+	makeIC := func(manager string, names ...string) shell.InstallCommand {
+		pkgs := make([]shell.PackageArg, 0, len(names))
+		for _, n := range names {
+			pkgs = append(pkgs, shell.PackageArg{Normalized: n})
+		}
+		return shell.InstallCommand{Manager: manager, Packages: pkgs}
+	}
+
+	tests := []struct {
+		name string
+		ic   shell.InstallCommand
+		want bool
+	}{
+		{name: "apt single xdebug", ic: makeIC("apt-get", "php-xdebug"), want: true},
+		{name: "apt versioned xdebug", ic: makeIC("apt-get", "php-xdebug=3.1.6"), want: true},
+		{name: "apt xdebug only (multi)", ic: makeIC("apt-get", "php-xdebug", "php8.3-xdebug"), want: true},
+		{name: "apt mixed with non-xdebug", ic: makeIC("apt-get", "php-gd", "php-xdebug"), want: false},
+		{name: "apt no xdebug", ic: makeIC("apt-get", "php-gd"), want: false},
+		{name: "apt empty packages", ic: makeIC("apt-get"), want: false},
+		{name: "npm not OS manager", ic: makeIC("npm", "xdebug"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := packagesOnlyXdebug(tt.ic); got != tt.want {
+				t.Errorf("packagesOnlyXdebug(%v) = %v, want %v", tt.ic, got, tt.want)
 			}
 		})
 	}

--- a/internal/rules/tally/php/no_xdebug_in_final_image.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image.go
@@ -83,33 +83,103 @@ func (r *NoXdebugInFinalImageRule) checkRunCommands(
 			continue
 		}
 
-		xdebugCmds, runStartLine := findXdebugCommands(runFacts.Run, shellVariant, sm)
+		xdebugCmds, runStartLine := findXdebugCommands(runFacts, shellVariant, sm)
 		if len(xdebugCmds) == 0 {
 			continue
 		}
 
-		allXdebug := allCommandsOnlyXdebug(runFacts.CommandInfos)
+		onlyXdebug := runOnlyInstallsXdebug(runFacts)
 
 		for _, cmd := range xdebugCmds {
-			v := rules.NewViolation(
-				phpCommandLocation(file, runFacts.Run, cmd, runStartLine),
-				meta.Code,
-				meta.Description,
-				meta.DefaultSeverity,
-			).WithDocURL(meta.DocURL).WithDetail(
-				"Xdebug is a development and debugging tool that should not ship in production images. " +
-					"Move the Xdebug installation into a dedicated dev or debug build stage.",
-			)
-
-			if allXdebug {
+			v := r.newRunViolation(file, runFacts.Run, cmd, runStartLine, meta)
+			if onlyXdebug {
 				v = v.WithSuggestedFixes(buildXdebugFixes(file, source, runFacts.Run, meta.FixPriority, sm))
 			}
-
 			violations = append(violations, v)
 		}
 	}
 
 	return violations
+}
+
+func (r *NoXdebugInFinalImageRule) newRunViolation(
+	file string,
+	run *instructions.RunCommand,
+	cmd shell.CommandInfo,
+	runStartLine int,
+	meta rules.RuleMetadata,
+) rules.Violation {
+	return rules.NewViolation(
+		phpCommandLocation(file, run, cmd, runStartLine),
+		meta.Code,
+		meta.Description,
+		meta.DefaultSeverity,
+	).WithDocURL(meta.DocURL).WithDetail(
+		"Xdebug is a development and debugging tool that should not ship in production images. " +
+			"Move the Xdebug installation into a dedicated dev or debug build stage.",
+	)
+}
+
+// runOnlyInstallsXdebug reports whether every command in a RUN instruction
+// exclusively installs or enables Xdebug (no other extensions or packages),
+// meaning the entire instruction can be safely commented out or deleted.
+//
+// A RUN qualifies when every parsed command is either:
+//   - a docker-php-ext-install/enable whose args are all Xdebug, or
+//   - a `pecl install` whose non-flag args are all Xdebug, or
+//   - an OS package-manager install whose package list is all Xdebug.
+func runOnlyInstallsXdebug(runFacts *facts.RunFacts) bool {
+	if len(runFacts.CommandInfos) == 0 {
+		return false
+	}
+
+	// All OS package-manager installs in this RUN must target only Xdebug.
+	for _, ic := range runFacts.InstallCommands {
+		if !osPackageManagersForPHP[strings.ToLower(ic.Manager)] {
+			return false
+		}
+		if !packagesOnlyXdebug(ic) {
+			return false
+		}
+	}
+
+	sawXdebug := false
+	for _, cmd := range runFacts.CommandInfos {
+		switch cmd.Name {
+		case cmdDockerPHPExtInstall, cmdDockerPHPExtEnable:
+			if !allNonFlagArgsAreXdebug(cmd.Args) {
+				return false
+			}
+			sawXdebug = true
+		case cmdPecl:
+			if cmd.Subcommand != subcommandInstall {
+				return false
+			}
+			if !allNonFlagArgsAreXdebug(argsAfterSubcommand(cmd.Args, subcommandInstall)) {
+				return false
+			}
+			sawXdebug = true
+		default:
+			// Anything else is only permitted if it's a recognized OS package
+			// manager — InstallCommands was already validated above, so any
+			// other command name means the RUN does additional work.
+			if !osPackageManagersForPHP[strings.ToLower(cmd.Name)] {
+				return false
+			}
+			sawXdebug = true
+		}
+	}
+	return sawXdebug
+}
+
+// argsAfterSubcommand returns args after the first occurrence of subcmd.
+func argsAfterSubcommand(args []string, subcmd string) []string {
+	for i, a := range args {
+		if a == subcmd {
+			return args[i+1:]
+		}
+	}
+	return args
 }
 
 func (r *NoXdebugInFinalImageRule) checkObservableFiles(
@@ -135,72 +205,55 @@ func (r *NoXdebugInFinalImageRule) checkObservableFiles(
 			continue
 		}
 
-		cmds := shell.FindCommands(content, shell.VariantBash, xdebugCommandNames...)
-		for _, cmd := range cmds {
-			if !commandReferencesXdebug(cmd) {
-				continue
-			}
-
-			v := rules.NewViolation(
-				rules.NewLineLocation(file, observed.Line),
-				meta.Code,
-				"Observable script installs Xdebug in the final image",
-				meta.DefaultSeverity,
-			).WithDocURL(meta.DocURL).WithDetail(
-				"The script at " + observed.Path + " installs Xdebug. " +
-					"Move the Xdebug installation into a dedicated dev or debug build stage.",
-			)
-			violations = append(violations, v)
+		for range extensionXdebugOccurrences(content) {
+			violations = append(violations, observableXdebugViolation(file, observed, meta))
+		}
+		for range installXdebugOccurrences(content) {
+			violations = append(violations, observableXdebugViolation(file, observed, meta))
 		}
 	}
 
 	return violations
 }
 
-// allCommandsOnlyXdebug reports whether every command in a RUN instruction
-// exclusively does Xdebug work (no other extensions or packages), meaning the
-// entire instruction can be safely commented out or deleted.
-func allCommandsOnlyXdebug(cmds []shell.CommandInfo) bool {
-	if len(cmds) == 0 {
-		return false
-	}
-	for _, cmd := range cmds {
-		if !commandOnlyDoesXdebug(cmd) {
-			return false
+// extensionXdebugOccurrences counts xdebug installs/enables via
+// docker-php-ext-* or pecl in a shell script.
+func extensionXdebugOccurrences(script string) []shell.CommandInfo {
+	var hits []shell.CommandInfo
+	for _, cmd := range shell.FindCommands(script, shell.VariantBash, phpExtensionCommandNames...) {
+		if phpExtensionReferencesXdebug(cmd) {
+			hits = append(hits, cmd)
 		}
 	}
-	return true
+	return hits
 }
 
-// commandOnlyDoesXdebug checks whether a command installs/enables Xdebug
-// exclusively, with no other extensions or packages.
-func commandOnlyDoesXdebug(cmd shell.CommandInfo) bool {
-	switch cmd.Name {
-	case "docker-php-ext-install", "docker-php-ext-enable":
-		return allNonFlagArgsAreXdebug(cmd.Args)
-	case "pecl":
-		if cmd.Subcommand != subcommandInstall {
-			return false
+// installXdebugOccurrences counts OS package-manager installs of xdebug
+// packages in a shell script.
+func installXdebugOccurrences(script string) []shell.InstallCommand {
+	var hits []shell.InstallCommand
+	for _, ic := range shell.FindInstallPackages(script, shell.VariantBash) {
+		if installCommandInstallsXdebug(ic) {
+			hits = append(hits, ic)
 		}
-		return allNonFlagArgsAreXdebug(argsAfterSubcommand(cmd.Args, subcommandInstall))
-	case "apt-get", "apt":
-		if cmd.Subcommand != subcommandInstall {
-			return false
-		}
-		return allNonFlagArgsAreXdebugSubstring(argsAfterSubcommand(cmd.Args, subcommandInstall))
-	case "apk":
-		if cmd.Subcommand != subcommandAdd {
-			return false
-		}
-		return allNonFlagArgsAreXdebugSubstring(argsAfterSubcommand(cmd.Args, subcommandAdd))
-	case "dnf", "yum":
-		if cmd.Subcommand != subcommandInstall {
-			return false
-		}
-		return allNonFlagArgsAreXdebugSubstring(argsAfterSubcommand(cmd.Args, subcommandInstall))
-	default:
-		return false
 	}
+	return hits
+}
+
+func observableXdebugViolation(
+	file string,
+	observed *facts.ObservableFile,
+	meta rules.RuleMetadata,
+) rules.Violation {
+	return rules.NewViolation(
+		rules.NewLineLocation(file, observed.Line),
+		meta.Code,
+		"Observable script installs Xdebug in the final image",
+		meta.DefaultSeverity,
+	).WithDocURL(meta.DocURL).WithDetail(
+		"The script at " + observed.Path + " installs Xdebug. " +
+			"Move the Xdebug installation into a dedicated dev or debug build stage.",
+	)
 }
 
 func allNonFlagArgsAreXdebug(args []string) bool {
@@ -216,31 +269,6 @@ func allNonFlagArgsAreXdebug(args []string) bool {
 		found = true
 	}
 	return found
-}
-
-// allNonFlagArgsAreXdebugSubstring is like allNonFlagArgsAreXdebug but uses
-// substring matching for package-manager packages (e.g., "php-xdebug").
-func allNonFlagArgsAreXdebugSubstring(args []string) bool {
-	found := false
-	for _, arg := range args {
-		if strings.HasPrefix(arg, "-") {
-			continue
-		}
-		if !strings.Contains(strings.ToLower(arg), "xdebug") {
-			return false
-		}
-		found = true
-	}
-	return found
-}
-
-func argsAfterSubcommand(args []string, subcmd string) []string {
-	for i, arg := range args {
-		if arg == subcmd {
-			return args[i+1:]
-		}
-	}
-	return args
 }
 
 // buildXdebugFixes returns comment-out and delete fix alternatives for a RUN

--- a/internal/rules/tally/php/no_xdebug_in_final_image.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
 	"github.com/wharflab/tally/internal/facts"
@@ -127,7 +128,8 @@ func (r *NoXdebugInFinalImageRule) newRunViolation(
 // A RUN qualifies when every parsed command is either:
 //   - a docker-php-ext-install/enable whose args are all Xdebug, or
 //   - a `pecl install` whose non-flag args are all Xdebug, or
-//   - an OS package-manager install whose package list is all Xdebug.
+//   - an OS package-manager install/remove whose package list is all Xdebug, or
+//   - a harmless OS package-manager cache-refresh/cleanup command.
 func runOnlyInstallsXdebug(runFacts *facts.RunFacts) bool {
 	if len(runFacts.CommandInfos) == 0 {
 		return false
@@ -160,13 +162,11 @@ func runOnlyInstallsXdebug(runFacts *facts.RunFacts) bool {
 			}
 			sawXdebug = true
 		default:
-			// Anything else is only permitted if it's a recognized OS package
-			// manager — InstallCommands was already validated above, so any
-			// other command name means the RUN does additional work.
-			if !osPackageManagersForPHP[strings.ToLower(cmd.Name)] {
+			allowed, touchesXdebug := osPackageManagerCommandOnlyTouchesXdebug(cmd)
+			if !allowed {
 				return false
 			}
-			sawXdebug = true
+			sawXdebug = sawXdebug || touchesXdebug
 		}
 	}
 	return sawXdebug
@@ -179,7 +179,63 @@ func argsAfterSubcommand(args []string, subcmd string) []string {
 			return args[i+1:]
 		}
 	}
-	return args
+	return nil
+}
+
+func osPackageManagerCommandOnlyTouchesXdebug(cmd shell.CommandInfo) (allowed, touchesXdebug bool) {
+	if !osPackageManagersForPHP[strings.ToLower(cmd.Name)] {
+		return false, false
+	}
+
+	args := argsAfterSubcommand(cmd.Args, cmd.Subcommand)
+	switch strings.ToLower(cmd.Subcommand) {
+	case "install", command.Add, "in", "remove", "del", "erase", "purge":
+		matches := allNonFlagArgsAreXdebugPackages(args)
+		return matches, matches
+	case "update", "upgrade", "refresh", "makecache", "autoremove":
+		return noNonFlagArgs(args), false
+	case "clean":
+		return onlyCleanupTargets(args), false
+	default:
+		return false, false
+	}
+}
+
+func noNonFlagArgs(args []string) bool {
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			return false
+		}
+	}
+	return true
+}
+
+func allNonFlagArgsAreXdebugPackages(args []string) bool {
+	found := false
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if !packageNameContainsXdebug(shell.PackageArg{Normalized: arg}) {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+func onlyCleanupTargets(args []string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		switch strings.ToLower(arg) {
+		case "all", "packages", "metadata", "dbcache", "expire-cache":
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (r *NoXdebugInFinalImageRule) checkObservableFiles(

--- a/internal/rules/tally/php/no_xdebug_in_final_image_test.go
+++ b/internal/rules/tally/php/no_xdebug_in_final_image_test.go
@@ -87,6 +87,13 @@ RUN apk add --no-cache php83-pecl-xdebug
 			WantViolations: 1,
 		},
 		{
+			Name: "only exact xdebug install command is reported among same-manager commands",
+			Content: `FROM php:8.4-cli
+RUN apt-get update && apt-get install -y php-xdebug && apt-get install -y curl
+`,
+			WantViolations: 1,
+		},
+		{
 			Name: "chained install and enable reports both",
 			Content: `FROM php:8.4-cli
 RUN pecl install xdebug && docker-php-ext-enable xdebug
@@ -277,6 +284,25 @@ func TestNoXdebugInFinalImageRule_SuggestedFix_AptGetSinglePackage(t *testing.T)
 	}
 }
 
+func TestNoXdebugInFinalImageRule_SuggestedFix_AptGetUpdateInstallClean(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN apt-get update && apt-get install -y php-xdebug && apt-get clean\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix for xdebug-only package-manager RUN")
+	}
+	if fix.Edits[0].NewText != "# RUN apt-get update && apt-get install -y php-xdebug && apt-get clean" {
+		t.Errorf("NewText = %q, want commented-out line", fix.Edits[0].NewText)
+	}
+}
+
 func TestNoXdebugInFinalImageRule_NoFixWhenMixedPackages(t *testing.T) {
 	t.Parallel()
 
@@ -288,6 +314,20 @@ func TestNoXdebugInFinalImageRule_NoFixWhenMixedPackages(t *testing.T) {
 	}
 	if violations[0].SuggestedFix != nil {
 		t.Error("expected no SuggestedFix when xdebug is mixed with other packages")
+	}
+}
+
+func TestNoXdebugInFinalImageRule_NoFixWhenPackageManagerDoesOtherWork(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM php:8.4-cli\nRUN apt-get install -y php-xdebug && apt-get remove -y curl\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewNoXdebugInFinalImageRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Error("expected no SuggestedFix when the RUN does non-xdebug package-manager work")
 	}
 }
 

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -70,38 +70,13 @@ func (r *PreferPackageCacheMountsRule) checkStageWithFacts(
 	consumedCacheEnvEntries := make(cacheEnvEntrySet)
 	var cacheEnvEntries []cacheEnvEntry
 	var violations []rules.Violation
+	runOrdinal := 0
 	for _, runFacts := range stageFacts.Runs {
-		if runFacts == nil || !runFacts.UsesShell || runFacts.SourceScript == "" {
-			continue
+		if runFacts != nil && runFacts.UsesShell {
+			runOrdinal++
 		}
-		if !runFacts.Shell.HasParser {
-			continue
-		}
-
-		required, cleaners := detectRequiredCacheMountsFromCommands(
-			runFacts.CommandInfos,
-			runFacts.Workdir,
-			runFacts.CachePathOverrides,
-		)
-		if len(required) == 0 {
-			continue
-		}
-
-		existing := runmount.GetMounts(runFacts.Run)
-		mergedMounts, mountChanged := mergeCacheMounts(existing, required)
-		if !mountChanged {
-			continue
-		}
-
-		updatedScript, scriptCleaned := removeCacheCleanup(
-			runFacts.Run,
-			runFacts.CommandScript,
-			runFacts.Shell.Variant,
-			cleaners,
-		)
-
-		runLoc := runFacts.Run.Location()
-		if len(runLoc) == 0 {
+		analysis := analyzeRunForCacheMounts(file, runFacts, sm)
+		if analysis == nil {
 			continue
 		}
 
@@ -110,27 +85,129 @@ func (r *PreferPackageCacheMountsRule) checkStageWithFacts(
 			cacheEnvEntriesFromFacts(runFacts.CacheDisablingEnv),
 			consumedCacheEnvEntries,
 		)
-		edits, remaining, envCleaned := buildCacheMountEdits(cacheMountEditParams{
+		result := buildCacheMountEdits(cacheMountEditParams{
 			file:            file,
 			run:             runFacts.Run,
-			runLoc:          runLoc,
+			runLoc:          analysis.runLoc,
 			sm:              sm,
 			shellVariant:    runFacts.Shell.Variant,
-			existing:        existing,
-			merged:          mergedMounts,
-			cleanedScript:   updatedScript,
-			scriptCleaned:   scriptCleaned,
-			cleaners:        cleaners,
+			existing:        analysis.existing,
+			merged:          analysis.merged,
+			cleanedScript:   analysis.cleanedScript,
+			scriptCleaned:   analysis.scriptCleaned,
+			cleaners:        analysis.cleaners,
 			cacheEnvEntries: cacheEnvEntries,
 		})
-		consumedCacheEnvEntries.markConsumed(cacheEnvEntries, remaining)
-		cacheEnvEntries = remaining
+		consumedCacheEnvEntries.markConsumed(cacheEnvEntries, result.RemainingEnvEntries)
+		cacheEnvEntries = result.RemainingEnvEntries
 
-		v := buildViolation(meta, file, runLoc, required, scriptCleaned, envCleaned, edits)
+		v := buildViolation(violationParams{
+			meta:          meta,
+			file:          file,
+			runLoc:        analysis.runLoc,
+			required:      analysis.required,
+			scriptCleaned: analysis.scriptCleaned,
+			envCleaned:    result.EnvCleaned,
+			edits:         result.Edits,
+			needsAsync:    result.NeedsAsync,
+			stageIdx:      stageFacts.Index,
+			runOrdinal:    runOrdinal,
+		})
 		violations = append(violations, v)
 	}
 
 	return violations
+}
+
+// runAnalysis holds the per-RUN inputs to buildCacheMountEdits.
+type runAnalysis struct {
+	runLoc        []parser.Range
+	existing      []*instructions.Mount
+	merged        []*instructions.Mount
+	required      []cacheMountSpec
+	cleaners      map[cleanupKind]bool
+	cleanedScript string
+	scriptCleaned bool
+}
+
+// analyzeRunForCacheMounts runs the detection and mount-merge step for a
+// single RUN. Returns nil when the RUN isn't eligible (non-shell, no cache
+// needed, or no mount change).
+func analyzeRunForCacheMounts(_ string, runFacts *facts.RunFacts, _ *sourcemap.SourceMap) *runAnalysis {
+	if runFacts == nil || !runFacts.UsesShell || runFacts.SourceScript == "" {
+		return nil
+	}
+	if !runFacts.Shell.HasParser {
+		return nil
+	}
+
+	required, cleaners := detectRequiredCacheMountsFromCommands(
+		runFacts.CommandInfos,
+		runFacts.Workdir,
+		runFacts.CachePathOverrides,
+	)
+	if len(required) == 0 {
+		return nil
+	}
+
+	existing := runmount.GetMounts(runFacts.Run)
+	merged, mountChanged := mergeCacheMounts(existing, required)
+	if !mountChanged {
+		return nil
+	}
+
+	cleanedScript, scriptCleaned := removeCacheCleanup(
+		runFacts.Run,
+		runFacts.CommandScript,
+		runFacts.Shell.Variant,
+		cleaners,
+	)
+
+	runLoc := runFacts.Run.Location()
+	if len(runLoc) == 0 {
+		return nil
+	}
+
+	return &runAnalysis{
+		runLoc:        runLoc,
+		existing:      existing,
+		merged:        merged,
+		required:      required,
+		cleaners:      cleaners,
+		cleanedScript: cleanedScript,
+		scriptCleaned: scriptCleaned,
+	}
+}
+
+// computeCacheMountEditsForRun produces the full set of cache-mount edits
+// for a single RUN using post-sync-fix content. Used by the async resolver
+// after sync narrow fixes have landed; forces the tail-rewrite branch to
+// emit real edits rather than re-deferring.
+func computeCacheMountEditsForRun(
+	file string,
+	runFacts *facts.RunFacts,
+	sm *sourcemap.SourceMap,
+) []rules.TextEdit {
+	analysis := analyzeRunForCacheMounts(file, runFacts, sm)
+	if analysis == nil {
+		return nil
+	}
+	entries := cacheEnvEntriesFromFacts(runFacts.CacheDisablingEnv)
+	result := buildCacheMountEdits(cacheMountEditParams{
+		file:                 file,
+		run:                  runFacts.Run,
+		runLoc:               analysis.runLoc,
+		sm:                   sm,
+		shellVariant:         runFacts.Shell.Variant,
+		existing:             analysis.existing,
+		merged:               analysis.merged,
+		cleanedScript:        analysis.cleanedScript,
+		scriptCleaned:        analysis.scriptCleaned,
+		cleaners:             analysis.cleaners,
+		cacheEnvEntries:      entries,
+		forceEmitTailRewrite: true,
+	})
+	return result.Edits
 }
 
 // buildCacheMountEdits produces targeted, non-overlapping edits:
@@ -150,11 +227,33 @@ type cacheMountEditParams struct {
 	scriptCleaned   bool
 	cleaners        map[cleanupKind]bool
 	cacheEnvEntries []cacheEnvEntry
+	// forceEmitTailRewrite is set by the async resolver so the tail
+	// rewrite branch emits real edits rather than returning needsAsync.
+	// In sync Check, this stays false and the rule defers to the resolver.
+	forceEmitTailRewrite bool
+}
+
+// cacheMountEditResult bundles the outputs of buildCacheMountEdits.
+type cacheMountEditResult struct {
+	// Edits are the sync edits to apply immediately. Nil when NeedsAsync
+	// is true.
+	Edits []rules.TextEdit
+	// RemainingEnvEntries are cache env entries not consumed by this
+	// run's cleanup; callers carry them forward to later runs in the
+	// same stage so the same binding isn't removed twice.
+	RemainingEnvEntries []cacheEnvEntry
+	// EnvCleaned reports whether env removal edits were produced.
+	EnvCleaned bool
+	// NeedsAsync is true when the fix needs a whole-RUN tail rewrite
+	// that would subsume narrow sync fixes on the same RUN. Callers
+	// should convert the fix to async so the tail rewrite runs on
+	// post-sync content. When true, Edits is nil.
+	NeedsAsync bool
 }
 
 // The insertion-based approach lets cache mount additions compose with other rules'
 // mount insertions at the same point (e.g., require-secret-mounts) without conflicting.
-func buildCacheMountEdits(p cacheMountEditParams) ([]rules.TextEdit, []cacheEnvEntry, bool) {
+func buildCacheMountEdits(p cacheMountEditParams) cacheMountEditResult {
 	envEdits, remaining := consumeEnvRemovalEdits(p.file, p.cleaners, p.cacheEnvEntries)
 
 	existing := p.existing
@@ -185,6 +284,19 @@ func buildCacheMountEdits(p cacheMountEditParams) ([]rules.TextEdit, []cacheEnvE
 	// all mounts: tail rewrites (non-heredoc) use formatRunFlags with merged,
 	// and heredoc mount-flag edits (buildMountFlagEdit) also use merged.
 	needsTailRewrite := !isHeredoc && (mutated || (p.scriptCleaned && len(cleanupEdits) == 0))
+
+	// Non-heredoc tail rewrites span the entire RUN script and would
+	// subsume narrow sync fixes on the same RUN (quoting, flag insertion
+	// by other rules). Defer the whole fix to the async resolver so those
+	// fixes land first and the tail rewrite sees updated content.
+	if needsTailRewrite && !p.forceEmitTailRewrite {
+		return cacheMountEditResult{
+			RemainingEnvEntries: remaining,
+			EnvCleaned:          len(envEdits) > 0,
+			NeedsAsync:          true,
+		}
+	}
+
 	skipMountInsert := needsTailRewrite || (isHeredoc && mutated)
 
 	// Edit 1: zero-length insertion for new mount flags right after "RUN ".
@@ -206,28 +318,21 @@ func buildCacheMountEdits(p cacheMountEditParams) ([]rules.TextEdit, []cacheEnvE
 		edits = append(edits, buildMountFlagEdit(p, merged)...)
 	}
 
-	// Edit 2+: cleanup and/or mount rewrite.
-	switch {
-	case isHeredoc:
-		// Heredoc: use line-based cleanup edits (mount handled above).
-		edits = append(edits, cleanupEdits...)
+	// Edit 2+: cleanup edits (heredoc or targeted non-heredoc).
+	edits = append(edits, cleanupEdits...)
 
-	case mutated:
-		// Mount flags modified: full tail rewrite with merged mounts + cleaned script.
-		edits = append(edits, buildTailRewrite(p, merged)...)
-
-	case len(cleanupEdits) > 0:
-		// Targeted cleanup deletions (non-heredoc): compose with other rules' edits.
-		edits = append(edits, cleanupEdits...)
-
-	case p.scriptCleaned:
-		// Fallback: targeted cleanup unavailable, tail rewrite
-		// with merged mounts (includes new) + cleaned script.
+	// Async resolver path: emit the whole-RUN tail rewrite now that narrow
+	// sync fixes have already been applied to the content the resolver sees.
+	if needsTailRewrite && p.forceEmitTailRewrite {
 		edits = append(edits, buildTailRewrite(p, merged)...)
 	}
 
 	edits = append(edits, envEdits...)
-	return edits, remaining, len(envEdits) > 0
+	return cacheMountEditResult{
+		Edits:               edits,
+		RemainingEnvEntries: remaining,
+		EnvCleaned:          len(envEdits) > 0,
+	}
 }
 
 // buildTailRewrite produces a single edit replacing everything after "RUN "
@@ -667,37 +772,59 @@ func mountsMutated(existing, merged []*instructions.Mount) bool {
 	return false
 }
 
-func buildViolation(
-	meta rules.RuleMetadata,
-	file string,
-	runLoc []parser.Range,
-	required []cacheMountSpec,
-	scriptCleaned, envCleaned bool,
-	edits []rules.TextEdit,
-) rules.Violation {
+type violationParams struct {
+	meta          rules.RuleMetadata
+	file          string
+	runLoc        []parser.Range
+	required      []cacheMountSpec
+	scriptCleaned bool
+	envCleaned    bool
+	edits         []rules.TextEdit
+	needsAsync    bool
+	stageIdx      int
+	runOrdinal    int
+}
+
+func buildViolation(p violationParams) rules.Violation {
 	fixDescription := "Add package cache mount(s)"
 	switch {
-	case scriptCleaned && envCleaned:
+	case p.scriptCleaned && p.envCleaned:
 		fixDescription = "Add package cache mount(s), remove cache cleanup commands, and remove cache-disabling ENV vars"
-	case scriptCleaned:
+	case p.scriptCleaned:
 		fixDescription = "Add package cache mount(s) and remove cache cleanup commands"
-	case envCleaned:
+	case p.envCleaned:
 		fixDescription = "Add package cache mount(s) and remove cache-disabling ENV vars"
 	}
 
-	mountDescriptions := describeMounts(required)
-	return rules.NewViolation(
-		rules.NewLocationFromRanges(file, runLoc),
-		meta.Code,
+	mountDescriptions := describeMounts(p.required)
+	v := rules.NewViolation(
+		rules.NewLocationFromRanges(p.file, p.runLoc),
+		p.meta.Code,
 		"use cache mounts for package manager cache directories",
-		meta.DefaultSeverity,
-	).WithDocURL(meta.DocURL).WithDetail(
+		p.meta.DefaultSeverity,
+	).WithDocURL(p.meta.DocURL).WithDetail(
 		"Detected package install/build command; add cache mount(s): " + strings.Join(mountDescriptions, ", "),
-	).WithSuggestedFix(&rules.SuggestedFix{
+	)
+
+	if p.needsAsync {
+		return v.WithSuggestedFix(&rules.SuggestedFix{
+			Description:  fixDescription,
+			Safety:       rules.FixSuggestion,
+			Priority:     p.meta.FixPriority,
+			NeedsResolve: true,
+			ResolverID:   rules.CacheMountsResolverID,
+			ResolverData: &rules.CacheMountsResolveData{
+				StageIndex: p.stageIdx,
+				RunOrdinal: p.runOrdinal,
+			},
+		})
+	}
+
+	return v.WithSuggestedFix(&rules.SuggestedFix{
 		Description: fixDescription,
 		Safety:      rules.FixSuggestion,
-		Priority:    meta.FixPriority,
-		Edits:       edits,
+		Priority:    p.meta.FixPriority,
+		Edits:       p.edits,
 	})
 }
 

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -75,7 +75,7 @@ func (r *PreferPackageCacheMountsRule) checkStageWithFacts(
 		if runFacts != nil && runFacts.UsesShell {
 			runOrdinal++
 		}
-		analysis := analyzeRunForCacheMounts(file, runFacts, sm)
+		analysis := analyzeRunForCacheMounts(runFacts)
 		if analysis == nil {
 			continue
 		}
@@ -85,6 +85,7 @@ func (r *PreferPackageCacheMountsRule) checkStageWithFacts(
 			cacheEnvEntriesFromFacts(runFacts.CacheDisablingEnv),
 			consumedCacheEnvEntries,
 		)
+		currentCacheEnvEntries := cacheEnvEntries
 		result := buildCacheMountEdits(cacheMountEditParams{
 			file:            file,
 			run:             runFacts.Run,
@@ -96,9 +97,9 @@ func (r *PreferPackageCacheMountsRule) checkStageWithFacts(
 			cleanedScript:   analysis.cleanedScript,
 			scriptCleaned:   analysis.scriptCleaned,
 			cleaners:        analysis.cleaners,
-			cacheEnvEntries: cacheEnvEntries,
+			cacheEnvEntries: currentCacheEnvEntries,
 		})
-		consumedCacheEnvEntries.markConsumed(cacheEnvEntries, result.RemainingEnvEntries)
+		consumedCacheEnvEntries.markConsumed(currentCacheEnvEntries, result.RemainingEnvEntries)
 		cacheEnvEntries = result.RemainingEnvEntries
 
 		v := buildViolation(violationParams{
@@ -112,6 +113,14 @@ func (r *PreferPackageCacheMountsRule) checkStageWithFacts(
 			needsAsync:    result.NeedsAsync,
 			stageIdx:      stageFacts.Index,
 			runOrdinal:    runOrdinal,
+			resolverData: buildCacheMountsResolveData(
+				stageFacts.Index,
+				runOrdinal,
+				runFacts,
+				analysis.required,
+				currentCacheEnvEntries,
+				result.ConsumedEnvEntries,
+			),
 		})
 		violations = append(violations, v)
 	}
@@ -133,7 +142,7 @@ type runAnalysis struct {
 // analyzeRunForCacheMounts runs the detection and mount-merge step for a
 // single RUN. Returns nil when the RUN isn't eligible (non-shell, no cache
 // needed, or no mount change).
-func analyzeRunForCacheMounts(_ string, runFacts *facts.RunFacts, _ *sourcemap.SourceMap) *runAnalysis {
+func analyzeRunForCacheMounts(runFacts *facts.RunFacts) *runAnalysis {
 	if runFacts == nil || !runFacts.UsesShell || runFacts.SourceScript == "" {
 		return nil
 	}
@@ -187,12 +196,12 @@ func computeCacheMountEditsForRun(
 	file string,
 	runFacts *facts.RunFacts,
 	sm *sourcemap.SourceMap,
+	cacheEnvEntries []cacheEnvEntry,
 ) []rules.TextEdit {
-	analysis := analyzeRunForCacheMounts(file, runFacts, sm)
+	analysis := analyzeRunForCacheMounts(runFacts)
 	if analysis == nil {
 		return nil
 	}
-	entries := cacheEnvEntriesFromFacts(runFacts.CacheDisablingEnv)
 	result := buildCacheMountEdits(cacheMountEditParams{
 		file:                 file,
 		run:                  runFacts.Run,
@@ -204,7 +213,7 @@ func computeCacheMountEditsForRun(
 		cleanedScript:        analysis.cleanedScript,
 		scriptCleaned:        analysis.scriptCleaned,
 		cleaners:             analysis.cleaners,
-		cacheEnvEntries:      entries,
+		cacheEnvEntries:      cacheEnvEntries,
 		forceEmitTailRewrite: true,
 	})
 	return result.Edits
@@ -238,6 +247,10 @@ type cacheMountEditResult struct {
 	// Edits are the sync edits to apply immediately. Nil when NeedsAsync
 	// is true.
 	Edits []rules.TextEdit
+	// ConsumedEnvEntries are the specific cache-disabling ENV bindings this
+	// run selected for removal. Async resolution carries only these bindings
+	// forward so shared ENV keys are removed at most once across multiple RUNs.
+	ConsumedEnvEntries []cacheEnvEntry
 	// RemainingEnvEntries are cache env entries not consumed by this
 	// run's cleanup; callers carry them forward to later runs in the
 	// same stage so the same binding isn't removed twice.
@@ -254,7 +267,7 @@ type cacheMountEditResult struct {
 // The insertion-based approach lets cache mount additions compose with other rules'
 // mount insertions at the same point (e.g., require-secret-mounts) without conflicting.
 func buildCacheMountEdits(p cacheMountEditParams) cacheMountEditResult {
-	envEdits, remaining := consumeEnvRemovalEdits(p.file, p.cleaners, p.cacheEnvEntries)
+	envEdits, matched, remaining := consumeEnvRemovalEdits(p.file, p.cleaners, p.cacheEnvEntries)
 
 	existing := p.existing
 	merged := p.merged
@@ -279,11 +292,12 @@ func buildCacheMountEdits(p cacheMountEditParams) cacheMountEditResult {
 			cleanupEdits = computeCleanupEdits(p.file, run, runLoc, p.sm, p.shellVariant, p.cleaners)
 		}
 	}
+	cleanupOverlapsMountInsert := cleanupEditsOverlapMountInsert(runLoc, p.sm, cleanupEdits)
 
 	// Skip the zero-width mount insertion when another edit already includes
 	// all mounts: tail rewrites (non-heredoc) use formatRunFlags with merged,
 	// and heredoc mount-flag edits (buildMountFlagEdit) also use merged.
-	needsTailRewrite := !isHeredoc && (mutated || (p.scriptCleaned && len(cleanupEdits) == 0))
+	needsTailRewrite := !isHeredoc && (mutated || (p.scriptCleaned && (len(cleanupEdits) == 0 || cleanupOverlapsMountInsert)))
 
 	// Non-heredoc tail rewrites span the entire RUN script and would
 	// subsume narrow sync fixes on the same RUN (quoting, flag insertion
@@ -291,6 +305,7 @@ func buildCacheMountEdits(p cacheMountEditParams) cacheMountEditResult {
 	// fixes land first and the tail rewrite sees updated content.
 	if needsTailRewrite && !p.forceEmitTailRewrite {
 		return cacheMountEditResult{
+			ConsumedEnvEntries:  matched,
 			RemainingEnvEntries: remaining,
 			EnvCleaned:          len(envEdits) > 0,
 			NeedsAsync:          true,
@@ -329,10 +344,42 @@ func buildCacheMountEdits(p cacheMountEditParams) cacheMountEditResult {
 
 	edits = append(edits, envEdits...)
 	return cacheMountEditResult{
+		ConsumedEnvEntries:  matched,
 		Edits:               edits,
 		RemainingEnvEntries: remaining,
 		EnvCleaned:          len(envEdits) > 0,
 	}
+}
+
+func cleanupEditsOverlapMountInsert(
+	runLoc []parser.Range,
+	sm *sourcemap.SourceMap,
+	edits []rules.TextEdit,
+) bool {
+	if len(runLoc) == 0 || sm == nil || len(edits) == 0 {
+		return false
+	}
+
+	line := runLoc[0].Start.Line
+	col := runKeywordEndColumn(runLoc, sm)
+	for _, edit := range edits {
+		if locationContainsPoint(edit.Location, line, col) {
+			return true
+		}
+	}
+	return false
+}
+
+func locationContainsPoint(loc rules.Location, line, col int) bool {
+	point := rules.Position{Line: line, Column: col}
+	return comparePosition(loc.Start, point) <= 0 && comparePosition(point, loc.End) < 0
+}
+
+func comparePosition(a, b rules.Position) int {
+	if a.Line != b.Line {
+		return a.Line - b.Line
+	}
+	return a.Column - b.Column
 }
 
 // buildTailRewrite produces a single edit replacing everything after "RUN "
@@ -783,6 +830,7 @@ type violationParams struct {
 	needsAsync    bool
 	stageIdx      int
 	runOrdinal    int
+	resolverData  *rules.CacheMountsResolveData
 }
 
 func buildViolation(p violationParams) rules.Violation {
@@ -813,10 +861,7 @@ func buildViolation(p violationParams) rules.Violation {
 			Priority:     p.meta.FixPriority,
 			NeedsResolve: true,
 			ResolverID:   rules.CacheMountsResolverID,
-			ResolverData: &rules.CacheMountsResolveData{
-				StageIndex: p.stageIdx,
-				RunOrdinal: p.runOrdinal,
-			},
+			ResolverData: p.resolverData,
 		})
 	}
 
@@ -826,6 +871,81 @@ func buildViolation(p violationParams) rules.Violation {
 		Priority:    p.meta.FixPriority,
 		Edits:       p.edits,
 	})
+}
+
+func buildCacheMountsResolveData(
+	stageIdx int,
+	runOrdinal int,
+	runFacts *facts.RunFacts,
+	required []cacheMountSpec,
+	cacheEnvEntries []cacheEnvEntry,
+	consumed []cacheEnvEntry,
+) *rules.CacheMountsResolveData {
+	if runFacts == nil {
+		return nil
+	}
+
+	return &rules.CacheMountsResolveData{
+		StageIndex:         stageIdx,
+		RunOrdinal:         runOrdinal,
+		RunSignature:       normalizeResolverRunSignature(runFacts.CommandScript),
+		CommandNames:       resolverCommandNames(runFacts.CommandInfos),
+		RequiredTargets:    requiredTargets(required),
+		CacheEnvSelections: cacheEnvSelections(cacheEnvEntries, consumed),
+	}
+}
+
+func normalizeResolverRunSignature(script string) string {
+	return strings.Join(strings.Fields(script), " ")
+}
+
+func resolverCommandNames(commands []shell.CommandInfo) []string {
+	if len(commands) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(commands))
+	for _, cmd := range commands {
+		names = append(names, strings.ToLower(cmd.Name))
+	}
+	return names
+}
+
+func requiredTargets(required []cacheMountSpec) []string {
+	if len(required) == 0 {
+		return nil
+	}
+
+	targets := make([]string, 0, len(required))
+	for _, mount := range required {
+		targets = append(targets, mount.Target)
+	}
+	return targets
+}
+
+func cacheEnvSelections(allEntries, selected []cacheEnvEntry) []rules.CacheMountsEnvSelection {
+	if len(selected) == 0 {
+		return nil
+	}
+
+	selections := make([]rules.CacheMountsEnvSelection, 0, len(selected))
+	for _, entry := range selected {
+		bindingIndex := -1
+		for i, candidate := range allEntries {
+			if candidate.env == entry.env && candidate.key == entry.key {
+				bindingIndex = i
+				break
+			}
+		}
+		if bindingIndex < 0 {
+			continue
+		}
+		selections = append(selections, rules.CacheMountsEnvSelection{
+			BindingIndex: bindingIndex,
+			Key:          entry.key,
+		})
+	}
+	return selections
 }
 
 type cacheMountSpec struct {
@@ -1201,8 +1321,13 @@ type cacheEnvEntry struct {
 	kind cleanupKind
 }
 
-// consumeEnvRemovalEdits builds TextEdits for matching entries and returns the remaining (unconsumed) entries.
-func consumeEnvRemovalEdits(file string, cleaners map[cleanupKind]bool, entries []cacheEnvEntry) ([]rules.TextEdit, []cacheEnvEntry) {
+// consumeEnvRemovalEdits builds TextEdits for matching entries and returns the
+// matched plus remaining (unconsumed) entries.
+func consumeEnvRemovalEdits(
+	file string,
+	cleaners map[cleanupKind]bool,
+	entries []cacheEnvEntry,
+) ([]rules.TextEdit, []cacheEnvEntry, []cacheEnvEntry) {
 	// Partition entries into matched vs remaining.
 	var matched []cacheEnvEntry
 	var remaining []cacheEnvEntry
@@ -1214,7 +1339,7 @@ func consumeEnvRemovalEdits(file string, cleaners map[cleanupKind]bool, entries 
 		}
 	}
 	if len(matched) == 0 {
-		return nil, entries
+		return nil, nil, entries
 	}
 
 	// Group matched entries by ENV instruction pointer.
@@ -1241,7 +1366,7 @@ func consumeEnvRemovalEdits(file string, cleaners map[cleanupKind]bool, entries 
 		}
 	}
 
-	return edits, remaining
+	return edits, matched, remaining
 }
 
 // buildEnvKeyRemovalEdit delegates to the shared rules.BuildEnvKeyRemovalEdit helper.

--- a/internal/rules/tally/prefer_package_cache_mounts.go
+++ b/internal/rules/tally/prefer_package_cache_mounts.go
@@ -416,10 +416,25 @@ func computeCleanupEdits(
 	sourceFull := strings.Join(lines, "\n")
 
 	script := dockerfile.RunScript(run)
-	commands := shell.ExtractChainedCommands(script, variant)
-	if len(commands) == 0 {
+	ranges := shell.ExtractChainCommandRanges(script, variant)
+	if len(ranges) == 0 {
 		return nil
 	}
+
+	// Derive raw command text directly from script[range], then normalize
+	// whitespace the same way normalizeSource does (collapse runs of spaces
+	// and tabs into a single space) so substring search in `normalized`
+	// matches byte-for-byte. Avoids the round-trip through the mvdan
+	// printer, which reformats some constructs (e.g., "$( curl" → "$(curl")
+	// and loses raw-source fidelity.
+	commands := make([]string, len(ranges))
+	for i, r := range ranges {
+		if int(r.EndOffset) > len(script) || r.StartOffset > r.EndOffset {
+			return nil
+		}
+		commands[i] = normalizeWhitespaceRuns(script[r.StartOffset:r.EndOffset])
+	}
+
 	separators := shell.ExtractChainSeparators(script, variant, len(commands))
 
 	// Normalize the source: collapse continuations and runs of whitespace
@@ -528,6 +543,29 @@ func buildCleanupEdit(ctx cleanupEditContext, i int, cmd string) *rules.TextEdit
 		ctx.file, ctx.sourceFull, ctx.startLine,
 		ctx.scriptIdx+ctx.spans[i].start, ctx.scriptIdx+ctx.spans[i].end, cleaned,
 	)
+}
+
+// normalizeWhitespaceRuns collapses runs of spaces and tabs within s into
+// single spaces, matching the whitespace treatment in normalizeSource. Used
+// to make command text extracted from a buildkit-joined RUN script (which
+// preserves original indentation after line continuations) comparable to
+// the whitespace-collapsed source view.
+func normalizeWhitespaceRuns(s string) string {
+	var buf strings.Builder
+	buf.Grow(len(s))
+	inSpace := false
+	for i := range len(s) {
+		if s[i] == ' ' || s[i] == '\t' {
+			if !inSpace {
+				buf.WriteByte(' ')
+				inSpace = true
+			}
+			continue
+		}
+		inSpace = false
+		buf.WriteByte(s[i])
+	}
+	return buf.String()
 }
 
 // normalizeSource collapses backslash-newline continuations and runs of

--- a/internal/rules/tally/prefer_package_cache_mounts_resolver.go
+++ b/internal/rules/tally/prefer_package_cache_mounts_resolver.go
@@ -1,0 +1,95 @@
+package tally
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/sourcemap"
+)
+
+// cacheMountsResolver re-runs prefer-package-cache-mounts analysis on the
+// post-sync-fix Dockerfile and emits the set of edits (mount insertion,
+// tail rewrite, env removals) that would have been produced synchronously.
+//
+// Running post-sync lets narrow fixes (shellcheck SC2086 quoting,
+// curl-should-follow-redirects flag insertion, ...) land first and be
+// preserved when this rule needs to rewrite the full RUN tail, rather
+// than having them conflict-evicted by the large replacement range.
+type cacheMountsResolver struct{}
+
+func (r *cacheMountsResolver) ID() string { return rules.CacheMountsResolverID }
+
+func (r *cacheMountsResolver) Resolve(
+	_ context.Context,
+	resolveCtx fix.ResolveContext,
+	f *rules.SuggestedFix,
+) ([]rules.TextEdit, error) {
+	data, ok := f.ResolverData.(*rules.CacheMountsResolveData)
+	if !ok || data == nil {
+		return nil, nil
+	}
+
+	parseResult, err := dockerfile.Parse(bytes.NewReader(resolveCtx.Content), nil)
+	if err != nil {
+		return nil, nil //nolint:nilerr // best-effort: skip silently on parse failure
+	}
+	if data.StageIndex < 0 || data.StageIndex >= len(parseResult.Stages) {
+		return nil, nil
+	}
+
+	sem := semantic.NewBuilder(parseResult, nil, resolveCtx.FilePath).Build()
+	fileFacts := facts.NewFileFacts(resolveCtx.FilePath, parseResult, sem, nil, nil)
+	stageFacts := fileFacts.Stage(data.StageIndex)
+	if stageFacts == nil {
+		return nil, nil
+	}
+
+	targetRunFacts := findRunFactsByOrdinal(parseResult.Stages[data.StageIndex], stageFacts, data.RunOrdinal)
+	if targetRunFacts == nil {
+		return nil, nil
+	}
+
+	sm := sourcemap.New(resolveCtx.Content)
+	return computeCacheMountEditsForRun(resolveCtx.FilePath, targetRunFacts, sm), nil
+}
+
+// findRunFactsByOrdinal returns the RunFacts for the 1-based shell-form RUN
+// ordinal within stage, or nil when no match is found.
+func findRunFactsByOrdinal(
+	stage instructions.Stage,
+	stageFacts *facts.StageFacts,
+	ordinal int,
+) *facts.RunFacts {
+	if ordinal <= 0 {
+		return nil
+	}
+	seen := 0
+	for _, cmd := range stage.Commands {
+		run, ok := cmd.(*instructions.RunCommand)
+		if !ok || !run.PrependShell {
+			continue
+		}
+		seen++
+		if seen != ordinal {
+			continue
+		}
+		for _, rf := range stageFacts.Runs {
+			if rf != nil && rf.Run == run {
+				return rf
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+func init() {
+	fix.RegisterResolver(&cacheMountsResolver{})
+}

--- a/internal/rules/tally/prefer_package_cache_mounts_resolver.go
+++ b/internal/rules/tally/prefer_package_cache_mounts_resolver.go
@@ -3,6 +3,8 @@ package tally
 import (
 	"bytes"
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
@@ -51,43 +53,190 @@ func (r *cacheMountsResolver) Resolve(
 		return nil, nil
 	}
 
-	targetRunFacts := findRunFactsByOrdinal(parseResult.Stages[data.StageIndex], stageFacts, data.RunOrdinal)
+	targetRunFacts := findRunFactsForResolveData(parseResult.Stages[data.StageIndex], stageFacts, data)
 	if targetRunFacts == nil {
 		return nil, nil
 	}
 
+	selectedEnvEntries := selectResolvedCacheEnvEntries(
+		cacheEnvEntriesFromFacts(targetRunFacts.CacheDisablingEnv),
+		data.CacheEnvSelections,
+	)
 	sm := sourcemap.New(resolveCtx.Content)
-	return computeCacheMountEditsForRun(resolveCtx.FilePath, targetRunFacts, sm), nil
+	return computeCacheMountEditsForRun(resolveCtx.FilePath, targetRunFacts, sm, selectedEnvEntries), nil
 }
 
-// findRunFactsByOrdinal returns the RunFacts for the 1-based shell-form RUN
-// ordinal within stage, or nil when no match is found.
-func findRunFactsByOrdinal(
+type resolvedRunCandidate struct {
+	runFacts *facts.RunFacts
+	ordinal  int
+}
+
+func findRunFactsForResolveData(
 	stage instructions.Stage,
 	stageFacts *facts.StageFacts,
-	ordinal int,
+	data *rules.CacheMountsResolveData,
 ) *facts.RunFacts {
-	if ordinal <= 0 {
+	if data == nil {
 		return nil
 	}
-	seen := 0
+
+	candidates := collectResolvedRunCandidates(stage, stageFacts)
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	var (
+		best      *facts.RunFacts
+		bestScore = -1
+	)
+	for _, candidate := range candidates {
+		analysis := analyzeRunForCacheMounts(candidate.runFacts)
+		if analysis == nil {
+			continue
+		}
+		if len(data.RequiredTargets) > 0 && !slices.Equal(requiredTargets(analysis.required), data.RequiredTargets) {
+			continue
+		}
+		if len(data.CommandNames) > 0 && !slices.Equal(resolverCommandNames(candidate.runFacts.CommandInfos), data.CommandNames) {
+			continue
+		}
+		score := resolvedRunMatchScore(candidate.runFacts, candidate.ordinal, data)
+		if score < bestScore {
+			continue
+		}
+		best = candidate.runFacts
+		bestScore = score
+	}
+
+	if best != nil {
+		return best
+	}
+
+	if data.RunOrdinal <= 0 || data.RunOrdinal > len(candidates) {
+		return nil
+	}
+	analysis := analyzeRunForCacheMounts(candidates[data.RunOrdinal-1].runFacts)
+	if analysis == nil {
+		return nil
+	}
+	if len(data.RequiredTargets) > 0 && !slices.Equal(requiredTargets(analysis.required), data.RequiredTargets) {
+		return nil
+	}
+	return candidates[data.RunOrdinal-1].runFacts
+}
+
+func collectResolvedRunCandidates(
+	stage instructions.Stage,
+	stageFacts *facts.StageFacts,
+) []resolvedRunCandidate {
+	if stageFacts == nil {
+		return nil
+	}
+
+	runFactsByRun := make(map[*instructions.RunCommand]*facts.RunFacts, len(stageFacts.Runs))
+	for _, runFacts := range stageFacts.Runs {
+		if runFacts == nil || runFacts.Run == nil {
+			continue
+		}
+		runFactsByRun[runFacts.Run] = runFacts
+	}
+
+	candidates := make([]resolvedRunCandidate, 0, len(stageFacts.Runs))
+	runOrdinal := 0
 	for _, cmd := range stage.Commands {
 		run, ok := cmd.(*instructions.RunCommand)
 		if !ok || !run.PrependShell {
 			continue
 		}
-		seen++
-		if seen != ordinal {
+		runOrdinal++
+		runFacts := runFactsByRun[run]
+		if runFacts == nil {
 			continue
 		}
-		for _, rf := range stageFacts.Runs {
-			if rf != nil && rf.Run == run {
-				return rf
-			}
+		candidates = append(candidates, resolvedRunCandidate{
+			runFacts: runFacts,
+			ordinal:  runOrdinal,
+		})
+	}
+	return candidates
+}
+
+func resolvedRunMatchScore(
+	runFacts *facts.RunFacts,
+	runOrdinal int,
+	data *rules.CacheMountsResolveData,
+) int {
+	if runFacts == nil {
+		return -1
+	}
+
+	score := 0
+	signature := normalizeResolverRunSignature(runFacts.CommandScript)
+	switch {
+	case signature != "" && signature == data.RunSignature:
+		score += 100
+	case signature != "" && data.RunSignature != "" &&
+		(strings.Contains(signature, data.RunSignature) || strings.Contains(data.RunSignature, signature)):
+		score += 50
+	default:
+		score += sharedResolverSignatureTokens(signature, data.RunSignature)
+	}
+
+	if data.RunOrdinal > 0 {
+		score -= abs(runOrdinal - data.RunOrdinal)
+	}
+	return score
+}
+
+func sharedResolverSignatureTokens(a, b string) int {
+	if a == "" || b == "" {
+		return 0
+	}
+
+	tokens := make(map[string]bool)
+	for token := range strings.FieldsSeq(a) {
+		tokens[token] = true
+	}
+
+	shared := 0
+	seen := make(map[string]bool)
+	for token := range strings.FieldsSeq(b) {
+		if seen[token] || !tokens[token] {
+			continue
 		}
+		seen[token] = true
+		shared++
+	}
+	return shared
+}
+
+func selectResolvedCacheEnvEntries(
+	entries []cacheEnvEntry,
+	selections []rules.CacheMountsEnvSelection,
+) []cacheEnvEntry {
+	if len(selections) == 0 {
 		return nil
 	}
-	return nil
+
+	selected := make([]cacheEnvEntry, 0, len(selections))
+	for _, selection := range selections {
+		if selection.BindingIndex < 0 || selection.BindingIndex >= len(entries) {
+			continue
+		}
+		entry := entries[selection.BindingIndex]
+		if entry.key != selection.Key {
+			continue
+		}
+		selected = append(selected, entry)
+	}
+	return selected
+}
+
+func abs(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
 }
 
 func init() {

--- a/internal/rules/tally/prefer_package_cache_mounts_test.go
+++ b/internal/rules/tally/prefer_package_cache_mounts_test.go
@@ -317,6 +317,12 @@ func resolveIfAsync(t *testing.T, fix *rules.SuggestedFix, content string) []rul
 	return resolved
 }
 
+func applyResolvedFix(t *testing.T, fix *rules.SuggestedFix, content string) string {
+	t.Helper()
+	edits := resolveIfAsync(t, fix, content)
+	return string(fixpkg.ApplyEdits([]byte(content), edits))
+}
+
 func TestPreferPackageCacheMountsRule_CheckWithFixes(t *testing.T) {
 	t.Parallel()
 	r := NewPreferPackageCacheMountsRule()
@@ -699,27 +705,21 @@ RUN npm install
 			}
 
 			edits := resolveIfAsync(t, fix, tt.content)
+			fixedContent := applyResolvedFix(t, fix, tt.content)
 
 			// Only check edit count if explicitly set (non-zero)
 			if tt.wantEditCount != 0 && len(edits) != tt.wantEditCount {
 				t.Fatalf("fix edits = %d, want %d", len(edits), tt.wantEditCount)
 			}
 
-			// Concatenate all edit texts for contains/notContains checks.
-			var allNewText strings.Builder
-			for _, edit := range edits {
-				allNewText.WriteString(edit.NewText)
-				allNewText.WriteString("\n")
-			}
-			combined := allNewText.String()
 			for _, want := range tt.wantFixContains {
-				if !strings.Contains(combined, want) {
-					t.Fatalf("fix missing %q in:\n%s", want, combined)
+				if !strings.Contains(fixedContent, want) {
+					t.Fatalf("fixed content missing %q in:\n%s", want, fixedContent)
 				}
 			}
 			for _, notWant := range tt.wantNotContains {
-				if strings.Contains(combined, notWant) {
-					t.Fatalf("fix unexpectedly contains %q in:\n%s", notWant, combined)
+				if strings.Contains(fixedContent, notWant) {
+					t.Fatalf("fixed content unexpectedly contains %q in:\n%s", notWant, fixedContent)
 				}
 			}
 		})
@@ -894,6 +894,64 @@ RUN pip install -r requirements.txt
 
 	if envRemovalEdits != 2 {
 		t.Fatalf("expected 2 ENV removal edits, got %d", envRemovalEdits)
+	}
+}
+
+func TestPreferPackageCacheMountsResolver_ReidentifiesRunAfterEarlierRunRemoved(t *testing.T) {
+	t.Parallel()
+
+	original := `FROM python:3.13
+RUN pip install --no-cache-dir left-pad
+RUN pip install --no-cache-dir lodash
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", original)
+	violations := NewPreferPackageCacheMountsRule().Check(input)
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(violations))
+	}
+
+	fix := violations[1].SuggestedFix
+	if fix == nil || !fix.NeedsResolve {
+		t.Fatal("expected async suggested fix for second RUN")
+	}
+
+	modified := `FROM python:3.13
+RUN pip install --no-cache-dir lodash
+`
+	got := applyResolvedFix(t, fix, modified)
+	want := `FROM python:3.13
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip pip install lodash
+`
+	if got != want {
+		t.Fatalf("fixed content =\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestPreferPackageCacheMountsResolver_OnlyRemovesSelectedEnvBindings(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM python:3.13
+ENV PIP_NO_CACHE_DIR=1
+RUN pip install --no-cache-dir left-pad
+RUN pip install --no-cache-dir lodash
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewPreferPackageCacheMountsRule().Check(input)
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(violations))
+	}
+
+	secondFix := violations[1].SuggestedFix
+	if secondFix == nil || !secondFix.NeedsResolve {
+		t.Fatal("expected async suggested fix for second RUN")
+	}
+
+	got := applyResolvedFix(t, secondFix, content)
+	if !strings.Contains(got, "ENV PIP_NO_CACHE_DIR=1") {
+		t.Fatalf("second async fix unexpectedly removed shared ENV binding:\n%s", got)
+	}
+	if !strings.Contains(got, "--mount=type=cache,target=/root/.cache/pip,id=pip") {
+		t.Fatalf("second async fix did not rewrite the target RUN:\n%s", got)
 	}
 }
 

--- a/internal/rules/tally/prefer_package_cache_mounts_test.go
+++ b/internal/rules/tally/prefer_package_cache_mounts_test.go
@@ -295,6 +295,28 @@ RUN bun install
 	})
 }
 
+// resolveIfAsync materializes edits for assertions: returns fix.Edits for
+// sync fixes, and invokes the registered resolver against the original
+// content for async (NeedsResolve) fixes.
+func resolveIfAsync(t *testing.T, fix *rules.SuggestedFix, content string) []rules.TextEdit {
+	t.Helper()
+	if !fix.NeedsResolve {
+		return fix.Edits
+	}
+	resolver := fixpkg.GetResolver(fix.ResolverID)
+	if resolver == nil {
+		t.Fatalf("resolver %q not registered", fix.ResolverID)
+	}
+	resolved, err := resolver.Resolve(context.Background(), fixpkg.ResolveContext{
+		FilePath: "Dockerfile",
+		Content:  []byte(content),
+	}, fix)
+	if err != nil {
+		t.Fatalf("resolver error: %v", err)
+	}
+	return resolved
+}
+
 func TestPreferPackageCacheMountsRule_CheckWithFixes(t *testing.T) {
 	t.Parallel()
 	r := NewPreferPackageCacheMountsRule()
@@ -676,14 +698,16 @@ RUN npm install
 				t.Fatalf("fix priority = %d, want 90", fix.Priority)
 			}
 
+			edits := resolveIfAsync(t, fix, tt.content)
+
 			// Only check edit count if explicitly set (non-zero)
-			if tt.wantEditCount != 0 && len(fix.Edits) != tt.wantEditCount {
-				t.Fatalf("fix edits = %d, want %d", len(fix.Edits), tt.wantEditCount)
+			if tt.wantEditCount != 0 && len(edits) != tt.wantEditCount {
+				t.Fatalf("fix edits = %d, want %d", len(edits), tt.wantEditCount)
 			}
 
 			// Concatenate all edit texts for contains/notContains checks.
 			var allNewText strings.Builder
-			for _, edit := range fix.Edits {
+			for _, edit := range edits {
 				allNewText.WriteString(edit.NewText)
 				allNewText.WriteString("\n")
 			}

--- a/internal/shell/count.go
+++ b/internal/shell/count.go
@@ -197,8 +197,23 @@ func collectCommandRanges(stmt *syntax.Stmt, ranges *[]CommandRange) {
 	}
 	*ranges = append(*ranges, CommandRange{
 		StartOffset: stmt.Pos().Offset(),
-		EndOffset:   stmt.Cmd.End().Offset(),
+		EndOffset:   commandLeafEndOffset(stmt),
 	})
+}
+
+// commandLeafEndOffset returns the end offset of stmt's command content,
+// extended to cover statement-level redirections (Stmt.Redirs) but NOT the
+// trailing ';'/'&' terminator. Stmt.End() conflates the two — it returns
+// Semicolon+1 when the statement has a terminator — which would shift the
+// chain-separator extraction one byte, so we compute the end manually.
+func commandLeafEndOffset(stmt *syntax.Stmt) uint {
+	end := stmt.Cmd.End().Offset()
+	for _, redir := range stmt.Redirs {
+		if re := redir.End().Offset(); re > end {
+			end = re
+		}
+	}
+	return end
 }
 
 // extractFromStatement extracts commands from a statement, flattening && chains.

--- a/internal/shell/count.go
+++ b/internal/shell/count.go
@@ -118,11 +118,24 @@ func ExtractChainedCommands(script string, variant Variant) []string {
 	return commands
 }
 
-// ExtractChainSeparators returns the raw separator text between commands in an
-// && chain (for example " && " or " && \\\n    "). The result length is
-// commandCount-1 on success; otherwise nil.
-func ExtractChainSeparators(script string, variant Variant, commandCount int) []string {
-	if !variant.SupportsPOSIXShellAST() || commandCount <= 1 {
+// CommandRange is the byte range of a single chained leaf command within a
+// shell script. StartOffset is the command's start byte (inclusive); EndOffset
+// is the command's end byte (exclusive). Offsets reference the script passed
+// to [ExtractChainCommandRanges].
+type CommandRange struct {
+	StartOffset uint
+	EndOffset   uint
+}
+
+// ExtractChainCommandRanges returns the byte-offset range of each chained
+// leaf command in the script. && chains are flattened so that each leaf
+// contributes one range; top-level statements separated by `;` or newline
+// each produce their own range. Compound commands (if, for, while, etc.)
+// and || chains are treated as a single leaf.
+//
+// Returns nil for non-POSIX shells or when the parser fails.
+func ExtractChainCommandRanges(script string, variant Variant) []CommandRange {
+	if !variant.SupportsPOSIXShellAST() {
 		return nil
 	}
 
@@ -136,45 +149,56 @@ func ExtractChainSeparators(script string, variant Variant, commandCount int) []
 		return nil
 	}
 
-	boundaries := make([][2]uint, 0, commandCount-1)
+	var ranges []CommandRange
 	for _, stmt := range prog.Stmts {
-		collectAndBoundaries(stmt, &boundaries)
+		collectCommandRanges(stmt, &ranges)
 	}
-	if len(boundaries) != commandCount-1 {
+	return ranges
+}
+
+// ExtractChainSeparators returns the raw separator text between commands in a
+// chained script. Handles both && chains within a statement (" && ",
+// " && \\\n    ") and top-level `;`/newline separators between statements
+// ("; ", "; \\\n    "). The result length is commandCount-1 on success;
+// otherwise nil.
+func ExtractChainSeparators(script string, variant Variant, commandCount int) []string {
+	if commandCount <= 1 {
 		return nil
 	}
 
-	separators := make([]string, 0, len(boundaries))
-	for _, boundary := range boundaries {
-		start, end := boundary[0], boundary[1]
+	ranges := ExtractChainCommandRanges(script, variant)
+	if len(ranges) != commandCount {
+		return nil
+	}
+
+	separators := make([]string, 0, commandCount-1)
+	for i := range commandCount - 1 {
+		start, end := ranges[i].EndOffset, ranges[i+1].StartOffset
 		if start > uint(len(script)) || end > uint(len(script)) || end < start {
 			return nil
 		}
 		separators = append(separators, script[start:end])
 	}
-
 	return separators
 }
 
-func collectAndBoundaries(stmt *syntax.Stmt, boundaries *[][2]uint) {
+// collectCommandRanges walks a statement and appends the Pos/End byte
+// offsets of each chained-leaf command. && chains are flattened so that
+// each leaf command contributes one CommandRange; compound or || chains
+// are treated as a single leaf.
+func collectCommandRanges(stmt *syntax.Stmt, ranges *[]CommandRange) {
 	if stmt == nil || stmt.Cmd == nil {
 		return
 	}
-
-	binaryCmd, ok := stmt.Cmd.(*syntax.BinaryCmd)
-	if !ok || binaryCmd.Op != syntax.AndStmt {
+	if binaryCmd, ok := stmt.Cmd.(*syntax.BinaryCmd); ok && binaryCmd.Op == syntax.AndStmt {
+		collectCommandRanges(binaryCmd.X, ranges)
+		collectCommandRanges(binaryCmd.Y, ranges)
 		return
 	}
-
-	collectAndBoundaries(binaryCmd.X, boundaries)
-
-	start := binaryCmd.X.End().Offset()
-	end := binaryCmd.Y.Pos().Offset()
-	if end >= start {
-		*boundaries = append(*boundaries, [2]uint{start, end})
-	}
-
-	collectAndBoundaries(binaryCmd.Y, boundaries)
+	*ranges = append(*ranges, CommandRange{
+		StartOffset: stmt.Pos().Offset(),
+		EndOffset:   stmt.Cmd.End().Offset(),
+	})
 }
 
 // extractFromStatement extracts commands from a statement, flattening && chains.

--- a/internal/shell/count_test.go
+++ b/internal/shell/count_test.go
@@ -342,6 +342,24 @@ func TestExtractChainSeparators(t *testing.T) {
 			commandCount: 3,
 			want:         []string{"\n", "\n"},
 		},
+		{
+			// Regression: statement-level redirections must be counted as
+			// part of the command's range so the separator after them is
+			// recognized correctly. `Stmt.Cmd.End()` alone would stop at
+			// "clean" and report the separator as ">/dev/null; ".
+			name:         "redirected command before semicolon",
+			script:       "apt-get clean >/dev/null; rm -rf /var/lib/apt/lists/*",
+			variant:      VariantBash,
+			commandCount: 2,
+			want:         []string{"; "},
+		},
+		{
+			name:         "redirected command before &&",
+			script:       "apt-get clean >/dev/null && rm -rf /var/lib/apt/lists/*",
+			variant:      VariantBash,
+			commandCount: 2,
+			want:         []string{" && "},
+		},
 	}
 
 	for _, tt := range tests {
@@ -354,6 +372,64 @@ func TestExtractChainSeparators(t *testing.T) {
 			for i := range got {
 				if got[i] != tt.want[i] {
 					t.Fatalf("separator %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractChainCommandRanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		script  string
+		variant Variant
+		want    []string // raw text slice of script[range] per command
+	}{
+		{
+			name:    "simple && chain",
+			script:  "apt-get update && apt-get clean",
+			variant: VariantBash,
+			want:    []string{"apt-get update", "apt-get clean"},
+		},
+		{
+			name:    "semicolon chain",
+			script:  "apt-get update; apt-get clean",
+			variant: VariantBash,
+			want:    []string{"apt-get update", "apt-get clean"},
+		},
+		{
+			name:    "redirected command includes redirection",
+			script:  "apt-get clean >/dev/null; rm -rf /var/lib/apt/lists/*",
+			variant: VariantBash,
+			want:    []string{"apt-get clean >/dev/null", "rm -rf /var/lib/apt/lists/*"},
+		},
+		{
+			name:    "multiple redirections",
+			script:  "apt-get clean >/dev/null 2>&1; rm -rf /tmp/foo",
+			variant: VariantBash,
+			want:    []string{"apt-get clean >/dev/null 2>&1", "rm -rf /tmp/foo"},
+		},
+		{
+			name:    "non-posix returns nil",
+			script:  "apt-get update",
+			variant: VariantPowerShell,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ExtractChainCommandRanges(tt.script, tt.variant)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ExtractChainCommandRanges() returned %d ranges, want %d", len(got), len(tt.want))
+			}
+			for i, r := range got {
+				sliced := tt.script[r.StartOffset:r.EndOffset]
+				if sliced != tt.want[i] {
+					t.Errorf("range %d = %q, want %q", i, sliced, tt.want[i])
 				}
 			}
 		})

--- a/internal/shell/count_test.go
+++ b/internal/shell/count_test.go
@@ -310,6 +310,38 @@ func TestExtractChainSeparators(t *testing.T) {
 			commandCount: 2,
 			want:         nil,
 		},
+		{
+			name:         "semicolon separators",
+			script:       "apt-get update; apt-get install -y curl; apt-get clean",
+			variant:      VariantBash,
+			commandCount: 3,
+			want:         []string{"; ", "; "},
+		},
+		{
+			name: "semicolon with continuation separators",
+			script: "apt-get update; \\\n" +
+				"    apt-get install -y curl; \\\n" +
+				"    apt-get clean",
+			variant:      VariantBash,
+			commandCount: 3,
+			want:         []string{"; \\\n    ", "; \\\n    "},
+		},
+		{
+			name: "mixed semicolon and && separators",
+			script: "set -ex; \\\n" +
+				"    apt-get update && apt-get install -y curl; \\\n" +
+				"    apt-get clean",
+			variant:      VariantBash,
+			commandCount: 4,
+			want:         []string{"; \\\n    ", " && ", "; \\\n    "},
+		},
+		{
+			name:         "newline separators at top level",
+			script:       "apt-get update\napt-get install -y curl\napt-get clean",
+			variant:      VariantBash,
+			commandCount: 3,
+			want:         []string{"\n", "\n"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Refactors `tally/php/no-xdebug-in-final-image`, `tally/php/composer-no-dev-in-production`, and `tally/php/helpers.go` to consume `facts.RunFacts.InstallCommands` + `shell.StripPackageVersion` for apt/apt-get/apk/dnf/microdnf/yum/zypper detection (closes #543).
- Follow `COPY --from=<builder>` edges in `tally/php/enable-opcache-in-production` so multi-stage builder patterns don't get a spurious `RUN docker-php-ext-install opcache` inserted in the runtime stage.
- Teach `tally/prefer-package-cache-mounts` to produce narrow targeted cleanup edits for `;`-separated RUN chains (previously it fell back to a whole-RUN tail rewrite and subsumed sibling sync fixes).
- Defer the remaining whole-RUN tail-rewrite cases to a post-sync `FixResolver` (same pattern as `prefer-run-heredoc` / `hadolint-dl4001-cleanup`) so narrow sync fixes on the same RUN (shellcheck SC2086, `curl-should-follow-redirects`, ...) are no longer conflict-evicted.

Real-world PHP 5.6-fpm fixture added as an end-to-end guard: `Fixed 11 issues, 0 skipped` (was `Fixed 9, Skipped 2` before this PR).

## Test plan

- [x] `go test ./internal/...` — all green
- [x] `make lint` — 0 issues
- [x] `make deadcode` — 0 issues
- [x] `make cpd` — 0 issues
- [x] Real-world fixture snapshot (`TestFixRealWorldPHPFPM56`) matches expected output with the inserted `RUN docker-php-ext-install opcache` removed (COPY --from inheritance recognized), narrow fixes preserved (curl `--location`, `\"\$NR_VERSION\"` quoting).
- [x] `TestLint/prefer-package-cache-mounts` snapshot updated for the mutated-mount RUN switching to async `needsResolve` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async resolver for deferred fix computation and application.
  * Expanded multi-stage analysis to infer PHP tooling (OPcache/Xdebug) across copied build artifacts.

* **Bug Fixes**
  * More accurate Xdebug detection for extension installs and OS package installs.
  * Improved cache-mount suggestion logic and command-range/separator handling.

* **Tests**
  * Broadened unit and integration snapshots covering real-world PHP images and resolver behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->