### PR TITLE
[codex] Format shell heredocs

### DIFF
--- a/_docs/integrations/editorconfig.mdx
+++ b/_docs/integrations/editorconfig.mdx
@@ -25,11 +25,14 @@ The pattern matches `Dockerfile`, `Dockerfile.*`, `Containerfile`, and `Containe
 ## Rules that use EditorConfig
 
 - [`tally/prefer-formatted-heredocs`](/rules/tally/prefer-formatted-heredocs) formats `COPY` and `ADD` heredoc bodies for JSON, YAML, TOML, XML, and
-  INI files, plus `RUN` heredoc bodies that are executed as shell scripts.
+  INI files, plus shell heredocs from executable `RUN` heredocs and `COPY` heredocs with a shell shebang or `.sh` destination.
 
 For structured heredoc payloads, tally resolves EditorConfig settings using a virtual filename next to the Dockerfile and the heredoc destination
 basename. For example, a heredoc in `services/api/Dockerfile` targeting `/etc/app/config.yaml` is resolved as `services/api/config.yaml`, so
 `*.yaml` and `config.yaml` sections apply.
+
+`COPY` shell heredocs use that same destination-basename lookup. For example, a heredoc targeting `/usr/local/bin/entrypoint.sh` is resolved as
+`entrypoint.sh`, so `*.sh` and `entrypoint.sh` sections apply.
 
 For `RUN` shell heredocs, tally uses a virtual filename next to the Dockerfile named `Dockerfile.heredoc.<dialect>`, such as
 `Dockerfile.heredoc.sh`, `Dockerfile.heredoc.bash`, or `Dockerfile.heredoc.zsh`.
@@ -43,14 +46,14 @@ The heredoc formatter currently reads these EditorConfig properties:
 | `indent_style` | Uses tabs when set to `tab`; otherwise uses spaces. |
 | `indent_size` | Sets the number of spaces per indent level when it is a positive integer. |
 | `tab_width` | Used as the fallback indent width when `indent_size` is not a positive integer. |
-| `max_line_length` | YAML and RUN shell heredocs. For YAML, a positive integer is used as the preferred scalar wrapping width. For shell heredocs, a positive integer is used as the preferred command wrapping width; unset and invalid values use `100`, and `off` disables the shell line-width pass. This is a formatting preference, not a hard maximum. |
-| `binary_next_line` | RUN shell heredocs only. Mirrors `shfmt --binary-next-line`. |
-| `switch_case_indent` | RUN shell heredocs only. Mirrors `shfmt --case-indent`. |
-| `space_redirects` | RUN shell heredocs only. Mirrors `shfmt --space-redirects`. |
-| `keep_padding` | RUN shell heredocs only. Mirrors `shfmt --keep-padding`. |
-| `function_next_line` | RUN shell heredocs only. Mirrors `shfmt --func-next-line`. |
-| `simplify` | RUN shell heredocs only. Mirrors `shfmt --simplify`. |
-| `minify` | RUN shell heredocs only. Mirrors `shfmt --minify` and implies `simplify`. |
+| `max_line_length` | YAML and shell heredocs. For YAML, a positive integer is used as the preferred scalar wrapping width. For shell heredocs, a positive integer is used as the preferred command wrapping width; unset and invalid values use `100`, and `off` disables the shell line-width pass. This is a formatting preference, not a hard maximum. |
+| `binary_next_line` | Shell heredocs only. Mirrors `shfmt --binary-next-line`. |
+| `switch_case_indent` | Shell heredocs only. Mirrors `shfmt --case-indent`. |
+| `space_redirects` | Shell heredocs only. Mirrors `shfmt --space-redirects`. |
+| `keep_padding` | Shell heredocs only. Mirrors `shfmt --keep-padding`. |
+| `function_next_line` | Shell heredocs only. Mirrors `shfmt --func-next-line`. |
+| `simplify` | Shell heredocs only. Mirrors `shfmt --simplify`. |
+| `minify` | Shell heredocs only. Mirrors `shfmt --minify` and implies `simplify`. |
 
 Other EditorConfig properties are intentionally not interpreted by the heredoc formatter today:
 

--- a/_docs/integrations/editorconfig.mdx
+++ b/_docs/integrations/editorconfig.mdx
@@ -25,11 +25,14 @@ The pattern matches `Dockerfile`, `Dockerfile.*`, `Containerfile`, and `Containe
 ## Rules that use EditorConfig
 
 - [`tally/prefer-formatted-heredocs`](/rules/tally/prefer-formatted-heredocs) formats `COPY` and `ADD` heredoc bodies for JSON, YAML, TOML, XML, and
-  INI files.
+  INI files, plus `RUN` heredoc bodies that are executed as shell scripts.
 
-For heredoc payloads, tally resolves EditorConfig settings using a virtual filename next to the Dockerfile and the heredoc destination basename. For
-example, a heredoc in `services/api/Dockerfile` targeting `/etc/app/config.yaml` is resolved as `services/api/config.yaml`, so `*.yaml` and
-`config.yaml` sections apply.
+For structured heredoc payloads, tally resolves EditorConfig settings using a virtual filename next to the Dockerfile and the heredoc destination
+basename. For example, a heredoc in `services/api/Dockerfile` targeting `/etc/app/config.yaml` is resolved as `services/api/config.yaml`, so
+`*.yaml` and `config.yaml` sections apply.
+
+For `RUN` shell heredocs, tally uses a virtual filename next to the Dockerfile named `Dockerfile.heredoc.<dialect>`, such as
+`Dockerfile.heredoc.sh`, `Dockerfile.heredoc.bash`, or `Dockerfile.heredoc.zsh`.
 
 ## Supported Properties
 
@@ -40,7 +43,14 @@ The heredoc formatter currently reads these EditorConfig properties:
 | `indent_style` | Uses tabs when set to `tab`; otherwise uses spaces. |
 | `indent_size` | Sets the number of spaces per indent level when it is a positive integer. |
 | `tab_width` | Used as the fallback indent width when `indent_size` is not a positive integer. |
-| `max_line_length` | YAML heredocs only. When set to a positive integer, uses that value as the preferred YAML scalar wrapping width. `off`, unset, and invalid values do not override the YAML serializer default. This is a formatting preference, not a hard maximum. |
+| `max_line_length` | YAML and RUN shell heredocs. For YAML, a positive integer is used as the preferred scalar wrapping width. For shell heredocs, a positive integer is used as the preferred command wrapping width; unset and invalid values use `100`, and `off` disables the shell line-width pass. This is a formatting preference, not a hard maximum. |
+| `binary_next_line` | RUN shell heredocs only. Mirrors `shfmt --binary-next-line`. |
+| `switch_case_indent` | RUN shell heredocs only. Mirrors `shfmt --case-indent`. |
+| `space_redirects` | RUN shell heredocs only. Mirrors `shfmt --space-redirects`. |
+| `keep_padding` | RUN shell heredocs only. Mirrors `shfmt --keep-padding`. |
+| `function_next_line` | RUN shell heredocs only. Mirrors `shfmt --func-next-line`. |
+| `simplify` | RUN shell heredocs only. Mirrors `shfmt --simplify`. |
+| `minify` | RUN shell heredocs only. Mirrors `shfmt --minify` and implies `simplify`. |
 
 Other EditorConfig properties are intentionally not interpreted by the heredoc formatter today:
 

--- a/_docs/rules/tally/prefer-formatted-heredocs.mdx
+++ b/_docs/rules/tally/prefer-formatted-heredocs.mdx
@@ -1,9 +1,9 @@
 ---
 title: "tally/prefer-formatted-heredocs"
-description: "Pretty-print COPY and ADD heredocs for structured file types."
+description: "Pretty-print structured COPY/ADD heredocs and shell RUN heredocs."
 ---
 
-Pretty-prints `COPY` and `ADD` heredoc bodies when the destination filename has a supported structured-data extension.
+Pretty-prints structured `COPY` and `ADD` heredoc bodies, and `RUN` heredoc bodies that are executed as shell scripts.
 
 | Property | Value |
 |----------|-------|
@@ -18,16 +18,23 @@ This rule formats heredoc payloads that are copied into JSON, YAML, TOML, XML, o
 path extension and uses the repository's `.editorconfig` settings for indentation. YAML heredocs can also use `max_line_length` as a preferred scalar
 wrapping width.
 
-For EditorConfig lookup, tally resolves a virtual filename next to the Dockerfile using the destination basename. For example, a heredoc in
-`services/api/Dockerfile` targeting `/etc/app/config.yaml` is matched as `services/api/config.yaml`, so selectors such as `*.yaml` and `config.yaml`
-apply naturally.
+The rule also formats `RUN <<EOF` heredocs whose body is executed as a shell script. It uses `mvdan.cc/sh/v3`, the same formatter library behind
+`shfmt`, for Bash, POSIX shell, mksh, Bats, and zsh. Heredocs that are stdin payloads for another command, such as `RUN cat <<EOF`, are left alone.
+PowerShell, cmd, and unknown shebang bodies are skipped.
+
+For structured payload EditorConfig lookup, tally resolves a virtual filename next to the Dockerfile using the destination basename. For example, a
+heredoc in `services/api/Dockerfile` targeting `/etc/app/config.yaml` is matched as `services/api/config.yaml`, so selectors such as `*.yaml` and
+`config.yaml` apply naturally.
+
+For `RUN` shell heredocs, tally resolves a virtual filename next to the Dockerfile named `Dockerfile.heredoc.<dialect>`, such as
+`Dockerfile.heredoc.sh`, `Dockerfile.heredoc.bash`, or `Dockerfile.heredoc.zsh`.
 
 The formatter also runs as a final auto-fix pass. This means heredocs emitted by other rules, such as `tally/prefer-copy-heredoc`, are formatted in
 the same `--fix` run when this rule is enabled.
 
 ## Examples
 
-### Bad
+### Bad: COPY
 
 ```dockerfile
 FROM alpine:3.20
@@ -36,7 +43,7 @@ COPY <<EOF /etc/app/config.json
 EOF
 ```
 
-### Good
+### Good: COPY
 
 ```dockerfile
 FROM alpine:3.20
@@ -45,6 +52,27 @@ COPY <<EOF /etc/app/config.json
   "b": 2,
   "a": 1
 }
+EOF
+```
+
+### Bad: RUN
+
+```dockerfile
+FROM alpine:3.20
+RUN <<EOF
+set -eu; apk add --no-cache ca-certificates curl openssl; install -d -o app -g app /opt/app/bin /opt/app/cache; chown -R app:app /opt/app
+EOF
+```
+
+### Good: RUN
+
+```dockerfile
+FROM alpine:3.20
+RUN <<EOF
+set -eu
+apk add --no-cache ca-certificates curl openssl
+install -d -o app -g app /opt/app/bin /opt/app/cache
+chown -R app:app /opt/app
 EOF
 ```
 
@@ -58,6 +86,16 @@ EOF
 | `.xml`, `.config`, `.xsd`, `.wsdl`, `.xsl`, `.xslt` | XML |
 | `.ini` | INI |
 
+## Supported Shells
+
+| Shell | Formatter dialect |
+|-------|-------------------|
+| `bash` | Bash |
+| `sh`, `dash`, `ash` | POSIX shell |
+| `mksh`, `ksh` | mksh |
+| `bats` | Bats |
+| `zsh` | zsh |
+
 ## Configuration
 
 Default (no config needed):
@@ -66,14 +104,21 @@ Default (no config needed):
 # Enabled by default with no rule-specific options
 ```
 
-This rule intentionally has no formatter-specific options. Use `.editorconfig` for indentation style and width, and for YAML scalar wrapping width.
+This rule intentionally has no rule-specific formatter options. Use `.editorconfig` for indentation style and width, YAML scalar wrapping width, and
+RUN shell heredoc line width.
 See [EditorConfig integration](/integrations/editorconfig) for recommended Dockerfile settings and path resolution details.
 
-The rule reads `indent_style`, `indent_size`, `tab_width`, and YAML-only `max_line_length`. `max_line_length` is treated as a preferred wrapping
-width, not a hard maximum. It does not currently interpret `insert_final_newline`, `end_of_line`, `charset`, or `trim_trailing_whitespace` for the
-virtual payload file. Formatted heredoc bodies always end with exactly one newline before the heredoc terminator, and line endings follow the parent
-Dockerfile/fix application rather than a separate payload setting. The current structured serializers do not emit incidental trailing whitespace, but
-tally does not run a separate trailing-whitespace trim pass because whitespace can be payload data.
+The rule reads `indent_style`, `indent_size`, `tab_width`, and `max_line_length`. For YAML, `max_line_length` is used as a preferred scalar wrapping
+width. For shell heredocs, it is used as a preferred command wrapping width; when unset or invalid, tally uses `100`, and `off` disables this shell
+line-width pass. This is not a hard maximum.
+
+For shell heredocs, tally also reads shfmt-compatible EditorConfig booleans: `binary_next_line`, `switch_case_indent`, `space_redirects`,
+`keep_padding`, `function_next_line`, `simplify`, and `minify`.
+
+The rule does not currently interpret `insert_final_newline`, `end_of_line`, `charset`, or `trim_trailing_whitespace` for the virtual payload file.
+Formatted heredoc bodies always end with exactly one newline before the heredoc terminator, and line endings follow the parent Dockerfile/fix
+application rather than a separate payload setting. The current formatters do not emit incidental trailing whitespace, but tally does not run a
+separate trailing-whitespace trim pass because whitespace can be payload data.
 
 ## Auto-fix
 

--- a/_docs/rules/tally/prefer-formatted-heredocs.mdx
+++ b/_docs/rules/tally/prefer-formatted-heredocs.mdx
@@ -1,9 +1,10 @@
 ---
 title: "tally/prefer-formatted-heredocs"
-description: "Pretty-print structured COPY/ADD heredocs and shell RUN heredocs."
+description: "Pretty-print structured COPY/ADD heredocs and shell heredocs."
 ---
 
-Pretty-prints structured `COPY` and `ADD` heredoc bodies, and `RUN` heredoc bodies that are executed as shell scripts.
+Pretty-prints structured `COPY` and `ADD` heredoc bodies, `COPY` heredocs that contain shell scripts, and `RUN` heredoc bodies that are executed as
+shell scripts.
 
 | Property | Value |
 |----------|-------|
@@ -14,9 +15,13 @@ Pretty-prints structured `COPY` and `ADD` heredoc bodies, and `RUN` heredoc bodi
 
 ## Description
 
-This rule formats heredoc payloads that are copied into JSON, YAML, TOML, XML, or INI files. It detects the file type from the heredoc destination
-path extension and uses the repository's `.editorconfig` settings for indentation. YAML heredocs can also use `max_line_length` as a preferred scalar
-wrapping width.
+This rule formats heredoc payloads that are copied into JSON, YAML, TOML, XML, or INI files. It detects structured file types from the heredoc
+destination path extension and uses the repository's `.editorconfig` settings for indentation. YAML heredocs can also use `max_line_length` as a
+preferred scalar wrapping width.
+
+The rule also formats `COPY` heredocs as shell scripts when the first payload line is a recognized shell shebang, or when the destination path ends
+in `.sh` and the payload has no shebang. Plain `.sh` payloads are parsed as POSIX shell. Unsupported shebangs are skipped instead of falling back to
+the `.sh` extension.
 
 The rule also formats `RUN <<EOF` heredocs whose body is executed as a shell script. It uses `mvdan.cc/sh/v3`, the same formatter library behind
 `shfmt`, for Bash, POSIX shell, mksh, Bats, and zsh. Heredocs that are stdin payloads for another command, such as `RUN cat <<EOF`, are left alone.
@@ -25,6 +30,9 @@ PowerShell, cmd, and unknown shebang bodies are skipped.
 For structured payload EditorConfig lookup, tally resolves a virtual filename next to the Dockerfile using the destination basename. For example, a
 heredoc in `services/api/Dockerfile` targeting `/etc/app/config.yaml` is matched as `services/api/config.yaml`, so selectors such as `*.yaml` and
 `config.yaml` apply naturally.
+
+`COPY` shell heredocs use the same destination-basename lookup, so a target such as `/usr/local/bin/entrypoint.sh` is matched as
+`entrypoint.sh` and can use EditorConfig sections such as `*.sh` or `entrypoint.sh`.
 
 For `RUN` shell heredocs, tally resolves a virtual filename next to the Dockerfile named `Dockerfile.heredoc.<dialect>`, such as
 `Dockerfile.heredoc.sh`, `Dockerfile.heredoc.bash`, or `Dockerfile.heredoc.zsh`.
@@ -76,6 +84,28 @@ chown -R app:app /opt/app
 EOF
 ```
 
+### Bad: COPY shell
+
+```dockerfile
+FROM alpine:3.20
+COPY <<EOF /usr/local/bin/entrypoint
+#!/usr/bin/env bash
+set -eu; mkdir -p /run/app /var/cache/app; chown -R app:app /run/app /var/cache/app
+EOF
+```
+
+### Good: COPY shell
+
+```dockerfile
+FROM alpine:3.20
+COPY <<EOF /usr/local/bin/entrypoint
+#!/usr/bin/env bash
+set -eu
+mkdir -p /run/app /var/cache/app
+chown -R app:app /run/app /var/cache/app
+EOF
+```
+
 ## Supported Types
 
 | Extension | Format |
@@ -87,6 +117,9 @@ EOF
 | `.ini` | INI |
 
 ## Supported Shells
+
+Shell formatting applies to executable `RUN` heredocs and to `COPY` heredocs with a recognized shell shebang. A `COPY` heredoc targeting `.sh`
+without a shebang uses POSIX shell.
 
 | Shell | Formatter dialect |
 |-------|-------------------|
@@ -105,7 +138,7 @@ Default (no config needed):
 ```
 
 This rule intentionally has no rule-specific formatter options. Use `.editorconfig` for indentation style and width, YAML scalar wrapping width, and
-RUN shell heredoc line width.
+shell heredoc line width.
 See [EditorConfig integration](/integrations/editorconfig) for recommended Dockerfile settings and path resolution details.
 
 The rule reads `indent_style`, `indent_size`, `tab_width`, and `max_line_length`. For YAML, `max_line_length` is used as a preferred scalar wrapping

--- a/internal/fix/heredoc_format_finalizer.go
+++ b/internal/fix/heredoc_format_finalizer.go
@@ -16,7 +16,7 @@ func (formattedHeredocsFinalizer) RuleCode() string {
 }
 
 func (formattedHeredocsFinalizer) Description() string {
-	return "Pretty-print COPY/ADD heredocs"
+	return "Pretty-print Dockerfile heredocs"
 }
 
 func (formattedHeredocsFinalizer) Safety() rules.FixSafety {

--- a/internal/fix/heredoc_format_finalizer.go
+++ b/internal/fix/heredoc_format_finalizer.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/wharflab/tally/internal/directive"
 	"github.com/wharflab/tally/internal/dockerfile"
 	"github.com/wharflab/tally/internal/heredocfmt"
 	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/sourcemap"
 )
 
 type formattedHeredocsFinalizer struct{}
@@ -35,9 +38,22 @@ func (formattedHeredocsFinalizer) Finalize(
 	if err != nil {
 		return nil, err
 	}
-	return heredocfmt.FormatDockerfileHeredocs(ctx.FilePath, result)
+	sem := semanticModelForFinalizer(ctx.FilePath, result)
+	return heredocfmt.FormatDockerfileHeredocs(ctx.FilePath, result, sem)
 }
 
 func init() {
 	RegisterFinalizer(formattedHeredocsFinalizer{})
+}
+
+func semanticModelForFinalizer(file string, result *dockerfile.ParseResult) *semantic.Model {
+	if result == nil {
+		return semantic.NewModel(nil, nil, file)
+	}
+	sm := sourcemap.New(result.Source)
+	spanIndex := directive.NewInstructionSpanIndexFromAST(result.AST, sm)
+	directiveResult := directive.Parse(sm, nil, spanIndex)
+	return semantic.NewBuilder(result, nil, file).
+		WithShellDirectives(directive.ToSemanticShellDirectives(directiveResult.ShellDirectives)).
+		Build()
 }

--- a/internal/fix/heredoc_format_finalizer_test.go
+++ b/internal/fix/heredoc_format_finalizer_test.go
@@ -57,6 +57,41 @@ func TestFormattedHeredocsFinalizerFormatsGeneratedHeredoc(t *testing.T) {
 	}
 }
 
+func TestFormattedHeredocsFinalizerFormatsRunHeredoc(t *testing.T) {
+	t.Parallel()
+
+	file := filepath.Join(t.TempDir(), "Dockerfile")
+	src := []byte("FROM ubuntu:22.04\n" +
+		"RUN <<EOF\n" +
+		"apt-get install -y --no-install-recommends build-essential ca-certificates curl git jq openssl " +
+		"pkg-config python3-dev unzip vim wget zlib1g-dev\n" +
+		"EOF\n")
+	fixer := &Fixer{
+		SafetyThreshold: rules.FixSafe,
+		EnabledRules: map[string][]string{
+			filepath.Clean(file): {rules.FormattedHeredocsRuleCode},
+		},
+	}
+	result, err := fixer.Apply(context.Background(), nil, map[string][]byte{file: src})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	change := result.Changes[filepath.Clean(file)]
+	if change == nil {
+		t.Fatal("missing file change")
+	}
+	got := string(change.ModifiedContent)
+	want := "apt-get install -y --no-install-recommends build-essential ca-certificates curl git jq openssl \\\n" +
+		"\tpkg-config python3-dev unzip vim wget zlib1g-dev"
+	if !strings.Contains(got, want) {
+		t.Fatalf("RUN heredoc was not formatted\ngot:\n%s\nwant substring:\n%s", got, want)
+	}
+	if result.TotalApplied() != 1 {
+		t.Fatalf("applied fixes = %d, want 1", result.TotalApplied())
+	}
+}
+
 func TestFormattedHeredocsFinalizerRequiresRuleEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/heredoc/format.go
+++ b/internal/heredoc/format.go
@@ -46,7 +46,7 @@ func heredocBodyLines(commands []string, variant shell.Variant, pipefail bool) [
 		return powerShellBodyLines(commands)
 	case shell.VariantCmd:
 		return cmdBodyLines(commands)
-	case shell.VariantBash, shell.VariantPOSIX, shell.VariantMksh, shell.VariantZsh, shell.VariantUnknown:
+	case shell.VariantBash, shell.VariantPOSIX, shell.VariantMksh, shell.VariantBats, shell.VariantZsh, shell.VariantUnknown:
 		return posixBodyLines(commands, variant, pipefail)
 	}
 

--- a/internal/heredocfmt/dockerfile.go
+++ b/internal/heredocfmt/dockerfile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/wharflab/tally/internal/dockerfile"
+	"github.com/wharflab/tally/internal/highlight/extract"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/sourcemap"
 )
@@ -22,6 +23,17 @@ type DockerfileHeredoc struct {
 	BodyStartLine  int
 	TerminatorLine int
 	BodyPrefix     string
+}
+
+// RunHeredoc describes a RUN heredoc body whose contents are executed as a script.
+type RunHeredoc struct {
+	Instruction       string
+	Content           string
+	StartLine         int
+	BodyStartLine     int
+	TerminatorLine    int
+	BodyPrefix        string
+	ShellNameOverride string
 }
 
 // CollectDockerfileHeredocs returns supported COPY/ADD heredocs from a parsed Dockerfile.
@@ -69,6 +81,51 @@ func CollectDockerfileHeredocs(result *dockerfile.ParseResult) []DockerfileHered
 				BodyPrefix:     span.bodyPrefix,
 			})
 		}
+	}
+	return docs
+}
+
+// CollectRunHeredocs returns RUN heredocs whose body is executed as a shell script.
+func CollectRunHeredocs(result *dockerfile.ParseResult) []RunHeredoc {
+	if result == nil || result.AST == nil || result.AST.AST == nil {
+		return nil
+	}
+
+	sm := sourcemap.New(result.Source)
+	escapeToken := result.AST.EscapeToken
+	if escapeToken == 0 {
+		escapeToken = '\\'
+	}
+
+	var docs []RunHeredoc
+	for _, node := range result.AST.AST.Children {
+		if len(node.Heredocs) != 1 || !strings.EqualFold(node.Value, command.Run) {
+			continue
+		}
+
+		mapping, ok := extract.ExtractRunScript(sm, node, escapeToken)
+		if !ok || !mapping.IsHeredoc {
+			continue
+		}
+
+		spans := heredocBodySpans(node, sm, escapeToken)
+		if len(spans) == 0 {
+			continue
+		}
+		span := spans[0]
+		if span.bodyStartLine <= 0 || span.terminatorLine <= 0 {
+			continue
+		}
+
+		docs = append(docs, RunHeredoc{
+			Instruction:       strings.ToUpper(node.Value),
+			Content:           node.Heredocs[0].Content,
+			StartLine:         node.StartLine,
+			BodyStartLine:     span.bodyStartLine,
+			TerminatorLine:    span.terminatorLine,
+			BodyPrefix:        span.bodyPrefix,
+			ShellNameOverride: mapping.ShellNameOverride,
+		})
 	}
 	return docs
 }

--- a/internal/heredocfmt/dockerfile.go
+++ b/internal/heredocfmt/dockerfile.go
@@ -11,6 +11,8 @@ import (
 	"github.com/wharflab/tally/internal/dockerfile"
 	"github.com/wharflab/tally/internal/highlight/extract"
 	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/sourcemap"
 )
 
@@ -151,8 +153,52 @@ func isOnbuildRunNode(node *parser.Node) bool {
 		strings.EqualFold(node.Next.Children[0].Value, command.Run)
 }
 
-// FormatDockerfileHeredocs builds text edits that pretty-print COPY/ADD heredoc bodies.
-func FormatDockerfileHeredocs(file string, result *dockerfile.ParseResult) ([]rules.TextEdit, error) {
+// RunHeredocShellVariant returns the shell variant used to parse a RUN heredoc body.
+func RunHeredocShellVariant(stages []instructions.Stage, sem *semantic.Model, doc RunHeredoc) shell.Variant {
+	if name, ok := shellFromHeredocShebang(doc.Content); ok {
+		return shell.VariantFromShell(name)
+	}
+	if doc.ShellNameOverride != "" {
+		return shell.VariantFromShell(doc.ShellNameOverride)
+	}
+	if sem == nil {
+		return shell.VariantUnknown
+	}
+
+	stageIdx := stageIndexAtLine(stages, doc.StartLine)
+	if stageIdx < 0 {
+		return shell.VariantUnknown
+	}
+	info := sem.StageInfo(stageIdx)
+	if info == nil {
+		return shell.VariantUnknown
+	}
+	return info.ShellVariantAtLine(doc.StartLine)
+}
+
+func shellFromHeredocShebang(content string) (string, bool) {
+	firstLine, _, _ := strings.Cut(content, "\n")
+	if name, ok := shell.ShellFromShebang(firstLine); ok {
+		return name, true
+	}
+	if strings.HasPrefix(firstLine, "#!") {
+		return "", true
+	}
+	return "", false
+}
+
+func stageIndexAtLine(stages []instructions.Stage, line int) int {
+	stageIdx := -1
+	for i, stage := range stages {
+		if len(stage.Location) > 0 && stage.Location[0].Start.Line <= line {
+			stageIdx = i
+		}
+	}
+	return stageIdx
+}
+
+// FormatDockerfileHeredocs builds text edits that pretty-print Dockerfile heredoc bodies.
+func FormatDockerfileHeredocs(file string, result *dockerfile.ParseResult, sem *semantic.Model) ([]rules.TextEdit, error) {
 	formatter := NewFormatter(file)
 	var edits []rules.TextEdit
 	for _, doc := range CollectDockerfileHeredocs(result) {
@@ -165,6 +211,25 @@ func FormatDockerfileHeredocs(file string, result *dockerfile.ParseResult) ([]ru
 			if err != nil {
 				return nil, err
 			}
+		}
+		if !ok || formatted == doc.Content {
+			continue
+		}
+
+		edits = append(edits, rules.TextEdit{
+			Location: rules.NewRangeLocation(file, doc.BodyStartLine, 0, doc.TerminatorLine, 0),
+			NewText:  WithBodyPrefix(formatted, doc.BodyPrefix),
+		})
+	}
+	for _, doc := range CollectRunHeredocs(result) {
+		variant := RunHeredocShellVariant(result.Stages, sem, doc)
+		if !variant.SupportsPOSIXShellAST() {
+			continue
+		}
+
+		formatted, ok, err := formatter.FormatShell(doc.Content, variant)
+		if err != nil {
+			return nil, err
 		}
 		if !ok || formatted == doc.Content {
 			continue

--- a/internal/heredocfmt/dockerfile.go
+++ b/internal/heredocfmt/dockerfile.go
@@ -99,11 +99,11 @@ func CollectRunHeredocs(result *dockerfile.ParseResult) []RunHeredoc {
 
 	var docs []RunHeredoc
 	for _, node := range result.AST.AST.Children {
-		if len(node.Heredocs) != 1 || !strings.EqualFold(node.Value, command.Run) {
+		if len(node.Heredocs) != 1 {
 			continue
 		}
 
-		mapping, ok := extract.ExtractRunScript(sm, node, escapeToken)
+		instruction, mapping, ok := extractRunHeredocMapping(sm, node, escapeToken)
 		if !ok || !mapping.IsHeredoc {
 			continue
 		}
@@ -118,7 +118,7 @@ func CollectRunHeredocs(result *dockerfile.ParseResult) []RunHeredoc {
 		}
 
 		docs = append(docs, RunHeredoc{
-			Instruction:       strings.ToUpper(node.Value),
+			Instruction:       instruction,
 			Content:           node.Heredocs[0].Content,
 			StartLine:         node.StartLine,
 			BodyStartLine:     span.bodyStartLine,
@@ -128,6 +128,27 @@ func CollectRunHeredocs(result *dockerfile.ParseResult) []RunHeredoc {
 		})
 	}
 	return docs
+}
+
+func extractRunHeredocMapping(sm *sourcemap.SourceMap, node *parser.Node, escapeToken rune) (string, extract.Mapping, bool) {
+	if strings.EqualFold(node.Value, command.Run) {
+		mapping, ok := extract.ExtractRunScript(sm, node, escapeToken)
+		return strings.ToUpper(command.Run), mapping, ok
+	}
+	if !isOnbuildRunNode(node) {
+		return "", extract.Mapping{}, false
+	}
+	mapping, ok := extract.ExtractOnbuildRunScript(sm, node, escapeToken)
+	return strings.ToUpper(command.Onbuild + " " + command.Run), mapping, ok
+}
+
+func isOnbuildRunNode(node *parser.Node) bool {
+	if node == nil || !strings.EqualFold(node.Value, command.Onbuild) {
+		return false
+	}
+	return node.Next != nil &&
+		len(node.Next.Children) > 0 &&
+		strings.EqualFold(node.Next.Children[0].Value, command.Run)
 }
 
 // FormatDockerfileHeredocs builds text edits that pretty-print COPY/ADD heredoc bodies.

--- a/internal/heredocfmt/dockerfile.go
+++ b/internal/heredocfmt/dockerfile.go
@@ -139,6 +139,12 @@ func FormatDockerfileHeredocs(file string, result *dockerfile.ParseResult) ([]ru
 		if err != nil {
 			return nil, err
 		}
+		if !ok && strings.EqualFold(doc.Instruction, command.Copy) {
+			formatted, _, ok, err = formatter.FormatShellTarget(doc.TargetPath, doc.Content)
+			if err != nil {
+				return nil, err
+			}
+		}
 		if !ok || formatted == doc.Content {
 			continue
 		}

--- a/internal/heredocfmt/dockerfile_test.go
+++ b/internal/heredocfmt/dockerfile_test.go
@@ -1,0 +1,11 @@
+package heredocfmt
+
+import "testing"
+
+func TestShellFromHeredocShebangIgnoresIndentedShebangComment(t *testing.T) {
+	t.Parallel()
+
+	if got, ok := shellFromHeredocShebang("  #!/usr/bin/env bash\necho hi\n"); ok {
+		t.Fatalf("shellFromHeredocShebang() = %q, true; want no shebang", got)
+	}
+}

--- a/internal/heredocfmt/format.go
+++ b/internal/heredocfmt/format.go
@@ -448,8 +448,12 @@ func formatShell(content string, variant shell.Variant, st style) (string, error
 		return "", err
 	}
 	if st.maxLineLength > 0 && hasLineLongerThan(formatted, st.maxLineLength) {
-		if wrapLongShellCalls(prog, st) {
-			formatted, err = printShell(prog, st)
+		wrappedProg, err := parseShell(formatted, variant)
+		if err != nil {
+			return "", errSkipFormat
+		}
+		if wrapLongShellCalls(wrappedProg, st) {
+			formatted, err = printShell(wrappedProg, st)
 			if err != nil {
 				return "", err
 			}
@@ -510,12 +514,17 @@ func hasLineLongerThan(s string, maxLen int) bool {
 	if maxLen <= 0 {
 		return false
 	}
-	for line := range strings.SplitSeq(strings.TrimRight(s, "\n"), "\n") {
-		if len(line) > maxLen {
+	s = strings.TrimRight(s, "\n")
+	for {
+		idx := strings.IndexByte(s, '\n')
+		if idx < 0 {
+			return len(s) > maxLen
+		}
+		if idx > maxLen {
 			return true
 		}
+		s = s[idx+1:]
 	}
-	return false
 }
 
 func wrapLongShellCalls(prog *syntax.File, st style) bool {
@@ -538,13 +547,9 @@ func wrapLongShellCall(call *syntax.CallExpr, st style) bool {
 		return false
 	}
 
-	words := make([]string, 0, len(call.Args))
-	for _, word := range call.Args {
-		text, ok := shellWordText(word, st)
-		if !ok {
-			return false
-		}
-		words = append(words, text)
+	words, ok := shellWordTexts(call.Args, st)
+	if !ok {
+		return false
 	}
 
 	lineLen := leadingColumn(call.Args[0]) + len(words[0])
@@ -557,7 +562,7 @@ func wrapLongShellCall(call *syntax.CallExpr, st style) bool {
 		nextLen := lineLen + 1 + len(words[i])
 		if nextLen > st.maxLineLength {
 			breaks[i] = true
-			lineLen = len(st.indent) + len(words[i])
+			lineLen = st.indentWidth + len(words[i])
 			continue
 		}
 		lineLen = nextLen
@@ -567,13 +572,19 @@ func wrapLongShellCall(call *syntax.CallExpr, st style) bool {
 	if line == 0 {
 		line = 1
 	}
+	currentLine := line
 	modified := false
 	for i, shouldBreak := range breaks {
-		if !shouldBreak {
+		if i == 0 {
 			continue
 		}
-		line++
-		if setWordStart(call.Args[i], line) {
+		if shouldBreak {
+			currentLine++
+		}
+		if currentLine == line {
+			continue
+		}
+		if setWordLine(call.Args[i], currentLine) {
 			modified = true
 		}
 	}
@@ -594,21 +605,6 @@ func callNeedsWrap(words []string, firstLineLen, maxLen int) bool {
 	return false
 }
 
-func shellWordText(word *syntax.Word, st style) (string, bool) {
-	if word == nil {
-		return "", false
-	}
-	var buf bytes.Buffer
-	if err := syntax.NewPrinter(shellPrinterOptions(st)...).Print(&buf, word); err != nil {
-		return "", false
-	}
-	text := buf.String()
-	if text == "" || strings.Contains(text, "\n") {
-		return "", false
-	}
-	return text, true
-}
-
 func leadingColumn(word *syntax.Word) int {
 	if word == nil {
 		return 0
@@ -620,27 +616,131 @@ func leadingColumn(word *syntax.Word) int {
 	return int(col - 1)
 }
 
-func setWordStart(word *syntax.Word, line uint) bool {
+func shellWordTexts(words []*syntax.Word, st style) ([]string, bool) {
+	printer := syntax.NewPrinter(shellPrinterOptions(st)...)
+	texts := make([]string, 0, len(words))
+	for _, word := range words {
+		if word == nil {
+			return nil, false
+		}
+		var buf bytes.Buffer
+		if err := printer.Print(&buf, word); err != nil {
+			return nil, false
+		}
+		text := buf.String()
+		if text == "" || strings.Contains(text, "\n") {
+			return nil, false
+		}
+		texts = append(texts, text)
+	}
+	return texts, true
+}
+
+func setWordLine(word *syntax.Word, line uint) bool {
 	if word == nil || len(word.Parts) == 0 {
 		return false
 	}
-	switch part := word.Parts[0].(type) {
+	baseCol := word.Pos().Col()
+	if baseCol == 0 {
+		baseCol = 1
+	}
+	for _, part := range word.Parts {
+		if !setWordPartLine(part, line, baseCol) {
+			return false
+		}
+	}
+	return true
+}
+
+func setWordPartsLine(parts []syntax.WordPart, line, baseCol uint) bool {
+	for _, part := range parts {
+		if !setWordPartLine(part, line, baseCol) {
+			return false
+		}
+	}
+	return true
+}
+
+func setWordPartLine(part syntax.WordPart, line, baseCol uint) bool {
+	switch part := part.(type) {
 	case *syntax.Lit:
-		part.ValuePos = syntax.NewPos(0, line, 1)
+		setLitLine(part, line, baseCol)
 	case *syntax.SglQuoted:
-		part.Left = syntax.NewPos(0, line, 1)
+		part.Left = withLineRelative(part.Left, line, baseCol)
+		part.Right = withLineRelative(part.Right, line, baseCol)
 	case *syntax.DblQuoted:
-		part.Left = syntax.NewPos(0, line, 1)
+		part.Left = withLineRelative(part.Left, line, baseCol)
+		part.Right = withLineRelative(part.Right, line, baseCol)
+		return setWordPartsLine(part.Parts, line, baseCol)
 	case *syntax.ParamExp:
-		part.Dollar = syntax.NewPos(0, line, 1)
+		part.Dollar = withLineRelative(part.Dollar, line, baseCol)
+		part.Rbrace = withLineRelative(part.Rbrace, line, baseCol)
+		setLitLine(part.Flags, line, baseCol)
+		setLitLine(part.Param, line, baseCol)
+		if part.NestedParam != nil && !setWordPartLine(part.NestedParam, line, baseCol) {
+			return false
+		}
+		for _, modifier := range part.Modifiers {
+			setLitLine(modifier, line, baseCol)
+		}
+		if part.Repl != nil {
+			if !setNestedWordLine(part.Repl.Orig, line, baseCol) || !setNestedWordLine(part.Repl.With, line, baseCol) {
+				return false
+			}
+		}
+		if part.Exp != nil && !setNestedWordLine(part.Exp.Word, line, baseCol) {
+			return false
+		}
 	case *syntax.CmdSubst:
-		part.Left = syntax.NewPos(0, line, 1)
+		part.Left = withLineRelative(part.Left, line, baseCol)
+		part.Right = withLineRelative(part.Right, line, baseCol)
 	case *syntax.ArithmExp:
-		part.Left = syntax.NewPos(0, line, 1)
+		part.Left = withLineRelative(part.Left, line, baseCol)
+		part.Right = withLineRelative(part.Right, line, baseCol)
+	case *syntax.ProcSubst:
+		part.OpPos = withLineRelative(part.OpPos, line, baseCol)
+		part.Rparen = withLineRelative(part.Rparen, line, baseCol)
+	case *syntax.ExtGlob:
+		part.OpPos = withLineRelative(part.OpPos, line, baseCol)
+		setLitLine(part.Pattern, line, baseCol)
+	case *syntax.BraceExp:
+		for _, elem := range part.Elems {
+			if !setNestedWordLine(elem, line, baseCol) {
+				return false
+			}
+		}
 	default:
 		return false
 	}
 	return true
+}
+
+func setNestedWordLine(word *syntax.Word, line, baseCol uint) bool {
+	if word == nil {
+		return true
+	}
+	return setWordPartsLine(word.Parts, line, baseCol)
+}
+
+func setLitLine(lit *syntax.Lit, line, baseCol uint) {
+	if lit == nil {
+		return
+	}
+	lit.ValuePos = withLineRelative(lit.ValuePos, line, baseCol)
+	lit.ValueEnd = withLineRelative(lit.ValueEnd, line, baseCol)
+}
+
+func withLineRelative(pos syntax.Pos, line, baseCol uint) syntax.Pos {
+	if !pos.IsValid() {
+		return pos
+	}
+	col := pos.Col()
+	if col == 0 {
+		col = 1
+	} else if col >= baseCol {
+		col = col - baseCol + 1
+	}
+	return syntax.NewPos(0, line, col)
 }
 
 func formatJSON(content string, st style) (string, error) {

--- a/internal/heredocfmt/format.go
+++ b/internal/heredocfmt/format.go
@@ -1,4 +1,4 @@
-// Package heredocfmt formats typed file content embedded in Dockerfile heredocs.
+// Package heredocfmt formats content embedded in Dockerfile heredocs.
 package heredocfmt
 
 import (
@@ -17,9 +17,13 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 	yaml "go.yaml.in/yaml/v4"
 	ini "gopkg.in/ini.v1"
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/wharflab/tally/internal/shell"
 )
 
 const defaultIndentWidth = 2
+const defaultShellMaxLineLength = 100
 
 var errSkipFormat = errors.New("skip formatting")
 
@@ -41,9 +45,18 @@ type Formatter struct {
 }
 
 type style struct {
-	indent        string
-	indentWidth   int
-	maxLineLength int
+	indent           string
+	indentWidth      int
+	maxLineLength    int
+	maxLineLengthSet bool
+	shellIndent      uint
+	binaryNextLine   bool
+	caseIndent       bool
+	spaceRedirects   bool
+	keepPadding      bool
+	functionNextLine bool
+	simplify         bool
+	minify           bool
 }
 
 // NewFormatter creates a formatter for heredocs inside dockerfilePath.
@@ -94,6 +107,27 @@ func (f *Formatter) FormatTarget(target, content string) (string, Kind, bool, er
 	return formatted, kind, true, nil
 }
 
+// FormatShell formats a RUN heredoc body as a shell script for a mvdan.cc/sh-supported variant.
+func (f *Formatter) FormatShell(content string, variant shell.Variant) (string, bool, error) {
+	if !variant.SupportsPOSIXShellAST() {
+		return "", false, nil
+	}
+
+	st, err := f.styleForShell(variant)
+	if err != nil {
+		return "", false, err
+	}
+
+	formatted, err := formatShell(content, variant, st)
+	if err != nil {
+		if errors.Is(err, errSkipFormat) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return formatted, true, nil
+}
+
 func (f *Formatter) styleForTarget(target string) (style, error) {
 	virtualName, err := VirtualFilename(f.dockerfilePath, target)
 	if err != nil {
@@ -108,6 +142,24 @@ func (f *Formatter) styleForTarget(target string) (style, error) {
 		return style{}, err
 	}
 	st := styleFromDefinition(def)
+	f.styleCache[virtualName] = st
+	return st, nil
+}
+
+func (f *Formatter) styleForShell(variant shell.Variant) (style, error) {
+	virtualName, err := VirtualShellFilename(f.dockerfilePath, variant)
+	if err != nil {
+		return style{}, err
+	}
+	if st, ok := f.styleCache[virtualName]; ok {
+		return st, nil
+	}
+
+	def, err := editorconfig.GetDefinitionForFilename(virtualName)
+	if err != nil {
+		return style{}, err
+	}
+	st := shellStyleFromDefinition(def)
 	f.styleCache[virtualName] = st
 	return st, nil
 }
@@ -131,6 +183,33 @@ func VirtualFilename(dockerfilePath, target string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, filepath.FromSlash(base)), nil
+}
+
+// VirtualShellFilename returns the synthetic filename used for RUN heredoc EditorConfig matching.
+func VirtualShellFilename(dockerfilePath string, variant shell.Variant) (string, error) {
+	dir, err := dockerfileDir(dockerfilePath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "Dockerfile.heredoc."+shellExtension(variant)), nil
+}
+
+func shellExtension(variant shell.Variant) string {
+	switch variant {
+	case shell.VariantPOSIX:
+		return "sh"
+	case shell.VariantBash:
+		return "bash"
+	case shell.VariantMksh:
+		return "mksh"
+	case shell.VariantBats:
+		return "bats"
+	case shell.VariantZsh:
+		return "zsh"
+	case shell.VariantPowerShell, shell.VariantCmd, shell.VariantUnknown:
+		return "sh"
+	}
+	return "sh"
 }
 
 func targetBasename(target string) string {
@@ -171,14 +250,47 @@ func styleFromDefinition(def *editorconfig.Definition) style {
 	}
 
 	width := parseIndentWidth(def)
+	maxLineLength, maxLineLengthSet := parseMaxLineLength(def)
+	st := style{
+		maxLineLength:    maxLineLength,
+		maxLineLengthSet: maxLineLengthSet,
+		binaryNextLine:   rawBool(def, "binary_next_line"),
+		caseIndent:       rawBool(def, "switch_case_indent"),
+		spaceRedirects:   rawBool(def, "space_redirects"),
+		keepPadding:      rawBool(def, "keep_padding"),
+		functionNextLine: rawBool(def, "function_next_line"),
+		minify:           rawBool(def, "minify"),
+		simplify:         rawBool(def, "simplify") || rawBool(def, "minify"),
+	}
 	if strings.EqualFold(def.IndentStyle, editorconfig.IndentStyleTab) {
-		return style{indent: "\t", indentWidth: width, maxLineLength: parseMaxLineLength(def)}
+		st.indent = "\t"
+		st.indentWidth = width
+		return st
 	}
-	return style{
-		indent:        strings.Repeat(" ", width),
-		indentWidth:   width,
-		maxLineLength: parseMaxLineLength(def),
+	st.indent = strings.Repeat(" ", width)
+	st.indentWidth = width
+	return st
+}
+
+func shellStyleFromDefinition(def *editorconfig.Definition) style {
+	st := styleFromDefinition(def)
+	st.indent = "\t"
+	st.indentWidth = 8
+	st.shellIndent = 0
+
+	if def != nil && strings.EqualFold(def.IndentStyle, editorconfig.IndentStyleSpaces) {
+		width := 8
+		if n := parseIndentWidth(def); n > 0 {
+			width = n
+		}
+		st.indent = strings.Repeat(" ", width)
+		st.indentWidth = width
+		st.shellIndent = uint(width)
 	}
+	if !st.maxLineLengthSet {
+		st.maxLineLength = defaultShellMaxLineLength
+	}
+	return st
 }
 
 func parseIndentWidth(def *editorconfig.Definition) int {
@@ -194,19 +306,29 @@ func parseIndentWidth(def *editorconfig.Definition) int {
 	return defaultIndentWidth
 }
 
-func parseMaxLineLength(def *editorconfig.Definition) int {
+func parseMaxLineLength(def *editorconfig.Definition) (int, bool) {
 	if def == nil || def.Raw == nil {
-		return 0
+		return 0, false
 	}
 	value := strings.TrimSpace(strings.ToLower(def.Raw["max_line_length"]))
-	if value == "" || value == "off" {
-		return 0
+	if value == "" {
+		return 0, false
+	}
+	if value == "off" {
+		return 0, true
 	}
 	n, err := strconv.Atoi(value)
 	if err != nil || n <= 0 {
-		return 0
+		return 0, false
 	}
-	return n
+	return n, true
+}
+
+func rawBool(def *editorconfig.Definition, key string) bool {
+	if def == nil || def.Raw == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(def.Raw[key]), "true")
 }
 
 func formatContent(kind Kind, content string, st style) (string, error) {
@@ -224,6 +346,219 @@ func formatContent(kind Kind, content string, st style) (string, error) {
 	default:
 		return "", errSkipFormat
 	}
+}
+
+func formatShell(content string, variant shell.Variant, st style) (string, error) {
+	if strings.TrimSpace(content) == "" || !variant.SupportsPOSIXShellAST() {
+		return "", errSkipFormat
+	}
+
+	prog, err := parseShell(content, variant)
+	if err != nil {
+		return "", err
+	}
+	if st.simplify {
+		syntax.Simplify(prog)
+	}
+
+	formatted, err := printShell(prog, st)
+	if err != nil {
+		return "", err
+	}
+	if st.maxLineLength > 0 && hasLineLongerThan(formatted, st.maxLineLength) {
+		if wrapLongShellCalls(prog, st) {
+			formatted, err = printShell(prog, st)
+			if err != nil {
+				return "", err
+			}
+			if _, err := parseShell(formatted, variant); err != nil {
+				return "", errSkipFormat
+			}
+		}
+	}
+	return ensureTrailingNewline(formatted), nil
+}
+
+func parseShell(content string, variant shell.Variant) (*syntax.File, error) {
+	return syntax.NewParser(
+		syntax.KeepComments(true),
+		syntax.Variant(shellLangVariant(variant)),
+	).Parse(strings.NewReader(content), "")
+}
+
+func shellLangVariant(variant shell.Variant) syntax.LangVariant {
+	switch variant {
+	case shell.VariantPOSIX:
+		return syntax.LangPOSIX
+	case shell.VariantBash:
+		return syntax.LangBash
+	case shell.VariantMksh:
+		return syntax.LangMirBSDKorn
+	case shell.VariantBats:
+		return syntax.LangBats
+	case shell.VariantZsh:
+		return syntax.LangZsh
+	case shell.VariantPowerShell, shell.VariantCmd, shell.VariantUnknown:
+		return syntax.LangBash
+	}
+	return syntax.LangBash
+}
+
+func printShell(prog *syntax.File, st style) (string, error) {
+	var buf bytes.Buffer
+	if err := syntax.NewPrinter(shellPrinterOptions(st)...).Print(&buf, prog); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func shellPrinterOptions(st style) []syntax.PrinterOption {
+	return []syntax.PrinterOption{
+		syntax.Indent(st.shellIndent),
+		syntax.BinaryNextLine(st.binaryNextLine),
+		syntax.SwitchCaseIndent(st.caseIndent),
+		syntax.SpaceRedirects(st.spaceRedirects),
+		syntax.KeepPadding(st.keepPadding), //nolint:staticcheck // Match shfmt's supported keep_padding EditorConfig option.
+		syntax.FunctionNextLine(st.functionNextLine),
+		syntax.Minify(st.minify),
+	}
+}
+
+func hasLineLongerThan(s string, maxLen int) bool {
+	if maxLen <= 0 {
+		return false
+	}
+	for line := range strings.SplitSeq(strings.TrimRight(s, "\n"), "\n") {
+		if len(line) > maxLen {
+			return true
+		}
+	}
+	return false
+}
+
+func wrapLongShellCalls(prog *syntax.File, st style) bool {
+	modified := false
+	syntax.Walk(prog, func(node syntax.Node) bool {
+		call, ok := node.(*syntax.CallExpr)
+		if !ok {
+			return true
+		}
+		if wrapLongShellCall(call, st) {
+			modified = true
+		}
+		return true
+	})
+	return modified
+}
+
+func wrapLongShellCall(call *syntax.CallExpr, st style) bool {
+	if call == nil || len(call.Assigns) > 0 || len(call.Args) < 2 || st.maxLineLength <= 0 {
+		return false
+	}
+
+	words := make([]string, 0, len(call.Args))
+	for _, word := range call.Args {
+		text, ok := shellWordText(word, st)
+		if !ok {
+			return false
+		}
+		words = append(words, text)
+	}
+
+	lineLen := leadingColumn(call.Args[0]) + len(words[0])
+	if !callNeedsWrap(words, lineLen, st.maxLineLength) {
+		return false
+	}
+
+	breaks := make([]bool, len(words))
+	for i := 1; i < len(words); i++ {
+		nextLen := lineLen + 1 + len(words[i])
+		if nextLen > st.maxLineLength {
+			breaks[i] = true
+			lineLen = len(st.indent) + len(words[i])
+			continue
+		}
+		lineLen = nextLen
+	}
+
+	line := call.Args[0].Pos().Line()
+	if line == 0 {
+		line = 1
+	}
+	modified := false
+	for i, shouldBreak := range breaks {
+		if !shouldBreak {
+			continue
+		}
+		line++
+		if setWordStart(call.Args[i], line) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+func callNeedsWrap(words []string, firstLineLen, maxLen int) bool {
+	if firstLineLen > maxLen {
+		return true
+	}
+	lineLen := firstLineLen
+	for _, word := range words[1:] {
+		lineLen += 1 + len(word)
+		if lineLen > maxLen {
+			return true
+		}
+	}
+	return false
+}
+
+func shellWordText(word *syntax.Word, st style) (string, bool) {
+	if word == nil {
+		return "", false
+	}
+	var buf bytes.Buffer
+	if err := syntax.NewPrinter(shellPrinterOptions(st)...).Print(&buf, word); err != nil {
+		return "", false
+	}
+	text := buf.String()
+	if text == "" || strings.Contains(text, "\n") {
+		return "", false
+	}
+	return text, true
+}
+
+func leadingColumn(word *syntax.Word) int {
+	if word == nil {
+		return 0
+	}
+	col := word.Pos().Col()
+	if col == 0 {
+		return 0
+	}
+	return int(col - 1)
+}
+
+func setWordStart(word *syntax.Word, line uint) bool {
+	if word == nil || len(word.Parts) == 0 {
+		return false
+	}
+	switch part := word.Parts[0].(type) {
+	case *syntax.Lit:
+		part.ValuePos = syntax.NewPos(0, line, 1)
+	case *syntax.SglQuoted:
+		part.Left = syntax.NewPos(0, line, 1)
+	case *syntax.DblQuoted:
+		part.Left = syntax.NewPos(0, line, 1)
+	case *syntax.ParamExp:
+		part.Dollar = syntax.NewPos(0, line, 1)
+	case *syntax.CmdSubst:
+		part.Left = syntax.NewPos(0, line, 1)
+	case *syntax.ArithmExp:
+		part.Left = syntax.NewPos(0, line, 1)
+	default:
+		return false
+	}
+	return true
 }
 
 func formatJSON(content string, st style) (string, error) {

--- a/internal/heredocfmt/format.go
+++ b/internal/heredocfmt/format.go
@@ -128,6 +128,28 @@ func (f *Formatter) FormatShell(content string, variant shell.Variant) (string, 
 	return formatted, true, nil
 }
 
+// FormatShellTarget formats a COPY heredoc body as a shell script when the destination or shebang implies one.
+func (f *Formatter) FormatShellTarget(target, content string) (string, shell.Variant, bool, error) {
+	variant, ok := shellTargetVariant(target, content)
+	if !ok {
+		return "", shell.VariantUnknown, false, nil
+	}
+
+	st, err := f.styleForShellTarget(target, variant)
+	if err != nil {
+		return "", variant, false, err
+	}
+
+	formatted, err := formatShell(content, variant, st)
+	if err != nil {
+		if errors.Is(err, errSkipFormat) {
+			return "", variant, false, nil
+		}
+		return "", variant, false, err
+	}
+	return formatted, variant, true, nil
+}
+
 func (f *Formatter) styleForTarget(target string) (style, error) {
 	virtualName, err := VirtualFilename(f.dockerfilePath, target)
 	if err != nil {
@@ -148,6 +170,24 @@ func (f *Formatter) styleForTarget(target string) (style, error) {
 
 func (f *Formatter) styleForShell(variant shell.Variant) (style, error) {
 	virtualName, err := VirtualShellFilename(f.dockerfilePath, variant)
+	if err != nil {
+		return style{}, err
+	}
+	if st, ok := f.styleCache[virtualName]; ok {
+		return st, nil
+	}
+
+	def, err := editorconfig.GetDefinitionForFilename(virtualName)
+	if err != nil {
+		return style{}, err
+	}
+	st := shellStyleFromDefinition(def)
+	f.styleCache[virtualName] = st
+	return st, nil
+}
+
+func (f *Formatter) styleForShellTarget(target string, variant shell.Variant) (style, error) {
+	virtualName, err := VirtualShellTargetFilename(f.dockerfilePath, target, variant)
 	if err != nil {
 		return style{}, err
 	}
@@ -194,6 +234,19 @@ func VirtualShellFilename(dockerfilePath string, variant shell.Variant) (string,
 	return filepath.Join(dir, "Dockerfile.heredoc."+shellExtension(variant)), nil
 }
 
+// VirtualShellTargetFilename returns the synthetic filename used for COPY shell heredoc EditorConfig matching.
+func VirtualShellTargetFilename(dockerfilePath, target string, variant shell.Variant) (string, error) {
+	base := targetBasenameAny(target)
+	if base == "" {
+		return VirtualShellFilename(dockerfilePath, variant)
+	}
+	dir, err := dockerfileDir(dockerfilePath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, filepath.FromSlash(base)), nil
+}
+
 func shellExtension(variant shell.Variant) string {
 	switch variant {
 	case shell.VariantPOSIX:
@@ -213,14 +266,22 @@ func shellExtension(variant shell.Variant) string {
 }
 
 func targetBasename(target string) string {
+	base := targetBasenameAny(target)
+	if base == "" {
+		return ""
+	}
+	if _, ok := SupportedKind(base); !ok {
+		return ""
+	}
+	return base
+}
+
+func targetBasenameAny(target string) string {
 	target = strings.TrimSpace(target)
 	target = strings.Trim(target, `"'`)
 	target = strings.ReplaceAll(target, `\`, `/`)
 	base := path.Base(target)
 	if base == "." || base == "/" || base == "" {
-		return ""
-	}
-	if _, ok := SupportedKind(base); !ok {
 		return ""
 	}
 	return base
@@ -329,6 +390,27 @@ func rawBool(def *editorconfig.Definition, key string) bool {
 		return false
 	}
 	return strings.EqualFold(strings.TrimSpace(def.Raw[key]), "true")
+}
+
+func shellTargetVariant(target, content string) (shell.Variant, bool) {
+	firstLine, _, _ := strings.Cut(content, "\n")
+	if name, ok := shell.ShellFromShebang(firstLine); ok {
+		variant := shell.VariantFromShell(name)
+		return variant, variant.SupportsPOSIXShellAST()
+	}
+	if strings.HasPrefix(firstLine, "#!") {
+		return shell.VariantUnknown, false
+	}
+	if isDotShTarget(target) {
+		return shell.VariantPOSIX, true
+	}
+	return shell.VariantUnknown, false
+}
+
+func isDotShTarget(target string) bool {
+	target = strings.TrimSpace(target)
+	target = strings.Trim(target, `"'`)
+	return strings.EqualFold(path.Ext(filepath.ToSlash(target)), ".sh")
 }
 
 func formatContent(kind Kind, content string, st style) (string, error) {

--- a/internal/heredocfmt/format.go
+++ b/internal/heredocfmt/format.go
@@ -452,14 +452,18 @@ func formatShell(content string, variant shell.Variant, st style) (string, error
 		if err != nil {
 			return "", errSkipFormat
 		}
-		if wrapLongShellCalls(wrappedProg, st) {
-			formatted, err = printShell(wrappedProg, st)
-			if err != nil {
-				return "", err
-			}
-			if _, err := parseShell(formatted, variant); err != nil {
-				return "", errSkipFormat
-			}
+		if !wrapLongShellCalls(wrappedProg, st) {
+			return "", errSkipFormat
+		}
+		formatted, err = printShell(wrappedProg, st)
+		if err != nil {
+			return "", err
+		}
+		if _, err := parseShell(formatted, variant); err != nil {
+			return "", errSkipFormat
+		}
+		if hasLineLongerThan(formatted, st.maxLineLength) {
+			return "", errSkipFormat
 		}
 	}
 	return ensureTrailingNewline(formatted), nil

--- a/internal/heredocfmt/format_test.go
+++ b/internal/heredocfmt/format_test.go
@@ -196,6 +196,52 @@ func TestFormatShellWrapsMaxLineLength(t *testing.T) {
 	}
 }
 
+func TestFormatShellWrapsAllWordsAfterBreak(t *testing.T) {
+	t.Parallel()
+
+	st := shellStyleFromDefinition(&editorconfig.Definition{
+		IndentStyle: editorconfig.IndentStyleSpaces,
+		IndentSize:  "2",
+		Raw: map[string]string{
+			"indent_style":    "space",
+			"indent_size":     "2",
+			"max_line_length": "24",
+		},
+	})
+	got, err := formatShell("cmd alpha beta gamma delta epsilon zeta\n", shell.VariantPOSIX, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "cmd alpha beta gamma \\\n  delta epsilon zeta\n"
+	if got != want {
+		t.Fatalf("formatted shell mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatShellWrapsMultipartWord(t *testing.T) {
+	t.Parallel()
+
+	st := shellStyleFromDefinition(&editorconfig.Definition{
+		IndentStyle: editorconfig.IndentStyleSpaces,
+		IndentSize:  "2",
+		Raw: map[string]string{
+			"indent_style":    "space",
+			"indent_size":     "2",
+			"max_line_length": "24",
+		},
+	})
+	got, err := formatShell("cmd alpha beta prefix${APP_ENV}suffix gamma\n", shell.VariantPOSIX, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "cmd alpha beta \\\n  prefix${APP_ENV}suffix \\\n  gamma\n"
+	if got != want {
+		t.Fatalf("formatted shell mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 func TestShellTargetVariant(t *testing.T) {
 	t.Parallel()
 

--- a/internal/heredocfmt/format_test.go
+++ b/internal/heredocfmt/format_test.go
@@ -3,6 +3,8 @@ package heredocfmt
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -191,6 +193,99 @@ func TestFormatShellWrapsMaxLineLength(t *testing.T) {
 
 	if !strings.Contains(got, "\\\n  ") {
 		t.Fatalf("expected shell line wrapping, got:\n%s", got)
+	}
+}
+
+func TestShellTargetVariant(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		target  string
+		content string
+		want    shell.Variant
+		wantOK  bool
+	}{
+		{
+			name:    "bash shebang without extension",
+			target:  "/usr/local/bin/entrypoint",
+			content: "#!/usr/bin/env bash\nif true; then echo hi; fi\n",
+			want:    shell.VariantBash,
+			wantOK:  true,
+		},
+		{
+			name:    "ksh shebang maps to mksh",
+			target:  "/usr/local/bin/entrypoint",
+			content: "#!/bin/ksh\nif true; then echo hi; fi\n",
+			want:    shell.VariantMksh,
+			wantOK:  true,
+		},
+		{
+			name:    "sh extension without shebang uses POSIX",
+			target:  "/usr/local/bin/entrypoint.sh",
+			content: "if true; then echo hi; fi\n",
+			want:    shell.VariantPOSIX,
+			wantOK:  true,
+		},
+		{
+			name:    "unsupported shebang is skipped even with sh extension",
+			target:  "/usr/local/bin/entrypoint.sh",
+			content: "#!/usr/bin/env python\nprint('hi')\n",
+			wantOK:  false,
+		},
+		{
+			name:    "non-sh extension without shebang is skipped",
+			target:  "/usr/local/bin/entrypoint.bash",
+			content: "if true; then echo hi; fi\n",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := shellTargetVariant(tt.target, tt.content)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("variant = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatShellTargetUsesDestinationEditorConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte(`root = true
+
+[entrypoint.sh]
+indent_style = space
+indent_size = 2
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := NewFormatter(filepath.Join(dir, "Dockerfile"))
+	got, variant, ok, err := f.FormatShellTarget(
+		"/usr/local/bin/entrypoint.sh",
+		"if true; then\n echo hi\nfi\n",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("FormatShellTarget ok = false, want true")
+	}
+	if variant != shell.VariantPOSIX {
+		t.Fatalf("variant = %v, want %v", variant, shell.VariantPOSIX)
+	}
+
+	want := "if true; then\n  echo hi\nfi\n"
+	if got != want {
+		t.Fatalf("formatted shell target mismatch\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/heredocfmt/format_test.go
+++ b/internal/heredocfmt/format_test.go
@@ -2,10 +2,13 @@ package heredocfmt
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	editorconfig "github.com/editorconfig/editorconfig-core-go/v2"
+
+	"github.com/wharflab/tally/internal/shell"
 )
 
 func TestSupportedKindXMLAliases(t *testing.T) {
@@ -88,6 +91,106 @@ func TestStyleFromDefinitionReadsMaxLineLength(t *testing.T) {
 	})
 	if st.maxLineLength != 0 {
 		t.Fatalf("maxLineLength = %d, want 0 for off", st.maxLineLength)
+	}
+}
+
+func TestShellStyleDefaultMaxLineLength(t *testing.T) {
+	t.Parallel()
+
+	st := shellStyleFromDefinition(nil)
+	if st.maxLineLength != defaultShellMaxLineLength {
+		t.Fatalf("maxLineLength = %d, want %d", st.maxLineLength, defaultShellMaxLineLength)
+	}
+	if st.shellIndent != 0 {
+		t.Fatalf("shellIndent = %d, want tabs", st.shellIndent)
+	}
+
+	st = shellStyleFromDefinition(&editorconfig.Definition{
+		IndentStyle: editorconfig.IndentStyleSpaces,
+		IndentSize:  "4",
+		Raw: map[string]string{
+			"indent_style": "space",
+			"indent_size":  "4",
+		},
+	})
+	if st.shellIndent != 4 {
+		t.Fatalf("shellIndent = %d, want 4", st.shellIndent)
+	}
+}
+
+func TestShellStyleMaxLineLengthOff(t *testing.T) {
+	t.Parallel()
+
+	st := shellStyleFromDefinition(&editorconfig.Definition{
+		Raw: map[string]string{
+			"max_line_length": "off",
+		},
+	})
+	if st.maxLineLength != 0 {
+		t.Fatalf("maxLineLength = %d, want 0", st.maxLineLength)
+	}
+}
+
+func TestFormatShellUsesShfmt(t *testing.T) {
+	t.Parallel()
+
+	got, err := formatShell("if true; then\n  echo hi\nfi\n", shell.VariantPOSIX, shellStyleFromDefinition(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "if true; then\n\techo hi\nfi\n"
+	if got != want {
+		t.Fatalf("formatted shell mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatShellSupportsMvdanVariants(t *testing.T) {
+	t.Parallel()
+
+	for _, variant := range []shell.Variant{
+		shell.VariantBash,
+		shell.VariantPOSIX,
+		shell.VariantMksh,
+		shell.VariantBats,
+		shell.VariantZsh,
+	} {
+		t.Run(fmt.Sprint(variant), func(t *testing.T) {
+			t.Parallel()
+			got, err := formatShell("echo hi\n", variant, shellStyleFromDefinition(nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != "echo hi\n" {
+				t.Fatalf("formatted shell mismatch: %q", got)
+			}
+		})
+	}
+}
+
+func TestFormatShellWrapsMaxLineLength(t *testing.T) {
+	t.Parallel()
+
+	st := shellStyleFromDefinition(&editorconfig.Definition{
+		IndentStyle: editorconfig.IndentStyleSpaces,
+		IndentSize:  "2",
+		Raw: map[string]string{
+			"indent_style":    "space",
+			"indent_size":     "2",
+			"max_line_length": "48",
+		},
+	})
+	got, err := formatShell(
+		"apt-get install -y --no-install-recommends alpha beta gamma delta epsilon zeta\n",
+		shell.VariantPOSIX,
+		st,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(got, "\\\n  ") {
+		t.Fatalf("expected shell line wrapping, got:\n%s", got)
 	}
 }
 

--- a/internal/heredocfmt/format_test.go
+++ b/internal/heredocfmt/format_test.go
@@ -179,7 +179,7 @@ func TestFormatShellWrapsMaxLineLength(t *testing.T) {
 		Raw: map[string]string{
 			"indent_style":    "space",
 			"indent_size":     "2",
-			"max_line_length": "48",
+			"max_line_length": "64",
 		},
 	})
 	got, err := formatShell(
@@ -205,7 +205,7 @@ func TestFormatShellWrapsAllWordsAfterBreak(t *testing.T) {
 		Raw: map[string]string{
 			"indent_style":    "space",
 			"indent_size":     "2",
-			"max_line_length": "24",
+			"max_line_length": "28",
 		},
 	})
 	got, err := formatShell("cmd alpha beta gamma delta epsilon zeta\n", shell.VariantPOSIX, st)
@@ -213,7 +213,7 @@ func TestFormatShellWrapsAllWordsAfterBreak(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := "cmd alpha beta gamma \\\n  delta epsilon zeta\n"
+	want := "cmd alpha beta gamma delta \\\n  epsilon zeta\n"
 	if got != want {
 		t.Fatalf("formatted shell mismatch\ngot:\n%s\nwant:\n%s", got, want)
 	}
@@ -228,7 +228,7 @@ func TestFormatShellWrapsMultipartWord(t *testing.T) {
 		Raw: map[string]string{
 			"indent_style":    "space",
 			"indent_size":     "2",
-			"max_line_length": "24",
+			"max_line_length": "32",
 		},
 	})
 	got, err := formatShell("cmd alpha beta prefix${APP_ENV}suffix gamma\n", shell.VariantPOSIX, st)
@@ -236,9 +236,23 @@ func TestFormatShellWrapsMultipartWord(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := "cmd alpha beta \\\n  prefix${APP_ENV}suffix \\\n  gamma\n"
+	want := "cmd alpha beta \\\n  prefix${APP_ENV}suffix gamma\n"
 	if got != want {
 		t.Fatalf("formatted shell mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatShellSkipsWhenMaxLineLengthCannotBeMet(t *testing.T) {
+	t.Parallel()
+
+	st := shellStyleFromDefinition(&editorconfig.Definition{
+		Raw: map[string]string{
+			"max_line_length": "12",
+		},
+	})
+	_, err := formatShell("cmd this_argument_is_too_long_to_wrap\n", shell.VariantPOSIX, st)
+	if !errors.Is(err, errSkipFormat) {
+		t.Fatalf("error = %v, want errSkipFormat", err)
 	}
 }
 

--- a/internal/highlight/shell/tokenize.go
+++ b/internal/highlight/shell/tokenize.go
@@ -147,6 +147,8 @@ func langVariant(variant myshell.Variant) shsyntax.LangVariant {
 		return shsyntax.LangPOSIX
 	case myshell.VariantMksh:
 		return shsyntax.LangMirBSDKorn
+	case myshell.VariantBats:
+		return shsyntax.LangBats
 	case myshell.VariantZsh:
 		return shsyntax.LangZsh
 	case myshell.VariantPowerShell, myshell.VariantCmd, myshell.VariantUnknown:

--- a/internal/integration/__snapshots__/TestFixRealWorld_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFixRealWorld_1.snap.Dockerfile
@@ -77,7 +77,9 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip <<EOF
 set -e
 pip install -U "cython<3.0.0" wheel
 pip install pyyaml==5.4.1 --no-build-isolation
-pip install -U "awscli>1.27,<2" boto3 "click==8.1.2,<9" "cmake>=3.24.3,<3.25" "cryptography>41" ipython "mpi4py>=3.1.4,<3.2" "opencv-python>=4.6.0,<4.7" packaging Pillow "psutil>=5.9.4,<5.10" "pyyaml>=5.4,<5.5"
+pip install -U "awscli>1.27,<2" boto3 "click==8.1.2,<9" "cmake>=3.24.3,<3.25" "cryptography>41" \
+	ipython "mpi4py>=3.1.4,<3.2" "opencv-python>=4.6.0,<4.7" packaging Pillow \
+	"psutil>=5.9.4,<5.10" "pyyaml>=5.4,<5.5"
 EOF
 
 ARG TRITON_VERSION
@@ -211,7 +213,14 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked --mount=type=
 set -e
 apt-get update
 apt-get -y upgrade --only-upgrade systemd
-apt-get install -y --allow-change-held-packages --no-install-recommends build-essential ca-certificates check cmake cuda-command-line-tools-11-7 cuda-cudart-11-7 cuda-libraries-11-7 curl emacs git hwloc jq libcufft-dev-11-7 libcurand-dev-11-7 libcurl4-openssl-dev libcusolver-dev-11-7 libcusparse-dev-11-7 libgl1-mesa-glx libglib2.0-0 libgomp1 libhwloc-dev libibverbs-dev libnuma-dev libnuma1 libsm6 libssl-dev libssl3 libsubunit-dev libsubunit0 libtool libxext6 libxrender-dev openssl pkg-config python3-dev unzip vim wget zlib1g-dev libcublas-11-7=${CUBLAS_VERSION}-1 libcublas-dev-11-7=${CUBLAS_VERSION}-1 libcudnn8=$CUDNN_VERSION-1+cuda11.7
+apt-get install -y --allow-change-held-packages --no-install-recommends build-essential \
+	ca-certificates check cmake cuda-command-line-tools-11-7 cuda-cudart-11-7 \
+	cuda-libraries-11-7 curl emacs git hwloc jq libcufft-dev-11-7 libcurand-dev-11-7 \
+	libcurl4-openssl-dev libcusolver-dev-11-7 libcusparse-dev-11-7 libgl1-mesa-glx libglib2.0-0 \
+	libgomp1 libhwloc-dev libibverbs-dev libnuma-dev libnuma1 libsm6 libssl-dev libssl3 \
+	libsubunit-dev libsubunit0 libtool libxext6 libxrender-dev openssl pkg-config python3-dev \
+	unzip vim wget zlib1g-dev libcublas-11-7=${CUBLAS_VERSION}-1 \
+	libcublas-dev-11-7=${CUBLAS_VERSION}-1 libcudnn8=$CUDNN_VERSION-1+cuda11.7
 EOF
 
 ADD --link https://github.com/NVIDIA/nccl.git?ref=v${NCCL_VERSION}-1 /tmp/nccl
@@ -316,7 +325,8 @@ pip install pyOpenSSL --upgrade
 EOF
 RUN <<EOF
 set -e
-/opt/conda/bin/conda install -y -c conda-forge accelerate charset-normalizer conda-content-trust cython h5py libgcc mkl mkl-include parso pyopenssl requests typing
+/opt/conda/bin/conda install -y -c conda-forge accelerate charset-normalizer conda-content-trust \
+	cython h5py libgcc mkl mkl-include parso pyopenssl requests typing
 /opt/conda/bin/conda install -c dglteam -y dgl-cuda11.7=0.9.1
 /opt/conda/bin/conda install -c pytorch -y magma-cuda117
 /opt/conda/bin/conda install -c fastai fastai
@@ -392,7 +402,8 @@ RUN <<EOF
 set -e
 cd /tmp/efa-ofi-nccl/aws-ofi-nccl
 ./autogen.sh
-./configure --with-libfabric=/opt/amazon/efa --with-mpi=/opt/amazon/openmpi --with-cuda=/usr/local/cuda --with-nccl=/usr/local --prefix=/usr/local
+./configure --with-libfabric=/opt/amazon/efa --with-mpi=/opt/amazon/openmpi \
+	--with-cuda=/usr/local/cuda --with-nccl=/usr/local --prefix=/usr/local
 make
 make install
 rm -rf /tmp/efa-ofi-nccl
@@ -516,7 +527,8 @@ WORKDIR /
 RUN <<EOF
 set -e
 HOME_DIR=/root
-curl --location -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip
+curl --location -o ${HOME_DIR}/oss_compliance.zip \
+	https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip
 unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/
 cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance
 chmod +x /usr/local/bin/testOSSCompliance
@@ -538,7 +550,8 @@ EOF
 RUN <<EOF
 set -e
 HOME_DIR=/root
-curl --location -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip
+curl --location -o ${HOME_DIR}/oss_compliance.zip \
+	https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip
 unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/
 cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance
 chmod +x /usr/local/bin/testOSSCompliance

--- a/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-formats-generated-shell_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_prefer-copy-heredoc-formats-generated-shell_1.snap.Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+
+COPY <<EOF /usr/local/bin/entrypoint.sh
+if true; then
+	echo hi
+fi
+EOF

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -916,7 +916,7 @@ RUN printf 'zend_extension=opcache\n[opcache]\nopcache.enable=1\n' > /etc/app/ph
 				"--fix",
 				"--select", "tally/prefer-package-cache-mounts",
 			},
-			wantApplied: 1,
+			wantApplied: 2,
 		},
 		{
 			name: "prefer-package-cache-mounts-apt-heredoc-mutated-plus-new-mount",

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -623,6 +623,18 @@ severity = "error"
 			)...),
 			wantApplied: 2,
 		},
+		{
+			name:  "prefer-copy-heredoc-formats-generated-shell",
+			input: "FROM ubuntu:22.04\nRUN printf 'if true; then\\n echo hi\\nfi\\n' > /usr/local/bin/entrypoint.sh\n",
+			args: append([]string{
+				"--fix-unsafe",
+				"--fix",
+			}, mustSelectRules(
+				"tally/prefer-copy-heredoc",
+				"tally/prefer-formatted-heredocs",
+			)...),
+			wantApplied: 2,
+		},
 		// Mixed finalizer coverage: pre-existing COPY/ADD heredocs are formatted
 		// while prefer-copy-heredoc injects new COPY heredocs in the same fix run.
 		{

--- a/internal/rules/hadolint/dl4001.go
+++ b/internal/rules/hadolint/dl4001.go
@@ -836,6 +836,8 @@ func dl4001ShellVariant(variant shell.Variant) string {
 		return "sh"
 	case shell.VariantMksh:
 		return "mksh"
+	case shell.VariantBats:
+		return "bats"
 	case shell.VariantZsh:
 		return "zsh"
 	case shell.VariantPowerShell:

--- a/internal/rules/hadolint/dl4001_fix.go
+++ b/internal/rules/hadolint/dl4001_fix.go
@@ -603,6 +603,8 @@ func variantFromFact(name string) shell.Variant {
 		return shell.VariantPOSIX
 	case "mksh", "ksh":
 		return shell.VariantMksh
+	case "bats":
+		return shell.VariantBats
 	case "zsh":
 		return shell.VariantZsh
 	case "powershell", "pwsh":

--- a/internal/rules/shellcheck/shellcheck.go
+++ b/internal/rules/shellcheck/shellcheck.go
@@ -907,9 +907,11 @@ func isAllowedShebang(script string) bool {
 	allowed := []string{
 		"#!/bin/sh",
 		"#!/bin/bash",
+		"#!/usr/bin/bats",
 		"#!/bin/ksh",
 		"#!/usr/bin/env sh",
 		"#!/usr/bin/env bash",
+		"#!/usr/bin/env bats",
 		"#!/usr/bin/env ksh",
 	}
 	return slices.Contains(allowed, line)

--- a/internal/rules/shellcheck/shellcheck.go
+++ b/internal/rules/shellcheck/shellcheck.go
@@ -18,8 +18,9 @@ import (
 	intshellcheck "github.com/wharflab/tally/internal/shellcheck"
 	"github.com/wharflab/tally/internal/sourcemap"
 
-	"github.com/wharflab/tally/internal/rules"
 	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/wharflab/tally/internal/rules"
 )
 
 const (
@@ -879,7 +880,7 @@ func shellcheckDialect(shellName string) string {
 	name = strings.TrimSuffix(name, ".exe")
 
 	switch name {
-	case "bash", "zsh":
+	case "bash", "bats", "zsh":
 		return shellDialectBash
 	case "sh":
 		return "sh"

--- a/internal/rules/shellcheck/shellcheck_test.go
+++ b/internal/rules/shellcheck/shellcheck_test.go
@@ -104,6 +104,19 @@ func TestShellcheckDialect(t *testing.T) {
 	}
 }
 
+func TestIsAllowedShebangAcceptsBats(t *testing.T) {
+	t.Parallel()
+
+	for _, script := range []string{
+		"#!/usr/bin/bats\n@test \"demo\" { run true; }\n",
+		"#!/usr/bin/env bats\n@test \"demo\" { run true; }\n",
+	} {
+		if !isAllowedShebang(script) {
+			t.Fatalf("expected bats shebang to be allowed: %q", script)
+		}
+	}
+}
+
 func TestCheckShellSnippetReportsViolationOnFallbackLocation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/shellcheck/shellcheck_test.go
+++ b/internal/rules/shellcheck/shellcheck_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
 	"github.com/wharflab/tally/internal/directive"
 	"github.com/wharflab/tally/internal/dockerfile"
 	"github.com/wharflab/tally/internal/rules"
@@ -82,6 +83,7 @@ func TestShellcheckDialect(t *testing.T) {
 		{name: "default", shellName: "", want: "sh"},
 		{name: "sh", shellName: "/bin/sh", want: "sh"},
 		{name: "bash", shellName: "/bin/bash", want: "bash"},
+		{name: "bats-maps-to-bash", shellName: "/usr/bin/bats", want: "bash"},
 		{name: "windows-bash", shellName: `C:\Program Files\Git\bin\bash.exe`, want: "bash"},
 		{name: "zsh-maps-to-bash", shellName: "/usr/bin/zsh", want: "bash"},
 		{name: "dash", shellName: "/bin/dash", want: "dash"},

--- a/internal/rules/tally/prefer_formatted_heredocs.go
+++ b/internal/rules/tally/prefer_formatted_heredocs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
 	"github.com/wharflab/tally/internal/dockerfile"
@@ -33,7 +34,7 @@ func (r *PreferFormattedHeredocsRule) Metadata() rules.RuleMetadata {
 	return rules.RuleMetadata{
 		Code:            rules.FormattedHeredocsRuleCode,
 		Name:            "Prefer formatted heredocs",
-		Description:     "Pretty-print COPY/ADD typed heredocs and RUN shell heredocs",
+		Description:     "Pretty-print typed heredocs and shell heredocs",
 		DocURL:          rules.TallyDocURL(rules.FormattedHeredocsRuleCode),
 		DefaultSeverity: rules.SeverityStyle,
 		Category:        "style",
@@ -69,21 +70,53 @@ func (r *PreferFormattedHeredocsRule) Check(input rules.LintInput) []rules.Viola
 
 	for _, doc := range heredocfmt.CollectDockerfileHeredocs(parseResult) {
 		formatted, kind, ok, err := formatter.FormatTarget(doc.TargetPath, doc.Content)
+		if err != nil {
+			continue
+		}
+		if kind != "" {
+			if !ok || formatted == doc.Content {
+				continue
+			}
+
+			loc := rules.NewRangeLocation(input.File, doc.BodyStartLine, 0, doc.TerminatorLine, 0)
+			message := fmt.Sprintf(
+				"%s heredoc for %s should be pretty-printed as %s",
+				doc.Instruction,
+				doc.TargetPath,
+				strings.ToUpper(string(kind)),
+			)
+			v := rules.NewViolation(loc, meta.Code, message, meta.DefaultSeverity).
+				WithDocURL(meta.DocURL).
+				WithSuggestedFix(&rules.SuggestedFix{
+					Description: "Pretty-print heredoc body",
+					Safety:      rules.FixSafe,
+					Priority:    meta.FixPriority,
+					Edits: []rules.TextEdit{
+						{
+							Location: loc,
+							NewText:  heredocfmt.WithBodyPrefix(formatted, doc.BodyPrefix),
+						},
+					},
+					IsPreferred: true,
+				})
+			violations = append(violations, v)
+			continue
+		}
+
+		if !strings.EqualFold(doc.Instruction, command.Copy) {
+			continue
+		}
+		formatted, _, ok, err = formatter.FormatShellTarget(doc.TargetPath, doc.Content)
 		if err != nil || !ok || formatted == doc.Content {
 			continue
 		}
 
 		loc := rules.NewRangeLocation(input.File, doc.BodyStartLine, 0, doc.TerminatorLine, 0)
-		message := fmt.Sprintf(
-			"%s heredoc for %s should be pretty-printed as %s",
-			doc.Instruction,
-			doc.TargetPath,
-			strings.ToUpper(string(kind)),
-		)
+		message := doc.Instruction + " heredoc for " + doc.TargetPath + " should be pretty-printed as a shell script"
 		v := rules.NewViolation(loc, meta.Code, message, meta.DefaultSeverity).
 			WithDocURL(meta.DocURL).
 			WithSuggestedFix(&rules.SuggestedFix{
-				Description: "Pretty-print heredoc body",
+				Description: "Pretty-print COPY shell heredoc body",
 				Safety:      rules.FixSafe,
 				Priority:    meta.FixPriority,
 				Edits: []rules.TextEdit{

--- a/internal/rules/tally/prefer_formatted_heredocs.go
+++ b/internal/rules/tally/prefer_formatted_heredocs.go
@@ -190,7 +190,7 @@ func shellFromHeredocShebang(content string) (string, bool) {
 	if name, ok := shell.ShellFromShebang(firstLine); ok {
 		return name, true
 	}
-	if strings.HasPrefix(strings.TrimSpace(firstLine), "#!") {
+	if strings.HasPrefix(firstLine, "#!") {
 		return "", true
 	}
 	return "", false

--- a/internal/rules/tally/prefer_formatted_heredocs.go
+++ b/internal/rules/tally/prefer_formatted_heredocs.go
@@ -6,13 +6,11 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/command"
-	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
 	"github.com/wharflab/tally/internal/dockerfile"
 	"github.com/wharflab/tally/internal/heredocfmt"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/rules/configutil"
-	"github.com/wharflab/tally/internal/shell"
 )
 
 // PreferFormattedHeredocsRule implements heredoc body pretty-printing.
@@ -131,7 +129,7 @@ func (r *PreferFormattedHeredocsRule) Check(input rules.LintInput) []rules.Viola
 	}
 
 	for _, doc := range heredocfmt.CollectRunHeredocs(parseResult) {
-		variant := runHeredocShellVariant(input, doc)
+		variant := heredocfmt.RunHeredocShellVariant(input.Stages, input.Semantic, doc)
 		if !variant.SupportsPOSIXShellAST() {
 			continue
 		}
@@ -161,49 +159,6 @@ func (r *PreferFormattedHeredocsRule) Check(input rules.LintInput) []rules.Viola
 	}
 
 	return violations
-}
-
-func runHeredocShellVariant(input rules.LintInput, doc heredocfmt.RunHeredoc) shell.Variant {
-	if name, ok := shellFromHeredocShebang(doc.Content); ok {
-		return shell.VariantFromShell(name)
-	}
-	if doc.ShellNameOverride != "" {
-		return shell.VariantFromShell(doc.ShellNameOverride)
-	}
-	if input.Semantic == nil {
-		return shell.VariantUnknown
-	}
-
-	stageIdx := stageIndexAtLine(input.Stages, doc.StartLine)
-	if stageIdx < 0 {
-		return shell.VariantUnknown
-	}
-	info := input.Semantic.StageInfo(stageIdx)
-	if info == nil {
-		return shell.VariantUnknown
-	}
-	return info.ShellVariantAtLine(doc.StartLine)
-}
-
-func shellFromHeredocShebang(content string) (string, bool) {
-	firstLine, _, _ := strings.Cut(content, "\n")
-	if name, ok := shell.ShellFromShebang(firstLine); ok {
-		return name, true
-	}
-	if strings.HasPrefix(firstLine, "#!") {
-		return "", true
-	}
-	return "", false
-}
-
-func stageIndexAtLine(stages []instructions.Stage, line int) int {
-	stageIdx := -1
-	for i, stage := range stages {
-		if len(stage.Location) > 0 && stage.Location[0].Start.Line <= line {
-			stageIdx = i
-		}
-	}
-	return stageIdx
 }
 
 func init() {

--- a/internal/rules/tally/prefer_formatted_heredocs.go
+++ b/internal/rules/tally/prefer_formatted_heredocs.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
 	"github.com/wharflab/tally/internal/dockerfile"
 	"github.com/wharflab/tally/internal/heredocfmt"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/rules/configutil"
+	"github.com/wharflab/tally/internal/shell"
 )
 
-// PreferFormattedHeredocsRule implements heredoc body pretty-printing for typed files.
+// PreferFormattedHeredocsRule implements heredoc body pretty-printing.
 type PreferFormattedHeredocsRule struct {
 	schema map[string]any
 }
@@ -30,7 +33,7 @@ func (r *PreferFormattedHeredocsRule) Metadata() rules.RuleMetadata {
 	return rules.RuleMetadata{
 		Code:            rules.FormattedHeredocsRuleCode,
 		Name:            "Prefer formatted heredocs",
-		Description:     "Pretty-print COPY/ADD heredocs for JSON, YAML, TOML, and XML files",
+		Description:     "Pretty-print COPY/ADD typed heredocs and RUN shell heredocs",
 		DocURL:          rules.TallyDocURL(rules.FormattedHeredocsRuleCode),
 		DefaultSeverity: rules.SeverityStyle,
 		Category:        "style",
@@ -94,7 +97,80 @@ func (r *PreferFormattedHeredocsRule) Check(input rules.LintInput) []rules.Viola
 		violations = append(violations, v)
 	}
 
+	for _, doc := range heredocfmt.CollectRunHeredocs(parseResult) {
+		variant := runHeredocShellVariant(input, doc)
+		if !variant.SupportsPOSIXShellAST() {
+			continue
+		}
+
+		formatted, ok, err := formatter.FormatShell(doc.Content, variant)
+		if err != nil || !ok || formatted == doc.Content {
+			continue
+		}
+
+		loc := rules.NewRangeLocation(input.File, doc.BodyStartLine, 0, doc.TerminatorLine, 0)
+		message := doc.Instruction + " heredoc should be pretty-printed as a shell script"
+		v := rules.NewViolation(loc, meta.Code, message, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithSuggestedFix(&rules.SuggestedFix{
+				Description: "Pretty-print RUN heredoc body",
+				Safety:      rules.FixSafe,
+				Priority:    meta.FixPriority,
+				Edits: []rules.TextEdit{
+					{
+						Location: loc,
+						NewText:  heredocfmt.WithBodyPrefix(formatted, doc.BodyPrefix),
+					},
+				},
+				IsPreferred: true,
+			})
+		violations = append(violations, v)
+	}
+
 	return violations
+}
+
+func runHeredocShellVariant(input rules.LintInput, doc heredocfmt.RunHeredoc) shell.Variant {
+	if name, ok := shellFromHeredocShebang(doc.Content); ok {
+		return shell.VariantFromShell(name)
+	}
+	if doc.ShellNameOverride != "" {
+		return shell.VariantFromShell(doc.ShellNameOverride)
+	}
+	if input.Semantic == nil {
+		return shell.VariantBash
+	}
+
+	stageIdx := stageIndexAtLine(input.Stages, doc.StartLine)
+	if stageIdx < 0 {
+		return shell.VariantBash
+	}
+	info := input.Semantic.StageInfo(stageIdx)
+	if info == nil {
+		return shell.VariantBash
+	}
+	return info.ShellVariantAtLine(doc.StartLine)
+}
+
+func shellFromHeredocShebang(content string) (string, bool) {
+	firstLine, _, _ := strings.Cut(content, "\n")
+	if name, ok := shell.ShellFromShebang(firstLine); ok {
+		return name, true
+	}
+	if strings.HasPrefix(strings.TrimSpace(firstLine), "#!") {
+		return "", true
+	}
+	return "", false
+}
+
+func stageIndexAtLine(stages []instructions.Stage, line int) int {
+	stageIdx := -1
+	for i, stage := range stages {
+		if len(stage.Location) > 0 && stage.Location[0].Start.Line <= line {
+			stageIdx = i
+		}
+	}
+	return stageIdx
 }
 
 func init() {

--- a/internal/rules/tally/prefer_formatted_heredocs.go
+++ b/internal/rules/tally/prefer_formatted_heredocs.go
@@ -171,16 +171,16 @@ func runHeredocShellVariant(input rules.LintInput, doc heredocfmt.RunHeredoc) sh
 		return shell.VariantFromShell(doc.ShellNameOverride)
 	}
 	if input.Semantic == nil {
-		return shell.VariantBash
+		return shell.VariantUnknown
 	}
 
 	stageIdx := stageIndexAtLine(input.Stages, doc.StartLine)
 	if stageIdx < 0 {
-		return shell.VariantBash
+		return shell.VariantUnknown
 	}
 	info := input.Semantic.StageInfo(stageIdx)
 	if info == nil {
-		return shell.VariantBash
+		return shell.VariantUnknown
 	}
 	return info.ShellVariantAtLine(doc.StartLine)
 }

--- a/internal/rules/tally/prefer_formatted_heredocs_test.go
+++ b/internal/rules/tally/prefer_formatted_heredocs_test.go
@@ -30,17 +30,9 @@ func TestPreferFormattedHeredocsRule_Metadata(t *testing.T) {
 func TestRunHeredocShellVariantUnknownWithoutSemanticMetadata(t *testing.T) {
 	t.Parallel()
 
-	got := runHeredocShellVariant(rules.LintInput{}, heredocfmt.RunHeredoc{StartLine: 2})
+	got := heredocfmt.RunHeredocShellVariant(nil, nil, heredocfmt.RunHeredoc{StartLine: 2})
 	if got != shell.VariantUnknown {
 		t.Fatalf("variant = %v, want %v", got, shell.VariantUnknown)
-	}
-}
-
-func TestShellFromHeredocShebangIgnoresIndentedShebangComment(t *testing.T) {
-	t.Parallel()
-
-	if got, ok := shellFromHeredocShebang("  #!/usr/bin/env bash\necho hi\n"); ok {
-		t.Fatalf("shellFromHeredocShebang() = %q, true; want no shebang", got)
 	}
 }
 

--- a/internal/rules/tally/prefer_formatted_heredocs_test.go
+++ b/internal/rules/tally/prefer_formatted_heredocs_test.go
@@ -36,6 +36,14 @@ func TestRunHeredocShellVariantUnknownWithoutSemanticMetadata(t *testing.T) {
 	}
 }
 
+func TestShellFromHeredocShebangIgnoresIndentedShebangComment(t *testing.T) {
+	t.Parallel()
+
+	if got, ok := shellFromHeredocShebang("  #!/usr/bin/env bash\necho hi\n"); ok {
+		t.Fatalf("shellFromHeredocShebang() = %q, true; want no shebang", got)
+	}
+}
+
 func TestPreferFormattedHeredocsRule_Check(t *testing.T) {
 	t.Parallel()
 	rule := NewPreferFormattedHeredocsRule()

--- a/internal/rules/tally/prefer_formatted_heredocs_test.go
+++ b/internal/rules/tally/prefer_formatted_heredocs_test.go
@@ -105,6 +105,18 @@ EOF
 			WantMessages:   []string{"RUN heredoc should be pretty-printed as a shell script"},
 		},
 		{
+			Name: "unformatted ONBUILD RUN heredoc",
+			Content: `FROM alpine
+ONBUILD RUN <<EOF
+if true; then
+ echo hi
+fi
+EOF
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"ONBUILD RUN heredoc should be pretty-printed as a shell script"},
+		},
+		{
 			Name: "COPY sh heredoc without shebang",
 			Content: `FROM alpine
 COPY <<EOF /usr/local/bin/entrypoint.sh

--- a/internal/rules/tally/prefer_formatted_heredocs_test.go
+++ b/internal/rules/tally/prefer_formatted_heredocs_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/heredocfmt"
 	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/testutil"
 )
 
@@ -22,6 +24,15 @@ func TestPreferFormattedHeredocsRule_Metadata(t *testing.T) {
 	}
 	if meta.FixPriority != rules.FormattedHeredocsFixPriority {
 		t.Fatalf("FixPriority = %d, want %d", meta.FixPriority, rules.FormattedHeredocsFixPriority)
+	}
+}
+
+func TestRunHeredocShellVariantUnknownWithoutSemanticMetadata(t *testing.T) {
+	t.Parallel()
+
+	got := runHeredocShellVariant(rules.LintInput{}, heredocfmt.RunHeredoc{StartLine: 2})
+	if got != shell.VariantUnknown {
+		t.Fatalf("variant = %v, want %v", got, shell.VariantUnknown)
 	}
 }
 
@@ -281,13 +292,14 @@ func TestPreferFormattedHeredocsRule_FixRUNEditorConfigMaxLineLength(t *testing.
 [*.sh]
 indent_style = space
 indent_size = 2
-max_line_length = 48
+max_line_length = 64
 `); err != nil {
 		t.Fatal(err)
 	}
 	file := filepath.Join(dir, "Dockerfile")
 	content := `FROM alpine
 RUN <<EOF
+#!/bin/sh
 apt-get install -y --no-install-recommends alpha beta gamma delta epsilon zeta
 EOF
 `

--- a/internal/rules/tally/prefer_formatted_heredocs_test.go
+++ b/internal/rules/tally/prefer_formatted_heredocs_test.go
@@ -105,6 +105,52 @@ EOF
 			WantMessages:   []string{"RUN heredoc should be pretty-printed as a shell script"},
 		},
 		{
+			Name: "COPY sh heredoc without shebang",
+			Content: `FROM alpine
+COPY <<EOF /usr/local/bin/entrypoint.sh
+if true; then
+ echo hi
+fi
+EOF
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"COPY heredoc for /usr/local/bin/entrypoint.sh should be pretty-printed as a shell script"},
+		},
+		{
+			Name: "COPY extensionless shell heredoc with shebang",
+			Content: `FROM alpine
+COPY <<EOF /usr/local/bin/entrypoint
+#!/usr/bin/env bash
+if true; then
+ echo hi
+fi
+EOF
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"COPY heredoc for /usr/local/bin/entrypoint should be pretty-printed as a shell script"},
+		},
+		{
+			Name: "ADD sh heredoc is skipped",
+			Content: `FROM alpine
+ADD <<EOF /usr/local/bin/entrypoint.sh
+if true; then
+ echo hi
+fi
+EOF
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "COPY sh heredoc with unsupported shebang is skipped",
+			Content: `FROM alpine
+COPY <<EOF /usr/local/bin/entrypoint.sh
+#!/usr/bin/env python
+print("hi")
+EOF
+`,
+			WantViolations: 0,
+		},
+		{
 			Name: "RUN heredoc stdin payload is skipped",
 			Content: `FROM alpine
 RUN cat <<EOF
@@ -177,6 +223,34 @@ EOF
 	got := string(fix.ApplyFix([]byte(content), violations[0].PreferredFix()))
 	want := `FROM alpine
 RUN <<EOF
+if true; then
+	echo hi
+fi
+EOF
+`
+	if got != want {
+		t.Fatalf("fixed content mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestPreferFormattedHeredocsRule_FixCOPYShell(t *testing.T) {
+	t.Parallel()
+	content := `FROM alpine
+COPY <<EOF /usr/local/bin/entrypoint.sh
+if true; then
+ echo hi
+fi
+EOF
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewPreferFormattedHeredocsRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+
+	got := string(fix.ApplyFix([]byte(content), violations[0].PreferredFix()))
+	want := `FROM alpine
+COPY <<EOF /usr/local/bin/entrypoint.sh
 if true; then
 	echo hi
 fi

--- a/internal/rules/tally/prefer_formatted_heredocs_test.go
+++ b/internal/rules/tally/prefer_formatted_heredocs_test.go
@@ -93,6 +93,41 @@ EOF
 			WantMessages:   []string{"COPY heredoc for /etc/app/php.ini should be pretty-printed as INI"},
 		},
 		{
+			Name: "unformatted RUN heredoc",
+			Content: `FROM alpine
+RUN <<EOF
+if true; then
+ echo hi
+fi
+EOF
+`,
+			WantViolations: 1,
+			WantMessages:   []string{"RUN heredoc should be pretty-printed as a shell script"},
+		},
+		{
+			Name: "RUN heredoc stdin payload is skipped",
+			Content: `FROM alpine
+RUN cat <<EOF
+if true; then
+ echo hi
+fi
+EOF
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "PowerShell RUN heredoc is skipped",
+			Content: `FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022
+SHELL ["pwsh", "-Command"]
+RUN <<EOF
+if ($true) {
+ Write-Host hi
+}
+EOF
+`,
+			WantViolations: 0,
+		},
+		{
 			Name: "already formatted JSON",
 			Content: `FROM alpine
 COPY <<EOF /etc/app/config.json
@@ -122,6 +157,64 @@ EOF
 			WantViolations: 0,
 		},
 	})
+}
+
+func TestPreferFormattedHeredocsRule_FixRUN(t *testing.T) {
+	t.Parallel()
+	content := `FROM alpine
+RUN <<EOF
+if true; then
+ echo hi
+fi
+EOF
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewPreferFormattedHeredocsRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+
+	got := string(fix.ApplyFix([]byte(content), violations[0].PreferredFix()))
+	want := `FROM alpine
+RUN <<EOF
+if true; then
+	echo hi
+fi
+EOF
+`
+	if got != want {
+		t.Fatalf("fixed content mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestPreferFormattedHeredocsRule_FixRUNEditorConfigMaxLineLength(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := writeTestFile(filepath.Join(dir, ".editorconfig"), `root = true
+
+[*.sh]
+indent_style = space
+indent_size = 2
+max_line_length = 48
+`); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(dir, "Dockerfile")
+	content := `FROM alpine
+RUN <<EOF
+apt-get install -y --no-install-recommends alpha beta gamma delta epsilon zeta
+EOF
+`
+	input := testutil.MakeLintInput(t, file, content)
+	violations := NewPreferFormattedHeredocsRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+
+	got := string(fix.ApplyFix([]byte(content), violations[0].PreferredFix()))
+	if !strings.Contains(got, "\\\n  ") {
+		t.Fatalf("expected wrapped shell command with 2-space continuation, got:\n%s", got)
+	}
 }
 
 func TestPreferFormattedHeredocsRule_FixJSON(t *testing.T) {

--- a/internal/shell/explicit_shell.go
+++ b/internal/shell/explicit_shell.go
@@ -37,7 +37,7 @@ func ParseExplicitShellInvocation(script string) (ExplicitShellInvocation, bool)
 		return parsePowerShellInvocation(script, next, shellName)
 	case VariantCmd:
 		return parseCmdInvocation(script, next, shellName)
-	case VariantBash, VariantPOSIX, VariantMksh, VariantZsh:
+	case VariantBash, VariantPOSIX, VariantMksh, VariantBats, VariantZsh:
 		return parsePOSIXShellInvocation(script, next, shellName, variant)
 	default:
 		return ExplicitShellInvocation{}, false

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -24,6 +24,8 @@ const (
 	VariantPOSIX
 	// VariantMksh is the MirBSD Korn Shell.
 	VariantMksh
+	// VariantBats is the Bash Automated Testing System shell dialect.
+	VariantBats
 	// VariantZsh is the Z shell.
 	VariantZsh
 	// VariantPowerShell is PowerShell (cross-platform: powershell on Windows, pwsh on Linux/macOS).
@@ -38,19 +40,19 @@ const (
 	// variantParser are shells with a dedicated parser backend wired into Tally.
 	// This is the generic "can we build a syntax tree?" capability used by rules
 	// that only need structured commands, not POSIX-specific shell semantics.
-	variantParser = VariantBash | VariantPOSIX | VariantMksh | VariantZsh | VariantPowerShell
+	variantParser = VariantBash | VariantPOSIX | VariantMksh | VariantBats | VariantZsh | VariantPowerShell
 
 	// variantPOSIXShellAST are shells represented by the shared mvdan.cc/sh AST.
 	// Only these variants may use parseScript/toLangVariant and the helpers built
 	// on POSIX shell syntax/semantics.
-	variantPOSIXShellAST = VariantBash | VariantPOSIX | VariantMksh | VariantZsh
+	variantPOSIXShellAST = VariantBash | VariantPOSIX | VariantMksh | VariantBats | VariantZsh
 
 	// variantShellCheck are shells that ShellCheck can analyze
 	// (zsh is mapped to the bash dialect; ShellCheck has no native zsh support).
 	variantShellCheck = VariantBash | VariantPOSIX | VariantMksh | VariantZsh
 
 	// variantHeredoc are shells compatible with BuildKit RUN heredoc syntax.
-	variantHeredoc = VariantBash | VariantPOSIX | VariantMksh | VariantZsh | VariantPowerShell | VariantCmd
+	variantHeredoc = VariantBash | VariantPOSIX | VariantMksh | VariantBats | VariantZsh | VariantPowerShell | VariantCmd
 )
 
 // HasParser returns true for shells with any parser backend wired into Tally.
@@ -78,6 +80,7 @@ func (v Variant) IsPowerShell() bool { return v == VariantPowerShell }
 //   - bash -> VariantBash
 //   - sh, dash, ash -> VariantPOSIX
 //   - mksh, ksh -> VariantMksh
+//   - bats -> VariantBats
 //   - zsh -> VariantZsh
 //   - powershell, pwsh -> VariantPowerShell
 //   - cmd -> VariantCmd
@@ -92,6 +95,8 @@ func VariantFromShell(shell string) Variant {
 		return VariantPOSIX
 	case "mksh", "ksh":
 		return VariantMksh
+	case "bats":
+		return VariantBats
 	case "zsh":
 		return VariantZsh
 	case "powershell", "pwsh":
@@ -169,6 +174,8 @@ func (v Variant) toLangVariant() syntax.LangVariant {
 		return syntax.LangPOSIX
 	case VariantMksh:
 		return syntax.LangMirBSDKorn
+	case VariantBats:
+		return syntax.LangBats
 	case VariantZsh:
 		return syntax.LangZsh
 	default:

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -301,6 +301,8 @@ func TestVariantFromShell(t *testing.T) {
 		{"/bin/mksh", VariantMksh},
 		{"ksh", VariantMksh},
 		{"/bin/ksh", VariantMksh},
+		{"bats", VariantBats},
+		{"/usr/bin/bats", VariantBats},
 		{"zsh", VariantZsh},
 		{"/bin/zsh", VariantZsh},
 		{"powershell", VariantPowerShell},
@@ -493,6 +495,7 @@ func TestToLangVariant(t *testing.T) {
 		{VariantBash, syntax.LangBash},
 		{VariantPOSIX, syntax.LangPOSIX},
 		{VariantMksh, syntax.LangMirBSDKorn},
+		{VariantBats, syntax.LangBats},
 		{VariantZsh, syntax.LangZsh},
 		{VariantPowerShell, syntax.LangBash}, // PowerShell falls back to Bash
 		{VariantCmd, syntax.LangBash},        // Cmd falls back to Bash
@@ -521,6 +524,7 @@ func TestVariantCapabilities(t *testing.T) {
 		{VariantBash, true, true, true, true, false},
 		{VariantPOSIX, true, true, true, true, false},
 		{VariantMksh, true, true, true, true, false},
+		{VariantBats, true, true, false, true, false},
 		{VariantZsh, true, true, true, true, false},
 		{VariantPowerShell, true, false, false, true, true},
 		{VariantCmd, false, false, false, true, false},
@@ -587,6 +591,7 @@ func TestShellFromShebang(t *testing.T) {
 		{"#!/bin/zsh", "zsh", true},
 		{"#!/usr/bin/env zsh", "zsh", true},
 		{"#!/bin/mksh", "mksh", true},
+		{"#!/usr/bin/env bats", "bats", true},
 		{"#!/bin/ksh", "ksh", true},
 		{"#!/usr/bin/env ksh", "ksh", true},
 		{"#!/usr/bin/python3", "", false},


### PR DESCRIPTION
## Summary

- Extend `tally/prefer-formatted-heredocs` to format executable `RUN` heredocs with `mvdan.cc/sh/v3` for supported shell dialects.
- Add EditorConfig-backed shell formatting options, including `max_line_length` with a default of 100 for shell heredocs.
- Format `COPY` shell heredocs when they have a recognized shell shebang, or when the target ends in `.sh` without a shebang, using POSIX shell for the `.sh` fallback.
- Update docs and tests for RUN and COPY shell heredoc behavior.

## Validation

- `GOEXPERIMENT=jsonv2 go test ./internal/heredocfmt ./internal/rules/tally ./internal/fix -count=1`
- `make lint`
- `make cpd`
- `git diff --check`

Note: an earlier full `make test` run failed only in local `internal/ai/acp` timeout tests (`acp initialize: context deadline exceeded`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Formats shell-script heredocs in RUN and COPY instructions, with shebang/extension detection and EditorConfig-aware wrapping.
  * Recognizes and treats the Bats shell variant like POSIX for formatting and linting.

* **Documentation**
  * Expanded docs for shell heredocs: shebang rules, virtual filenames, shell-specific EditorConfig properties, and max-line-length behavior.

* **Tests**
  * Added unit and integration tests covering shell heredoc formatting, wrapping, and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->