### PR TITLE
feat: add Docker CLI plugin support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,26 @@ jobs:
           assert payload["platform"]["arch"] == os.environ["EXPECTED_GOARCH"], payload
           assert payload.get("shellcheckVersion"), f"shellcheckVersion missing or empty: {payload}"
           PY
+          PLUGIN_DIR="$(mktemp -d)"
+          ln -s "$(pwd)/${BINARY}" "${PLUGIN_DIR}/docker-lint"
+          PLUGIN_METADATA_FILE="$(mktemp)"
+          "${PLUGIN_DIR}/docker-lint" docker-cli-plugin-metadata > "${PLUGIN_METADATA_FILE}"
+          cat "${PLUGIN_METADATA_FILE}"
+          python - "${PLUGIN_METADATA_FILE}" <<'PY'
+          import json
+          import os
+          import sys
+
+          metadata_path = sys.argv[1]
+          expected_version = os.environ["EXPECTED_VERSION"].removeprefix("v")
+
+          with open(metadata_path, encoding="utf-8") as fh:
+              payload = json.load(fh)
+
+          assert payload["SchemaVersion"] == "0.1.0", payload
+          assert payload["Vendor"] == "Wharflab", payload
+          assert payload["Version"] == expected_version, payload
+          PY
       - name: Build macOS binary
         if: matrix.runner_os == 'macOS'
         shell: bash
@@ -243,6 +263,34 @@ jobs:
           GOOS="${{ matrix.goos }}" \
           GOARCH="${{ matrix.goarch }}" \
           go build -tags "${BUILD_TAGS}" -trimpath -ldflags "${LDFLAGS}" -o "${DIST_DIR}/${{ matrix.binary_name }}" .
+      - name: Smoke test macOS Docker plugin metadata
+        if: matrix.runner_os == 'macOS'
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ env.RELEASE_VERSION }}
+        run: |
+          set -euo pipefail
+          BINARY="dist/tally_${{ matrix.goos }}_${{ matrix.goarch }}_${{ matrix.variant }}/${{ matrix.binary_name }}"
+          PLUGIN_DIR="$(mktemp -d)"
+          ln -s "$(pwd)/${BINARY}" "${PLUGIN_DIR}/docker-lint"
+          PLUGIN_METADATA_FILE="$(mktemp)"
+          "${PLUGIN_DIR}/docker-lint" docker-cli-plugin-metadata > "${PLUGIN_METADATA_FILE}"
+          cat "${PLUGIN_METADATA_FILE}"
+          python - "${PLUGIN_METADATA_FILE}" <<'PY'
+          import json
+          import os
+          import sys
+
+          metadata_path = sys.argv[1]
+          expected_version = os.environ["EXPECTED_VERSION"].removeprefix("v")
+
+          with open(metadata_path, encoding="utf-8") as fh:
+              payload = json.load(fh)
+
+          assert payload["SchemaVersion"] == "0.1.0", payload
+          assert payload["Vendor"] == "Wharflab", payload
+          assert payload["Version"] == expected_version, payload
+          PY
       - name: Build Windows binary
         if: matrix.runner_os == 'Windows'
         shell: msys2 {0}
@@ -283,6 +331,20 @@ jobs:
           }
           if (-not $payload.shellcheckVersion) {
             throw "shellcheckVersion missing or empty: $versionJson"
+          }
+          $plugin = Join-Path $env:RUNNER_TEMP "docker-lint.exe"
+          Copy-Item $binary $plugin -Force
+          $metadataJson = & $plugin docker-cli-plugin-metadata | Out-String
+          Write-Host $metadataJson
+          $metadata = $metadataJson | ConvertFrom-Json
+          if ($metadata.SchemaVersion -ne "0.1.0") {
+            throw "metadata schema mismatch: $metadataJson"
+          }
+          if ($metadata.Vendor -ne "Wharflab") {
+            throw "metadata vendor mismatch: $metadataJson"
+          }
+          if ($metadata.Version -ne $expectedVersion) {
+            throw "metadata version mismatch: expected=$expectedVersion actual=$($metadata.Version)"
           }
       - name: Import macOS Code Signing Certificate
         if: matrix.goos == 'darwin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1567,14 +1567,14 @@ jobs:
           EXT_TOML="_integrations/zed-tally/extension.toml"
           CARGO_TOML="_integrations/zed-tally/Cargo.toml"
 
-          sed -i "s/^version = .*/version = \"${CLEAN_VERSION}\"/" "${EXT_TOML}"
+          sed -i -E "s/^version[[:space:]]*=.*/version = \"${CLEAN_VERSION}\"/" "${EXT_TOML}"
           ACTUAL="$(taplo get -f "${EXT_TOML}" --strip-newline version)"
           if [ "${ACTUAL}" != "${CLEAN_VERSION}" ]; then
             echo "::error::Failed to set version in extension.toml (expected=${CLEAN_VERSION}, actual=${ACTUAL})"
             exit 1
           fi
 
-          sed -i "0,/^version = .*/s/^version = .*/version = \"${CLEAN_VERSION}\"/" "${CARGO_TOML}"
+          sed -i -E "0,/^version[[:space:]]*=.*/s//version = \"${CLEAN_VERSION}\"/" "${CARGO_TOML}"
           ACTUAL="$(taplo get -f "${CARGO_TOML}" --strip-newline package.version)"
           if [ "${ACTUAL}" != "${CLEAN_VERSION}" ]; then
             echo "::error::Failed to set version in Cargo.toml (expected=${CLEAN_VERSION}, actual=${ACTUAL})"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Modern Dockerfiles deserve modern tooling. tally is opinionated in the right pla
   PowerShell-specific build patterns.
 - **Registry-aware without Docker**: uses a Podman-compatible registry client for image metadata checks (no daemon required).
 - **Editor + CI friendly**: VS Code extension (`wharflab.tally`, powered by `tally lsp`) and outputs for JSON, SARIF, and GitHub Actions annotations.
-- **Easy to install anywhere**: Homebrew, WinGet, Go, npm, uv, pip, and RubyGems.
+- **Easy to install anywhere**: Homebrew, WinGet, Go, npm, Bun, uv, pip, and RubyGems.
 - **Written in Go**: single fast binary, built on production-grade libraries.
 
 Quality bar: **92% code coverage on Codecov** and **2,900+ Go tests executed in CI**.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Modern Dockerfiles deserve modern tooling. tally is opinionated in the right pla
   PowerShell-specific build patterns.
 - **Registry-aware without Docker**: uses a Podman-compatible registry client for image metadata checks (no daemon required).
 - **Editor + CI friendly**: VS Code extension (`wharflab.tally`, powered by `tally lsp`) and outputs for JSON, SARIF, and GitHub Actions annotations.
-- **Easy to install anywhere**: Homebrew, WinGet, Go, npm, pip, and RubyGems.
+- **Easy to install anywhere**: Homebrew, WinGet, Go, npm, uv, pip, and RubyGems.
 - **Written in Go**: single fast binary, built on production-grade libraries.
 
 Quality bar: **92% code coverage on Codecov** and **2,900+ Go tests executed in CI**.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ tally lint .
 
 # Apply all safe fixes automatically
 tally lint --fix Dockerfile
+
+# Register docker lint, then lint a Bake file through Docker
+tally register-docker-plugin && docker lint bake.hcl
 ```
 
 ## Why tally

--- a/_docs/docs.json
+++ b/_docs/docs.json
@@ -48,7 +48,8 @@
           {
             "group": "Integrations",
             "pages": [
-              "integrations/editorconfig"
+              "integrations/editorconfig",
+              "integrations/docker-cli-plugin"
             ]
           }
         ]

--- a/_docs/index.mdx
+++ b/_docs/index.mdx
@@ -16,7 +16,7 @@ tally lint --fix Dockerfile
 
 <CardGroup cols={2}>
   <Card title="Installation" icon="download" href="/installation">
-    Install via Homebrew, npm, uv, pip, RubyGems, WinGet, Go, or Docker.
+    Install via Homebrew, npm, Bun, uv, pip, RubyGems, WinGet, Go, or Docker.
   </Card>
   <Card title="Quick start" icon="rocket" href="/quickstart">
     Lint your first Dockerfile in under a minute.
@@ -70,6 +70,9 @@ tally lint --fix Dockerfile
 
     # npm
     npm install -g tally-cli
+
+    # Bun
+    bun add -g tally-cli
 
     # uv
     uv tool install tally-cli

--- a/_docs/index.mdx
+++ b/_docs/index.mdx
@@ -16,7 +16,7 @@ tally lint --fix Dockerfile
 
 <CardGroup cols={2}>
   <Card title="Installation" icon="download" href="/installation">
-    Install via Homebrew, npm, pip, RubyGems, WinGet, Go, or Docker.
+    Install via Homebrew, npm, uv, pip, RubyGems, WinGet, Go, or Docker.
   </Card>
   <Card title="Quick start" icon="rocket" href="/quickstart">
     Lint your first Dockerfile in under a minute.
@@ -70,6 +70,9 @@ tally lint --fix Dockerfile
 
     # npm
     npm install -g tally-cli
+
+    # uv
+    uv tool install tally-cli
 
     # Go
     go install github.com/wharflab/tally@latest

--- a/_docs/installation.mdx
+++ b/_docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install tally via Homebrew, WinGet, npm, uv, pip, RubyGems, Docker, Go, or from source."
+description: "Install tally via Homebrew, WinGet, npm, Bun, uv, pip, RubyGems, Docker, Go, or from source."
 ---
 
 tally is a single self-contained binary. Pick the method that fits your environment.
@@ -17,6 +17,10 @@ winget install --id Wharflab.Tally
 
 ```bash npm
 npm install -g tally-cli
+```
+
+```bash Bun
+bun add -g tally-cli
 ```
 
 ```bash uv
@@ -63,6 +67,15 @@ npm install -g tally-cli
 ```
 
 Use a global npm install for Docker CLI plugin setup. Project-local `node_modules` installs are rejected by `tally register-docker-plugin`.
+
+## Bun
+
+```bash
+bun add -g tally-cli
+```
+
+Use a global Bun install for Docker CLI plugin setup. `bunx` and project-local `node_modules` launches are rejected by
+`tally register-docker-plugin`.
 
 ## uv
 

--- a/_docs/installation.mdx
+++ b/_docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install tally via Homebrew, WinGet, npm, pip, RubyGems, Docker, Go, or from source."
+description: "Install tally via Homebrew, WinGet, npm, uv, pip, RubyGems, Docker, Go, or from source."
 ---
 
 tally is a single self-contained binary. Pick the method that fits your environment.
@@ -17,6 +17,10 @@ winget install --id Wharflab.Tally
 
 ```bash npm
 npm install -g tally-cli
+```
+
+```bash uv
+uv tool install tally-cli
 ```
 
 ```bash pip
@@ -39,7 +43,10 @@ go install github.com/wharflab/tally@latest
 brew install wharflab/tap/tally
 ```
 
-Homebrew also installs a `docker-lint` symlink for Docker CLI plugin usage. See [Docker CLI plugin](/integrations/docker-cli-plugin) to configure Docker's `cliPluginsExtraDirs`.
+Run `tally register-docker-plugin` if you want Docker to discover the plugin without editing `~/.docker/config.json`.
+
+Homebrew also installs a `docker-lint` symlink under Homebrew's Docker plugin directory. See
+[Docker CLI plugin](/integrations/docker-cli-plugin) if you prefer to configure Docker's `cliPluginsExtraDirs`.
 
 ## WinGet (Windows)
 
@@ -47,11 +54,23 @@ Homebrew also installs a `docker-lint` symlink for Docker CLI plugin usage. See 
 winget install --id Wharflab.Tally
 ```
 
+Run `tally register-docker-plugin` after installation to register the plugin with Docker.
+
 ## npm
 
 ```bash
 npm install -g tally-cli
 ```
+
+Use a global npm install for Docker CLI plugin setup. Project-local `node_modules` installs are rejected by `tally register-docker-plugin`.
+
+## uv
+
+```bash
+uv tool install tally-cli
+```
+
+Use `uv tool install` for Python-managed Docker CLI plugin setup. Project-local virtual environments are rejected by `tally register-docker-plugin`.
 
 ## pip
 
@@ -149,7 +168,13 @@ tally --help
 tally lint --help
 ```
 
-If you configured the Docker CLI plugin, verify that Docker can discover it:
+To enable the Docker CLI plugin, run the registration command from a global tally install:
+
+```bash
+tally register-docker-plugin
+```
+
+Then verify that Docker can discover it:
 
 ```bash
 docker lint --help

--- a/_docs/installation.mdx
+++ b/_docs/installation.mdx
@@ -39,6 +39,8 @@ go install github.com/wharflab/tally@latest
 brew install wharflab/tap/tally
 ```
 
+Homebrew also installs a `docker-lint` symlink for Docker CLI plugin usage. See [Docker CLI plugin](/integrations/docker-cli-plugin) to configure Docker's `cliPluginsExtraDirs`.
+
 ## WinGet (Windows)
 
 ```powershell
@@ -145,6 +147,12 @@ After installing, confirm tally is on your `PATH`:
 ```bash
 tally --help
 tally lint --help
+```
+
+If you configured the Docker CLI plugin, verify that Docker can discover it:
+
+```bash
+docker lint --help
 ```
 
 Check the installed version:

--- a/_docs/installation.mdx
+++ b/_docs/installation.mdx
@@ -83,7 +83,8 @@ Use a global Bun install for Docker CLI plugin setup. `bunx` and project-local `
 uv tool install tally-cli
 ```
 
-Use `uv tool install` for Python-managed Docker CLI plugin setup. Project-local virtual environments are rejected by `tally register-docker-plugin`.
+Use `uv tool install` for Python-managed Docker CLI plugin setup. Active Python virtual environments are rejected by
+`tally register-docker-plugin`.
 
 ## pip
 

--- a/_docs/integrations/docker-cli-plugin.mdx
+++ b/_docs/integrations/docker-cli-plugin.mdx
@@ -28,6 +28,11 @@ npm install -g tally-cli
 tally register-docker-plugin
 ```
 
+```bash Bun
+bun add -g tally-cli
+tally register-docker-plugin
+```
+
 ```bash uv
 uv tool install tally-cli
 tally register-docker-plugin
@@ -35,7 +40,7 @@ tally register-docker-plugin
 
 </CodeGroup>
 
-The command refuses project-local or temporary launches such as `node_modules`, `.venv`, and `go run`. Use a global install before running it.
+The command refuses project-local or temporary launches such as `node_modules`, `bunx`, `.venv`, and `go run`. Use a global install before running it.
 
 During registration, tally runs `docker info --format json`, checks the Docker CLI version, inspects existing Docker CLI plugins, and verifies the
 registration after writing `docker-lint`. If Docker already has a non-tally `lint` plugin, tally stops instead of shadowing it. If an older tally

--- a/_docs/integrations/docker-cli-plugin.mdx
+++ b/_docs/integrations/docker-cli-plugin.mdx
@@ -40,7 +40,8 @@ tally register-docker-plugin
 
 </CodeGroup>
 
-The command refuses project-local or temporary launches such as `node_modules`, `bunx`, `.venv`, and `go run`. Use a global install before running it.
+The command refuses project-local or temporary launches such as `node_modules`, `bunx`, an active Python virtual environment, and `go run`. Use a
+global install before running it.
 
 During registration, tally runs `docker info --format json`, checks the Docker CLI version, inspects existing Docker CLI plugins, and verifies the
 registration after writing `docker-lint`. If Docker already has a non-tally `lint` plugin, tally stops instead of shadowing it. If an older tally

--- a/_docs/integrations/docker-cli-plugin.mdx
+++ b/_docs/integrations/docker-cli-plugin.mdx
@@ -3,7 +3,8 @@ title: "Docker CLI plugin"
 description: "Run tally as docker lint from the Docker CLI."
 ---
 
-The Docker CLI plugin lets you run `tally lint` as `docker lint`. It is a client-side Docker CLI plugin, not a Docker Engine plugin, so it does not install anything into the Docker daemon.
+The Docker CLI plugin lets you run `tally lint` as `docker lint`. It is a client-side Docker CLI plugin, not a Docker Engine plugin, so it does not
+install anything into the Docker daemon.
 
 `docker lint` maps to the lint command only. Use `tally lsp --stdio` for editor integrations and `tally version` for full standalone version details.
 
@@ -86,7 +87,8 @@ docker lint --help
 
 On Windows, repeat the copy after upgrading tally unless your installer manages the plugin file for you.
 
-Homebrew also installs a `docker-lint` symlink under its own Docker plugin directory. If you prefer to use that Homebrew-managed file, add Homebrew's plugin directory to `~/.docker/config.json`:
+Homebrew also installs a `docker-lint` symlink under its own Docker plugin directory. If you prefer to use that Homebrew-managed file, add Homebrew's
+plugin directory to `~/.docker/config.json`:
 
 ```json
 {
@@ -124,7 +126,8 @@ The first command selects Docker's current context. The second command passes ta
 
 ### `docker: 'lint' is not a docker command`
 
-Docker did not find `docker-lint`. Check that the file exists in one of Docker's CLI plugin directories or in a directory listed by `cliPluginsExtraDirs`.
+Docker did not find `docker-lint`. Check that the file exists in one of Docker's CLI plugin directories or in a directory listed by
+`cliPluginsExtraDirs`.
 
 ```bash
 ls ~/.docker/cli-plugins/docker-lint
@@ -140,11 +143,13 @@ Run the metadata command directly:
 ~/.docker/cli-plugins/docker-lint docker-cli-plugin-metadata
 ```
 
-The output should be JSON with `"SchemaVersion": "0.1.0"` and `"Vendor": "Wharflab"`. If it prints normal tally help instead, the file is not named `docker-lint`.
+The output should be JSON with `"SchemaVersion": "0.1.0"` and `"Vendor": "Wharflab"`. If it prints normal tally help instead, the file is not named
+`docker-lint`.
 
 ### Wrong architecture binary
 
-Use a tally binary that matches your operating system and CPU architecture. This matters when copying binaries manually between machines or between Intel and Apple Silicon Macs.
+Use a tally binary that matches your operating system and CPU architecture. This matters when copying binaries manually between machines or between
+Intel and Apple Silicon Macs.
 
 ### Missing execute bit on macOS/Linux
 
@@ -156,10 +161,12 @@ chmod +x ~/.docker/cli-plugins/docker-lint
 
 ### Command name conflict
 
-`lint` is a generic plugin command name. If another `docker-lint` exists earlier in Docker's plugin search path, Docker may run that plugin instead. Remove the conflicting file or adjust `cliPluginsExtraDirs`.
+`lint` is a generic plugin command name. If another `docker-lint` exists earlier in Docker's plugin search path, Docker may run that plugin instead.
+Remove the conflicting file or adjust `cliPluginsExtraDirs`.
 
 ## Limitations
 
 `docker lint` exposes linting only. It does not expose `tally lsp` or `tally version` as Docker subcommands.
 
-WinGet exposes `docker-lint` as a command alias, but Docker does not search `PATH` for CLI plugins. Run `tally register-docker-plugin` after installing or upgrading tally through WinGet.
+WinGet exposes `docker-lint` as a command alias, but Docker does not search `PATH` for CLI plugins. Run `tally register-docker-plugin` after
+installing or upgrading tally through WinGet.

--- a/_docs/integrations/docker-cli-plugin.mdx
+++ b/_docs/integrations/docker-cli-plugin.mdx
@@ -7,25 +7,44 @@ The Docker CLI plugin lets you run `tally lint` as `docker lint`. It is a client
 
 `docker lint` maps to the lint command only. Use `tally lsp --stdio` for editor integrations and `tally version` for full standalone version details.
 
-## Install with Homebrew
+## Install
 
-Homebrew installs the `tally` binary and a `docker-lint` plugin symlink.
+Install tally globally, make sure `docker info` works, then ask tally to register the `docker-lint` plugin with Docker.
 
-```bash
+<CodeGroup>
+
+```bash Homebrew
 brew install wharflab/tap/tally
+tally register-docker-plugin
 ```
 
-Add Homebrew's Docker plugin directory to `~/.docker/config.json`:
-
-```json
-{
-  "cliPluginsExtraDirs": [
-    "/opt/homebrew/lib/docker/cli-plugins"
-  ]
-}
+```powershell WinGet
+winget install --id Wharflab.Tally
+tally register-docker-plugin
 ```
 
-Use `/usr/local/lib/docker/cli-plugins` on Intel macOS, or the matching Linuxbrew prefix on Linux.
+```bash npm
+npm install -g tally-cli
+tally register-docker-plugin
+```
+
+```bash uv
+uv tool install tally-cli
+tally register-docker-plugin
+```
+
+</CodeGroup>
+
+The command refuses project-local or temporary launches such as `node_modules`, `.venv`, and `go run`. Use a global install before running it.
+
+During registration, tally runs `docker info --format json`, checks the Docker CLI version, inspects existing Docker CLI plugins, and verifies the
+registration after writing `docker-lint`. If Docker already has a non-tally `lint` plugin, tally stops instead of shadowing it. If an older tally
+plugin is present, tally reports the upgrade. If a newer tally plugin is already registered, tally does not overwrite it unless you pass `--force`.
+
+```text
+Found Docker CLI version 29.4.1
+Upgrading tally lint plugin from version 0.5.6 to 0.7.19
+```
 
 Verify the plugin:
 
@@ -33,9 +52,15 @@ Verify the plugin:
 docker lint --help
 ```
 
-## Manual install
+Use `--dry-run` to inspect the Docker CLI version, source, target path, and existing plugin decision before making changes:
 
-If you installed tally through another package manager, register the same binary as `docker-lint`.
+```bash
+tally register-docker-plugin --dry-run
+```
+
+## Manual fallback
+
+If you cannot use `tally register-docker-plugin`, register the same binary as `docker-lint`.
 
 <CodeGroup>
 
@@ -54,6 +79,18 @@ docker lint --help
 </CodeGroup>
 
 On Windows, repeat the copy after upgrading tally unless your installer manages the plugin file for you.
+
+Homebrew also installs a `docker-lint` symlink under its own Docker plugin directory. If you prefer to use that Homebrew-managed file, add Homebrew's plugin directory to `~/.docker/config.json`:
+
+```json
+{
+  "cliPluginsExtraDirs": [
+    "/opt/homebrew/lib/docker/cli-plugins"
+  ]
+}
+```
+
+Use `/usr/local/lib/docker/cli-plugins` on Intel macOS, or the matching Linuxbrew prefix on Linux.
 
 ## Usage
 
@@ -87,7 +124,7 @@ Docker did not find `docker-lint`. Check that the file exists in one of Docker's
 ls ~/.docker/cli-plugins/docker-lint
 ```
 
-For Homebrew installs, confirm that your Docker config uses the absolute Homebrew prefix path.
+Run `tally register-docker-plugin --dry-run` to confirm where tally will register `docker-lint`.
 
 ### Invalid plugin metadata
 
@@ -119,4 +156,4 @@ chmod +x ~/.docker/cli-plugins/docker-lint
 
 `docker lint` exposes linting only. It does not expose `tally lsp` or `tally version` as Docker subcommands.
 
-WinGet exposes `docker-lint` as a command alias, but Docker does not search `PATH` for CLI plugins. Use the Windows manual install command above to copy the binary into Docker's plugin directory.
+WinGet exposes `docker-lint` as a command alias, but Docker does not search `PATH` for CLI plugins. Run `tally register-docker-plugin` after installing or upgrading tally through WinGet.

--- a/_docs/integrations/docker-cli-plugin.mdx
+++ b/_docs/integrations/docker-cli-plugin.mdx
@@ -1,0 +1,122 @@
+---
+title: "Docker CLI plugin"
+description: "Run tally as docker lint from the Docker CLI."
+---
+
+The Docker CLI plugin lets you run `tally lint` as `docker lint`. It is a client-side Docker CLI plugin, not a Docker Engine plugin, so it does not install anything into the Docker daemon.
+
+`docker lint` maps to the lint command only. Use `tally lsp --stdio` for editor integrations and `tally version` for full standalone version details.
+
+## Install with Homebrew
+
+Homebrew installs the `tally` binary and a `docker-lint` plugin symlink.
+
+```bash
+brew install wharflab/tap/tally
+```
+
+Add Homebrew's Docker plugin directory to `~/.docker/config.json`:
+
+```json
+{
+  "cliPluginsExtraDirs": [
+    "/opt/homebrew/lib/docker/cli-plugins"
+  ]
+}
+```
+
+Use `/usr/local/lib/docker/cli-plugins` on Intel macOS, or the matching Linuxbrew prefix on Linux.
+
+Verify the plugin:
+
+```bash
+docker lint --help
+```
+
+## Manual install
+
+If you installed tally through another package manager, register the same binary as `docker-lint`.
+
+<CodeGroup>
+
+```bash macOS/Linux
+mkdir -p ~/.docker/cli-plugins
+ln -sf "$(command -v tally)" ~/.docker/cli-plugins/docker-lint
+docker lint --help
+```
+
+```powershell Windows
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.docker\cli-plugins"
+Copy-Item (Get-Command tally.exe).Source "$env:USERPROFILE\.docker\cli-plugins\docker-lint.exe" -Force
+docker lint --help
+```
+
+</CodeGroup>
+
+On Windows, repeat the copy after upgrading tally unless your installer manages the plugin file for you.
+
+## Usage
+
+Use `docker lint` the same way you use `tally lint`:
+
+```bash
+docker lint Dockerfile
+docker lint .
+docker lint --format json Dockerfile
+docker lint --fix Dockerfile
+docker lint docker-bake.hcl --target web
+docker lint compose.yaml --service api
+```
+
+Docker global flags go before `lint`. tally flags go after `lint`:
+
+```bash
+docker --context production lint Dockerfile
+docker lint --context . Dockerfile
+```
+
+The first command selects Docker's current context. The second command passes tally's build context option.
+
+## Troubleshooting
+
+### `docker: 'lint' is not a docker command`
+
+Docker did not find `docker-lint`. Check that the file exists in one of Docker's CLI plugin directories or in a directory listed by `cliPluginsExtraDirs`.
+
+```bash
+ls ~/.docker/cli-plugins/docker-lint
+```
+
+For Homebrew installs, confirm that your Docker config uses the absolute Homebrew prefix path.
+
+### Invalid plugin metadata
+
+Run the metadata command directly:
+
+```bash
+~/.docker/cli-plugins/docker-lint docker-cli-plugin-metadata
+```
+
+The output should be JSON with `"SchemaVersion": "0.1.0"` and `"Vendor": "Wharflab"`. If it prints normal tally help instead, the file is not named `docker-lint`.
+
+### Wrong architecture binary
+
+Use a tally binary that matches your operating system and CPU architecture. This matters when copying binaries manually between machines or between Intel and Apple Silicon Macs.
+
+### Missing execute bit on macOS/Linux
+
+Make the plugin executable:
+
+```bash
+chmod +x ~/.docker/cli-plugins/docker-lint
+```
+
+### Command name conflict
+
+`lint` is a generic plugin command name. If another `docker-lint` exists earlier in Docker's plugin search path, Docker may run that plugin instead. Remove the conflicting file or adjust `cliPluginsExtraDirs`.
+
+## Limitations
+
+`docker lint` exposes linting only. It does not expose `tally lsp` or `tally version` as Docker subcommands.
+
+WinGet exposes `docker-lint` as a command alias, but Docker does not search `PATH` for CLI plugins. Use the Windows manual install command above to copy the binary into Docker's plugin directory.

--- a/_docs/integrations/docker-cli-plugin.mdx
+++ b/_docs/integrations/docker-cli-plugin.mdx
@@ -168,5 +168,4 @@ Remove the conflicting file or adjust `cliPluginsExtraDirs`.
 
 `docker lint` exposes linting only. It does not expose `tally lsp` or `tally version` as Docker subcommands.
 
-WinGet exposes `docker-lint` as a command alias, but Docker does not search `PATH` for CLI plugins. Run `tally register-docker-plugin` after
-installing or upgrading tally through WinGet.
+WinGet exposes the `tally` command only. Run `tally register-docker-plugin` after installing or upgrading tally through WinGet.

--- a/_docs/introduction.mdx
+++ b/_docs/introduction.mdx
@@ -17,7 +17,7 @@ tally lint --fix Dockerfile
 
 <CardGroup cols={2}>
   <Card title="Installation" icon="download" href="/installation">
-    Install via Homebrew, WinGet, npm, pip, RubyGems, Docker, or Go.
+    Install via Homebrew, WinGet, npm, uv, pip, RubyGems, Docker, or Go.
   </Card>
   <Card title="Quick start" icon="rocket" href="/quickstart">
     Lint your first Dockerfile in under a minute.
@@ -110,7 +110,7 @@ tools. The Markdown format is optimized for AI agents and token efficiency.
 
 <CardGroup cols={2}>
   <Card title="Install tally" icon="download" href="/installation">
-    Choose your package manager: Homebrew, WinGet, npm, pip, RubyGems, Docker, or Go.
+    Choose your package manager: Homebrew, WinGet, npm, uv, pip, RubyGems, Docker, or Go.
   </Card>
   <Card title="Run your first lint" icon="rocket" href="/quickstart">
     Lint a Dockerfile, read the output, apply fixes, and set up `.tally.toml`.

--- a/_docs/introduction.mdx
+++ b/_docs/introduction.mdx
@@ -17,7 +17,7 @@ tally lint --fix Dockerfile
 
 <CardGroup cols={2}>
   <Card title="Installation" icon="download" href="/installation">
-    Install via Homebrew, WinGet, npm, uv, pip, RubyGems, Docker, or Go.
+    Install via Homebrew, WinGet, npm, Bun, uv, pip, RubyGems, Docker, or Go.
   </Card>
   <Card title="Quick start" icon="rocket" href="/quickstart">
     Lint your first Dockerfile in under a minute.
@@ -110,7 +110,7 @@ tools. The Markdown format is optimized for AI agents and token efficiency.
 
 <CardGroup cols={2}>
   <Card title="Install tally" icon="download" href="/installation">
-    Choose your package manager: Homebrew, WinGet, npm, uv, pip, RubyGems, Docker, or Go.
+    Choose your package manager: Homebrew, WinGet, npm, Bun, uv, pip, RubyGems, Docker, or Go.
   </Card>
   <Card title="Run your first lint" icon="rocket" href="/quickstart">
     Lint a Dockerfile, read the output, apply fixes, and set up `.tally.toml`.

--- a/_docs/quickstart.mdx
+++ b/_docs/quickstart.mdx
@@ -14,6 +14,9 @@ description: "Lint your first Dockerfile in under a minute."
       ```bash npm
       npm install -g tally-cli
       ```
+      ```bash uv
+      uv tool install tally-cli
+      ```
       ```bash pip
       pip install tally-cli
       ```
@@ -38,9 +41,10 @@ description: "Lint your first Dockerfile in under a minute."
 
     tally discovers files matching `Dockerfile`, `Dockerfile.*`, `*.Dockerfile`, `Containerfile`, and `Containerfile.*`.
 
-    If you configured the Docker CLI plugin, the same lint command is available as:
+    To make the same lint command available through Docker, register the Docker CLI plugin:
 
     ```bash
+    tally register-docker-plugin
     docker lint Dockerfile
     ```
   </Step>

--- a/_docs/quickstart.mdx
+++ b/_docs/quickstart.mdx
@@ -14,6 +14,9 @@ description: "Lint your first Dockerfile in under a minute."
       ```bash npm
       npm install -g tally-cli
       ```
+      ```bash Bun
+      bun add -g tally-cli
+      ```
       ```bash uv
       uv tool install tally-cli
       ```

--- a/_docs/quickstart.mdx
+++ b/_docs/quickstart.mdx
@@ -37,6 +37,12 @@ description: "Lint your first Dockerfile in under a minute."
     ```
 
     tally discovers files matching `Dockerfile`, `Dockerfile.*`, `*.Dockerfile`, `Containerfile`, and `Containerfile.*`.
+
+    If you configured the Docker CLI plugin, the same lint command is available as:
+
+    ```bash
+    docker lint Dockerfile
+    ```
   </Step>
 
   <Step title="Lint a Bake or Compose entrypoint">

--- a/cmd/tally/cmd/docker_plugin.go
+++ b/cmd/tally/cmd/docker_plugin.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	dockercli "github.com/docker/cli/cli"
+	"github.com/docker/cli/cli-plugins/metadata"
+	"github.com/docker/cli/cli-plugins/plugin"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/debug"
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+
+	"github.com/wharflab/tally/internal/version"
+)
+
+const dockerLintPluginName = "lint"
+
+// IsDockerLintPluginExecutable reports whether executable should run tally in
+// Docker CLI plugin mode.
+func IsDockerLintPluginExecutable(executable string) bool {
+	base := strings.ToLower(filepath.Base(strings.ReplaceAll(executable, "\\", "/")))
+	base = strings.TrimSuffix(base, ".exe")
+	return base == metadata.NamePrefix+dockerLintPluginName
+}
+
+// ExecuteDockerPlugin runs tally as the docker-lint CLI plugin.
+func ExecuteDockerPlugin() error {
+	otel.SetErrorHandler(debug.OTELErrorHandler)
+
+	dockerCLI, err := command.NewDockerCli()
+	if err != nil {
+		return err
+	}
+	return plugin.RunPlugin(dockerCLI, newDockerLintPluginCommand(dockerCLI), dockerPluginMetadata())
+}
+
+func newDockerLintPluginCommand(dockerCLI command.Cli) *cobra.Command {
+	opts := &lintOptions{}
+	cmd := newLintCommand(opts)
+	cmd.Version = version.Version()
+	cmd.SetVersionTemplate("docker-lint version {{.Version}}\n")
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := plugin.PersistentPreRunE(cmd, args); err != nil {
+			return err
+		}
+		opts.dockerPlugin = dockerPluginContextFrom(dockerCLI)
+		return nil
+	}
+	return cmd
+}
+
+func dockerPluginMetadata() metadata.Metadata {
+	return metadata.Metadata{
+		SchemaVersion:    "0.1.0",
+		Vendor:           "Wharflab",
+		Version:          version.Version(),
+		ShortDescription: "Lint Dockerfiles and Containerfiles",
+		URL:              "https://tally.wharflab.com/",
+	}
+}
+
+func dockerPluginContextFrom(dockerCLI command.Cli) *dockerPluginContext {
+	if dockerCLI == nil {
+		return nil
+	}
+
+	ctx := &dockerPluginContext{
+		CurrentContext: dockerCLI.CurrentContext(),
+	}
+	if cfg := dockerCLI.ConfigFile(); cfg != nil {
+		ctx.ConfigPath = cfg.GetFilename()
+	}
+	if ep := dockerCLI.DockerEndpoint(); ep.Host != "" {
+		ctx.EndpointHost = ep.Host
+	}
+	return ctx
+}
+
+// ExitStatus maps command-layer typed errors to process exit behavior. The
+// optional message is for Docker CLI status errors; ExitError messages are
+// already written by command handlers before returning.
+func ExitStatus(err error) (code int, message string, ok bool) {
+	var exitErr *ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.Code, "", true
+	}
+
+	var statusErr dockercli.StatusError
+	if errors.As(err, &statusErr) {
+		code := statusErr.StatusCode
+		if code == 0 {
+			code = 1
+		}
+		return code, statusErr.Error(), true
+	}
+
+	return 0, "", false
+}

--- a/cmd/tally/cmd/docker_plugin.go
+++ b/cmd/tally/cmd/docker_plugin.go
@@ -56,7 +56,7 @@ func dockerPluginMetadata() metadata.Metadata {
 	return metadata.Metadata{
 		SchemaVersion:    "0.1.0",
 		Vendor:           "Wharflab",
-		Version:          version.Version(),
+		Version:          version.RawVersion(),
 		ShortDescription: "Lint Dockerfiles and Containerfiles",
 		URL:              "https://tally.wharflab.com/",
 	}

--- a/cmd/tally/cmd/docker_plugin.go
+++ b/cmd/tally/cmd/docker_plugin.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"errors"
-	"path/filepath"
+	"path"
 	"strings"
 
 	dockercli "github.com/docker/cli/cli"
@@ -21,7 +21,7 @@ const dockerLintPluginName = "lint"
 // IsDockerLintPluginExecutable reports whether executable should run tally in
 // Docker CLI plugin mode.
 func IsDockerLintPluginExecutable(executable string) bool {
-	base := strings.ToLower(filepath.Base(strings.ReplaceAll(executable, "\\", "/")))
+	base := strings.ToLower(path.Base(strings.ReplaceAll(executable, "\\", "/")))
 	base = strings.TrimSuffix(base, ".exe")
 	return base == metadata.NamePrefix+dockerLintPluginName
 }

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -93,7 +93,7 @@ func registerDockerPluginCommand() *cobra.Command {
 The command registers docker-lint in Docker's per-user CLI plugin directory.
 It does not download Docker, Docker Compose, Docker Buildx, or another tally
 binary. It only runs from persistent global installs such as Homebrew, WinGet,
-global npm installs, uv tool installs, or a direct global binary.`,
+global npm or Bun installs, uv tool installs, or a direct global binary.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			registrar := newDockerPluginRegistrar()
 			out := cmd.OutOrStdout()
@@ -433,7 +433,13 @@ func (r dockerPluginRegistrar) classifySource(source string) (string, error) {
 		if r.isNPMGlobalPath(source) {
 			return "global npm", nil
 		}
-		return "", fmt.Errorf("%s looks like a project-local npm install; run npm install -g tally-cli first", source)
+		if r.isBunGlobalPath(source) {
+			return "global Bun", nil
+		}
+		return "", fmt.Errorf(
+			"%s looks like a project-local npm/Bun install; run npm install -g tally-cli or bun add -g tally-cli first",
+			source,
+		)
 	case looksLikePythonPackagePath(source):
 		if r.isUVToolPath(source) {
 			return "uv tool", nil
@@ -442,6 +448,8 @@ func (r dockerPluginRegistrar) classifySource(source string) (string, error) {
 			"%s looks like a Python virtual environment or package install; use uv tool install tally-cli for automatic plugin registration",
 			source,
 		)
+	case r.isBunGlobalPath(source):
+		return "global Bun", nil
 	case looksLikeGlobalBinaryPath(source):
 		return "global binary", nil
 	default:
@@ -528,7 +536,17 @@ func (r dockerPluginRegistrar) projectRoot() string {
 		return ""
 	}
 	for {
-		for _, marker := range []string{".git", "go.mod", "package.json", "pyproject.toml", "node_modules", ".venv", "venv"} {
+		for _, marker := range []string{
+			".git",
+			"go.mod",
+			"package.json",
+			"pyproject.toml",
+			"bun.lock",
+			"bun.lockb",
+			"node_modules",
+			".venv",
+			"venv",
+		} {
 			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
 				return dir
 			}
@@ -559,6 +577,49 @@ func (r dockerPluginRegistrar) npmGlobalRoots() []string {
 		if out, err := r.commandOut("npm", "root", "-g"); err == nil {
 			roots = appendPathList(roots, out)
 		}
+	}
+	return cleanPathList(roots)
+}
+
+func (r dockerPluginRegistrar) isBunGlobalPath(path string) bool {
+	for _, root := range r.bunGlobalRoots() {
+		if r.pathWithin(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r dockerPluginRegistrar) bunGlobalRoots() []string {
+	var roots []string
+	if v := strings.TrimSpace(os.Getenv("BUN_INSTALL_GLOBAL_DIR")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("TALLY_BUN_GLOBAL_DIR")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("TALLY_BUN_GLOBAL_ROOT")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("BUN_INSTALL_BIN")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("BUN_INSTALL")); v != "" {
+		roots = append(roots,
+			filepath.Join(v, "install", "global"),
+			filepath.Join(v, "bin"),
+		)
+	}
+	if r.commandOut != nil {
+		if out, err := r.commandOut("bun", "pm", "bin", "-g"); err == nil {
+			roots = appendPathList(roots, out)
+		}
+	}
+	if r.homeDir != "" {
+		roots = append(roots,
+			filepath.Join(r.homeDir, ".bun", "install", "global"),
+			filepath.Join(r.homeDir, ".bun", "bin"),
+		)
 	}
 	return cleanPathList(roots)
 }
@@ -769,6 +830,10 @@ func commandOutputWithTimeout(name string, args ...string) (string, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		return commandTextOutput(exec.CommandContext(ctx, "npm", "root", "-g"))
+	case "bun pm bin -g":
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		return commandTextOutput(exec.CommandContext(ctx, "bun", "pm", "bin", "-g"))
 	case "uv tool dir":
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -61,6 +61,7 @@ type dockerPluginRegistrar struct {
 	args0          string
 	currentVersion string
 	virtualEnv     string
+	dirWritable    func(string) bool
 	executable     func() (string, error)
 	lookPath       func(string) (string, error)
 	commandOut     func(string, ...string) (string, error)
@@ -474,8 +475,12 @@ func (r dockerPluginRegistrar) targetPath(
 	}
 
 	name := dockerPluginExecutableName(r.goos)
+	fallbackReason := ""
 	if dir, ok := commonDockerPluginDir(dockerInfo.Plugins); ok {
-		return filepath.Join(dir, name), "existing Docker CLI plugin directory", nil
+		if r.isDirWritable(dir) {
+			return filepath.Join(dir, name), "existing Docker CLI plugin directory", nil
+		}
+		fallbackReason = "inferred Docker CLI plugin directory is not writable"
 	}
 
 	configDir := r.dockerConfig
@@ -485,7 +490,11 @@ func (r dockerPluginRegistrar) targetPath(
 		}
 		configDir = filepath.Join(r.homeDir, ".docker")
 	}
-	return filepath.Join(configDir, "cli-plugins", name), "Docker per-user CLI plugin directory", nil
+	targetReason := "Docker per-user CLI plugin directory"
+	if fallbackReason != "" {
+		targetReason += "; " + fallbackReason
+	}
+	return filepath.Join(configDir, "cli-plugins", name), targetReason, nil
 }
 
 func dockerPluginExecutableName(goos string) string {
@@ -512,6 +521,33 @@ func commonDockerPluginDir(plugins []dockerCLIPluginInfo) (string, bool) {
 		}
 	}
 	return dir, dir != ""
+}
+
+func (r dockerPluginRegistrar) isDirWritable(dir string) bool {
+	if r.dirWritable != nil {
+		return r.dirWritable(dir)
+	}
+	return dirWritable(dir)
+}
+
+func dirWritable(dir string) bool {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	file, err := os.CreateTemp(dir, ".tally-write-test-*")
+	if err != nil {
+		return false
+	}
+	name := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(name)
+		return false
+	}
+	if err := os.Remove(name); err != nil {
+		return false
+	}
+	return true
 }
 
 func (r dockerPluginRegistrar) checkExistingTarget(plan dockerPluginRegistrationPlan) error {

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -1,0 +1,887 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/cobra"
+
+	"github.com/wharflab/tally/internal/version"
+)
+
+const (
+	registerDockerPluginCommandName = "register-docker-plugin"
+	registrationActionDowngrade     = "Downgrading"
+	registrationActionRefresh       = "Refreshing"
+	registrationActionRegister      = "Registering"
+	registrationActionReplace       = "Replacing"
+	registrationActionUpgrade       = "Upgrading"
+	installModeCopy                 = "copy"
+	installModeSymlink              = "symlink"
+	minimumDockerCLIVersion         = "20.10.0"
+	tallyDockerPluginVendor         = "Wharflab"
+	windowsGOOS                     = "windows"
+)
+
+type registerDockerPluginOptions struct {
+	force  bool
+	dryRun bool
+}
+
+type dockerPluginRegistrationPlan struct {
+	SourcePath         string
+	TargetPath         string
+	Mode               string
+	SourceKind         string
+	CurrentVersion     string
+	DockerVersion      string
+	TargetReason       string
+	Action             string
+	ExistingPlugin     *dockerCLIPluginInfo
+	AllowReplaceTarget bool
+}
+
+type dockerPluginRegistrar struct {
+	goos           string
+	homeDir        string
+	cwd            string
+	tempDir        string
+	dockerConfig   string
+	args0          string
+	currentVersion string
+	executable     func() (string, error)
+	lookPath       func(string) (string, error)
+	commandOut     func(string, ...string) (string, error)
+}
+
+type dockerInfoOutput struct {
+	ClientInfo *dockerCLIInfo `json:"ClientInfo"`
+}
+
+type dockerCLIInfo struct {
+	Version string                `json:"Version"`
+	Plugins []dockerCLIPluginInfo `json:"Plugins"`
+}
+
+type dockerCLIPluginInfo struct {
+	Vendor           string `json:"Vendor"`
+	Version          string `json:"Version"`
+	ShortDescription string `json:"ShortDescription"`
+	Name             string `json:"Name"`
+	Path             string `json:"Path"`
+}
+
+func registerDockerPluginCommand() *cobra.Command {
+	opts := &registerDockerPluginOptions{}
+
+	cmd := &cobra.Command{
+		Use:   registerDockerPluginCommandName,
+		Short: "Register tally as the docker lint CLI plugin",
+		Long: `Register tally as the Docker CLI plugin used by docker lint.
+
+The command registers docker-lint in Docker's per-user CLI plugin directory.
+It does not download Docker, Docker Compose, Docker Buildx, or another tally
+binary. It only runs from persistent global installs such as Homebrew, WinGet,
+global npm installs, uv tool installs, or a direct global binary.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registrar := newDockerPluginRegistrar()
+			out := cmd.OutOrStdout()
+
+			dockerInfo, err := registrar.inspectDocker()
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Unable to register tally plugin - %v\n", err)
+				return exitWith(ExitConfigError)
+			}
+			fmt.Fprintf(out, "Found Docker CLI version %s\n", dockerInfo.Version)
+
+			plan, err := registrar.plan(dockerInfo, opts.force)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Unable to register tally plugin - %v\n", err)
+				return exitWith(ExitConfigError)
+			}
+
+			printDockerPluginRegistrationPlan(out, plan, opts.dryRun)
+			if opts.dryRun {
+				return nil
+			}
+
+			if err := registrar.register(plan, opts.force); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Unable to register tally plugin - %v\n", err)
+				return exitWith(ExitConfigError)
+			}
+			verified, err := registrar.verify(plan)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Unable to verify tally plugin registration - %v\n", err)
+				return exitWith(ExitConfigError)
+			}
+			printDockerPluginRegistrationResult(out, plan, verified)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.force, "force", false, "Replace an existing docker-lint file controlled by tally")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Print the registration plan without changing files")
+	return cmd
+}
+
+func newDockerPluginRegistrar() dockerPluginRegistrar {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	return dockerPluginRegistrar{
+		goos:           runtime.GOOS,
+		homeDir:        home,
+		cwd:            cwd,
+		tempDir:        os.TempDir(),
+		dockerConfig:   os.Getenv("DOCKER_CONFIG"),
+		args0:          os.Args[0],
+		currentVersion: version.RawVersion(),
+		executable:     os.Executable,
+		lookPath:       exec.LookPath,
+		commandOut:     commandOutputWithTimeout,
+	}
+}
+
+func (r dockerPluginRegistrar) inspectDocker() (dockerCLIInfo, error) {
+	if r.lookPath != nil {
+		if _, err := r.lookPath("docker"); err != nil {
+			return dockerCLIInfo{}, errors.New("docker CLI was not found on PATH")
+		}
+	}
+	if r.commandOut == nil {
+		return dockerCLIInfo{}, errors.New("docker CLI inspection is unavailable")
+	}
+	out, err := r.commandOut("docker", "info", "--format", "json")
+	if err != nil {
+		return dockerCLIInfo{}, fmt.Errorf("docker info --format json failed: %w", err)
+	}
+
+	var info dockerInfoOutput
+	if err := json.Unmarshal([]byte(out), &info); err != nil {
+		return dockerCLIInfo{}, fmt.Errorf("parse docker info JSON: %w", err)
+	}
+	if info.ClientInfo == nil {
+		return dockerCLIInfo{}, errors.New("docker info did not include ClientInfo")
+	}
+	client := *info.ClientInfo
+	if client.Version == "" {
+		return dockerCLIInfo{}, errors.New("docker info did not include ClientInfo.Version")
+	}
+	if err := requireMinimumDockerVersion(client.Version); err != nil {
+		return dockerCLIInfo{}, err
+	}
+	if client.Plugins == nil {
+		client.Plugins = []dockerCLIPluginInfo{}
+	}
+	return client, nil
+}
+
+func requireMinimumDockerVersion(raw string) error {
+	got, err := parseSemverish(raw)
+	if err != nil {
+		return fmt.Errorf("docker CLI version %q is not a semantic version: %w", raw, err)
+	}
+	want := semver.MustParse(minimumDockerCLIVersion)
+	if got.Compare(want) < 0 {
+		return fmt.Errorf("docker CLI version %s is older than the minimum supported version %s", raw, minimumDockerCLIVersion)
+	}
+	return nil
+}
+
+func (r dockerPluginRegistrar) plan(dockerInfo dockerCLIInfo, force bool) (dockerPluginRegistrationPlan, error) {
+	source, err := r.currentExecutablePath()
+	if err != nil {
+		return dockerPluginRegistrationPlan{}, err
+	}
+	sourceKind, err := r.classifySource(source)
+	if err != nil {
+		return dockerPluginRegistrationPlan{}, err
+	}
+
+	existing := findDockerPlugin(dockerInfo.Plugins, dockerLintPluginName)
+	target, targetReason, err := r.targetPath(dockerInfo, existing)
+	if err != nil {
+		return dockerPluginRegistrationPlan{}, err
+	}
+
+	mode := installModeSymlink
+	if r.goos == windowsGOOS {
+		mode = installModeCopy
+	}
+	plan := dockerPluginRegistrationPlan{
+		SourcePath:     source,
+		TargetPath:     target,
+		Mode:           mode,
+		SourceKind:     sourceKind,
+		CurrentVersion: r.currentVersion,
+		DockerVersion:  dockerInfo.Version,
+		TargetReason:   targetReason,
+		Action:         registrationActionRegister,
+		ExistingPlugin: existing,
+	}
+
+	if existing != nil {
+		if !isTallyDockerPlugin(*existing) {
+			return dockerPluginRegistrationPlan{}, fmt.Errorf(
+				"`lint` command is already registered for %s: %s",
+				pluginVendorLabel(*existing),
+				pluginDescriptionLabel(*existing),
+			)
+		}
+		action, allowReplace, err := r.planExistingTallyPlugin(*existing, force)
+		if err != nil {
+			return dockerPluginRegistrationPlan{}, err
+		}
+		plan.Action = action
+		plan.AllowReplaceTarget = allowReplace
+	}
+
+	if !force {
+		if err := r.checkExistingTarget(plan); err != nil {
+			return dockerPluginRegistrationPlan{}, err
+		}
+	}
+	return plan, nil
+}
+
+func (r dockerPluginRegistrar) planExistingTallyPlugin(plugin dockerCLIPluginInfo, force bool) (string, bool, error) {
+	cmp, ok := compareSemverish(r.currentVersion, plugin.Version)
+	if !ok {
+		if !force {
+			return "", false, fmt.Errorf(
+				"unable to compare existing tally lint plugin version %q with current version %q; use --force to replace it",
+				plugin.Version,
+				r.currentVersion,
+			)
+		}
+		return registrationActionReplace, true, nil
+	}
+
+	switch {
+	case cmp < 0:
+		if !force {
+			return "", false, fmt.Errorf(
+				"registered tally lint plugin version %s is newer than current tally version %s; refusing to downgrade",
+				plugin.Version,
+				r.currentVersion,
+			)
+		}
+		return registrationActionDowngrade, true, nil
+	case cmp > 0:
+		return registrationActionUpgrade, true, nil
+	default:
+		return registrationActionRefresh, true, nil
+	}
+}
+
+func (r dockerPluginRegistrar) register(plan dockerPluginRegistrationPlan, force bool) error {
+	if err := os.MkdirAll(filepath.Dir(plan.TargetPath), 0o750); err != nil {
+		return fmt.Errorf("create Docker CLI plugin directory: %w", err)
+	}
+
+	if _, err := os.Lstat(plan.TargetPath); err == nil {
+		if sameDockerPluginRegistration(plan) {
+			return nil
+		}
+		if !force && !plan.AllowReplaceTarget {
+			return fmt.Errorf("%s already exists; use --force to replace it", plan.TargetPath)
+		}
+		if err := os.Remove(plan.TargetPath); err != nil {
+			return fmt.Errorf("remove existing docker-lint plugin: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect existing docker-lint plugin: %w", err)
+	}
+
+	if plan.Mode == installModeCopy {
+		return copyExecutable(plan.SourcePath, plan.TargetPath)
+	}
+	if err := os.Symlink(plan.SourcePath, plan.TargetPath); err != nil {
+		return fmt.Errorf("create docker-lint symlink: %w", err)
+	}
+	return nil
+}
+
+func (r dockerPluginRegistrar) verify(plan dockerPluginRegistrationPlan) (*dockerCLIPluginInfo, error) {
+	dockerInfo, err := r.inspectDocker()
+	if err != nil {
+		return nil, err
+	}
+	plugin := findDockerPlugin(dockerInfo.Plugins, dockerLintPluginName)
+	if plugin == nil {
+		return nil, errors.New("docker CLI did not report a `lint` plugin after registration")
+	}
+	if !isTallyDockerPlugin(*plugin) {
+		return nil, fmt.Errorf(
+			"docker CLI reports `lint` for %s: %s",
+			pluginVendorLabel(*plugin),
+			pluginDescriptionLabel(*plugin),
+		)
+	}
+	if plugin.Path != "" && !samePath(plugin.Path, plan.TargetPath) {
+		return nil, fmt.Errorf("docker CLI reports `lint` at %s, not %s", plugin.Path, plan.TargetPath)
+	}
+	if !versionsEquivalent(plan.CurrentVersion, plugin.Version) {
+		return nil, fmt.Errorf("docker CLI reports tally lint version %s, expected %s", plugin.Version, plan.CurrentVersion)
+	}
+	return plugin, nil
+}
+
+func (r dockerPluginRegistrar) currentExecutablePath() (string, error) {
+	candidates := make([]string, 0, 2)
+	if r.args0 != "" {
+		if resolved, err := r.resolveArg0(r.args0); err == nil {
+			candidates = append(candidates, resolved)
+		}
+	}
+	if r.executable != nil {
+		if exe, err := r.executable(); err == nil && exe != "" {
+			if abs, err := filepath.Abs(exe); err == nil {
+				candidates = append(candidates, filepath.Clean(abs))
+			}
+		}
+	}
+
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if r.goos != windowsGOOS && info.Mode()&0o111 == 0 {
+			return "", fmt.Errorf("current tally executable is not executable: %s", candidate)
+		}
+		return r.stableExecutablePath(candidate), nil
+	}
+	return "", errors.New("failed to resolve the current tally executable")
+}
+
+func (r dockerPluginRegistrar) resolveArg0(arg0 string) (string, error) {
+	if filepath.IsAbs(arg0) || strings.ContainsAny(arg0, `/\`) {
+		return filepath.Abs(arg0)
+	}
+	if r.lookPath == nil {
+		return "", errors.New("PATH lookup unavailable")
+	}
+	return r.lookPath(arg0)
+}
+
+func (r dockerPluginRegistrar) stableExecutablePath(path string) string {
+	clean := filepath.Clean(path)
+	if stable, ok := stableHomebrewExecutable(clean); ok {
+		return stable
+	}
+	return clean
+}
+
+func stableHomebrewExecutable(path string) (string, bool) {
+	slash := filepath.ToSlash(filepath.Clean(path))
+	parts := strings.Split(slash, "/")
+	for idx := 0; idx+4 < len(parts); idx++ {
+		if parts[idx] != "Cellar" || parts[idx+1] != "tally" || parts[idx+3] != "bin" {
+			continue
+		}
+		prefix := strings.Join(parts[:idx], "/")
+		if prefix == "" {
+			prefix = "/"
+		}
+		stable := filepath.FromSlash(strings.TrimRight(prefix, "/") + "/bin/tally")
+		if _, err := os.Stat(stable); err == nil {
+			return stable, true
+		}
+	}
+	return "", false
+}
+
+func (r dockerPluginRegistrar) classifySource(source string) (string, error) {
+	if IsDockerLintPluginExecutable(source) {
+		return "", errors.New("already running as docker-lint; run this command through tally")
+	}
+
+	source = filepath.Clean(source)
+	if r.pathWithin(source, r.tempDir) {
+		return "", fmt.Errorf("%s is a temporary executable, not a persistent global install", source)
+	}
+	if r.isProjectLocalExecutable(source) {
+		return "", fmt.Errorf("%s is inside the current project; install tally globally before registering the Docker plugin", source)
+	}
+
+	switch {
+	case looksLikeHomebrewPath(source):
+		return "Homebrew", nil
+	case looksLikeWingetPath(source):
+		return "WinGet", nil
+	case pathHasSegment(source, "node_modules"):
+		if r.isNPMGlobalPath(source) {
+			return "global npm", nil
+		}
+		return "", fmt.Errorf("%s looks like a project-local npm install; run npm install -g tally-cli first", source)
+	case looksLikePythonPackagePath(source):
+		if r.isUVToolPath(source) {
+			return "uv tool", nil
+		}
+		return "", fmt.Errorf(
+			"%s looks like a Python virtual environment or package install; use uv tool install tally-cli for automatic plugin registration",
+			source,
+		)
+	case looksLikeGlobalBinaryPath(source):
+		return "global binary", nil
+	default:
+		return "", fmt.Errorf("%s is not a recognized persistent global tally install", source)
+	}
+}
+
+func (r dockerPluginRegistrar) targetPath(
+	dockerInfo dockerCLIInfo,
+	existing *dockerCLIPluginInfo,
+) (path, reason string, err error) {
+	if existing != nil && existing.Path != "" {
+		return filepath.Clean(existing.Path), "existing docker lint plugin path", nil
+	}
+
+	name := dockerPluginExecutableName(r.goos)
+	if dir, ok := commonDockerPluginDir(dockerInfo.Plugins); ok {
+		return filepath.Join(dir, name), "existing Docker CLI plugin directory", nil
+	}
+
+	configDir := r.dockerConfig
+	if configDir == "" {
+		if r.homeDir == "" {
+			return "", "", errors.New("cannot resolve home directory; set DOCKER_CONFIG")
+		}
+		configDir = filepath.Join(r.homeDir, ".docker")
+	}
+	return filepath.Join(configDir, "cli-plugins", name), "Docker per-user CLI plugin directory", nil
+}
+
+func dockerPluginExecutableName(goos string) string {
+	name := "docker-lint"
+	if goos == windowsGOOS {
+		name += ".exe"
+	}
+	return name
+}
+
+func commonDockerPluginDir(plugins []dockerCLIPluginInfo) (string, bool) {
+	var dir string
+	for _, plugin := range plugins {
+		if plugin.Path == "" {
+			continue
+		}
+		pluginDir := filepath.Clean(filepath.Dir(plugin.Path))
+		if dir == "" {
+			dir = pluginDir
+			continue
+		}
+		if !samePath(dir, pluginDir) {
+			return "", false
+		}
+	}
+	return dir, dir != ""
+}
+
+func (r dockerPluginRegistrar) checkExistingTarget(plan dockerPluginRegistrationPlan) error {
+	if _, err := os.Lstat(plan.TargetPath); err == nil {
+		if sameDockerPluginRegistration(plan) || plan.AllowReplaceTarget {
+			return nil
+		}
+		return fmt.Errorf("%s already exists; use --force to replace it", plan.TargetPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect existing docker-lint plugin: %w", err)
+	}
+	return nil
+}
+
+func (r dockerPluginRegistrar) isProjectLocalExecutable(path string) bool {
+	root := r.projectRoot()
+	if root == "" || !r.pathWithin(path, root) {
+		return false
+	}
+	return true
+}
+
+func (r dockerPluginRegistrar) projectRoot() string {
+	if r.cwd == "" {
+		return ""
+	}
+
+	dir, err := filepath.Abs(r.cwd)
+	if err != nil {
+		return ""
+	}
+	for {
+		for _, marker := range []string{".git", "go.mod", "package.json", "pyproject.toml", "node_modules", ".venv", "venv"} {
+			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func (r dockerPluginRegistrar) isNPMGlobalPath(path string) bool {
+	for _, root := range r.npmGlobalRoots() {
+		if r.pathWithin(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r dockerPluginRegistrar) npmGlobalRoots() []string {
+	var roots []string
+	if v := strings.TrimSpace(os.Getenv("TALLY_NPM_GLOBAL_ROOT")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+	if r.commandOut != nil {
+		if out, err := r.commandOut("npm", "root", "-g"); err == nil {
+			roots = appendPathList(roots, out)
+		}
+	}
+	return cleanPathList(roots)
+}
+
+func (r dockerPluginRegistrar) isUVToolPath(path string) bool {
+	for _, root := range r.uvToolDirs() {
+		if r.pathWithin(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r dockerPluginRegistrar) uvToolDirs() []string {
+	var roots []string
+	if v := strings.TrimSpace(os.Getenv("UV_TOOL_DIR")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("TALLY_UV_TOOL_DIR")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+	if r.commandOut != nil {
+		if out, err := r.commandOut("uv", "tool", "dir"); err == nil {
+			roots = appendPathList(roots, out)
+		}
+	}
+	if r.homeDir != "" {
+		roots = append(roots,
+			filepath.Join(r.homeDir, ".local", "share", "uv", "tools"),
+			filepath.Join(r.homeDir, "Library", "Application Support", "uv", "tools"),
+			filepath.Join(r.homeDir, "AppData", "Roaming", "uv", "tools"),
+		)
+	}
+	return cleanPathList(roots)
+}
+
+func (r dockerPluginRegistrar) pathWithin(path, root string) bool {
+	if path == "" || root == "" {
+		return false
+	}
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func printDockerPluginRegistrationPlan(w io.Writer, plan dockerPluginRegistrationPlan, dryRun bool) {
+	action := plan.Action
+	if dryRun {
+		action = dryRunRegistrationAction(action)
+	}
+
+	switch {
+	case plan.ExistingPlugin != nil && isTallyDockerPlugin(*plan.ExistingPlugin) && plan.Action == registrationActionRefresh:
+		fmt.Fprintf(w, "%s tally lint plugin version %s\n", action, plan.CurrentVersion)
+	case plan.ExistingPlugin != nil && isTallyDockerPlugin(*plan.ExistingPlugin):
+		fmt.Fprintf(
+			w,
+			"%s tally lint plugin from version %s to %s\n",
+			action,
+			plan.ExistingPlugin.Version,
+			plan.CurrentVersion,
+		)
+	default:
+		fmt.Fprintf(w, "%s tally lint plugin version %s\n", action, plan.CurrentVersion)
+	}
+	fmt.Fprintf(w, "  source: %s (%s install)\n", plan.SourcePath, plan.SourceKind)
+	fmt.Fprintf(w, "  target: %s (%s)\n", plan.TargetPath, plan.TargetReason)
+	fmt.Fprintf(w, "  mode:   %s\n", plan.Mode)
+}
+
+func dryRunRegistrationAction(action string) string {
+	switch action {
+	case registrationActionDowngrade:
+		return "Would downgrade"
+	case registrationActionRefresh:
+		return "Would refresh"
+	case registrationActionReplace:
+		return "Would replace"
+	case registrationActionUpgrade:
+		return "Would upgrade"
+	default:
+		return "Would register"
+	}
+}
+
+func printDockerPluginRegistrationResult(w io.Writer, plan dockerPluginRegistrationPlan, plugin *dockerCLIPluginInfo) {
+	registeredPath := plan.TargetPath
+	if plugin != nil && plugin.Path != "" {
+		registeredPath = plugin.Path
+	}
+	fmt.Fprintf(w, "Registered and verified tally lint plugin version %s\n", plan.CurrentVersion)
+	fmt.Fprintf(w, "  path: %s\n", registeredPath)
+	fmt.Fprintf(w, "Run: docker lint --help\n")
+}
+
+func findDockerPlugin(plugins []dockerCLIPluginInfo, name string) *dockerCLIPluginInfo {
+	for idx := range plugins {
+		if strings.EqualFold(plugins[idx].Name, name) {
+			plugin := plugins[idx]
+			return &plugin
+		}
+	}
+	return nil
+}
+
+func isTallyDockerPlugin(plugin dockerCLIPluginInfo) bool {
+	return strings.EqualFold(plugin.Vendor, tallyDockerPluginVendor)
+}
+
+func pluginVendorLabel(plugin dockerCLIPluginInfo) string {
+	if plugin.Vendor != "" {
+		return plugin.Vendor
+	}
+	return "unknown vendor"
+}
+
+func pluginDescriptionLabel(plugin dockerCLIPluginInfo) string {
+	if plugin.ShortDescription != "" {
+		return plugin.ShortDescription
+	}
+	return "no description"
+}
+
+func sameDockerPluginRegistration(plan dockerPluginRegistrationPlan) bool {
+	if plan.Mode == installModeCopy {
+		return sameExecutableContent(plan.TargetPath, plan.SourcePath)
+	}
+	return sameDockerPluginTarget(plan.TargetPath, plan.SourcePath)
+}
+
+func sameDockerPluginTarget(target, source string) bool {
+	targetReal, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		targetReal = target
+	}
+	sourceReal, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		sourceReal = source
+	}
+	return samePath(targetReal, sourceReal)
+}
+
+func samePath(left, right string) bool {
+	leftAbs, err := filepath.Abs(left)
+	if err != nil {
+		return false
+	}
+	rightAbs, err := filepath.Abs(right)
+	if err != nil {
+		return false
+	}
+	leftClean := filepath.Clean(leftAbs)
+	rightClean := filepath.Clean(rightAbs)
+	if runtime.GOOS == windowsGOOS {
+		return strings.EqualFold(leftClean, rightClean)
+	}
+	return leftClean == rightClean
+}
+
+func sameExecutableContent(target, source string) bool {
+	targetInfo, err := os.Stat(target)
+	if err != nil || targetInfo.IsDir() {
+		return false
+	}
+	sourceInfo, err := os.Stat(source)
+	if err != nil || sourceInfo.IsDir() || targetInfo.Size() != sourceInfo.Size() {
+		return false
+	}
+	targetBytes, err := os.ReadFile(target)
+	if err != nil {
+		return false
+	}
+	sourceBytes, err := os.ReadFile(source)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(targetBytes, sourceBytes)
+}
+
+func copyExecutable(source, target string) error {
+	input, err := os.ReadFile(source)
+	if err != nil {
+		return fmt.Errorf("read current tally executable: %w", err)
+	}
+	if err := os.WriteFile(target, input, 0o700); err != nil { //nolint:gosec // Docker CLI plugins must be executable.
+		return fmt.Errorf("write docker-lint executable: %w", err)
+	}
+	return nil
+}
+
+func commandOutputWithTimeout(name string, args ...string) (string, error) {
+	switch name + " " + strings.Join(args, " ") {
+	case "docker info --format json":
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return commandTextOutput(exec.CommandContext(ctx, "docker", "info", "--format", "json"))
+	case "npm root -g":
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		return commandTextOutput(exec.CommandContext(ctx, "npm", "root", "-g"))
+	case "uv tool dir":
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		return commandTextOutput(exec.CommandContext(ctx, "uv", "tool", "dir"))
+	default:
+		return "", fmt.Errorf("unsupported command probe: %s %s", name, strings.Join(args, " "))
+	}
+}
+
+func commandTextOutput(cmd *exec.Cmd) (string, error) {
+	out, err := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(out))
+	if err != nil {
+		if text != "" {
+			return "", fmt.Errorf("%w: %s", err, text)
+		}
+		return "", err
+	}
+	return text, nil
+}
+
+func compareSemverish(current, existing string) (int, bool) {
+	currentVersion, err := parseSemverish(current)
+	if err != nil {
+		return 0, false
+	}
+	existingVersion, err := parseSemverish(existing)
+	if err != nil {
+		return 0, false
+	}
+	return currentVersion.Compare(existingVersion), true
+}
+
+func versionsEquivalent(left, right string) bool {
+	if cmp, ok := compareSemverish(left, right); ok {
+		return cmp == 0
+	}
+	return strings.TrimSpace(left) == strings.TrimSpace(right)
+}
+
+func parseSemverish(raw string) (*semver.Version, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("empty version")
+	}
+	if fields := strings.Fields(raw); len(fields) > 0 {
+		raw = fields[0]
+	}
+	return semver.NewVersion(raw)
+}
+
+func looksLikeHomebrewPath(path string) bool {
+	slash := strings.ToLower(filepath.ToSlash(filepath.Clean(path)))
+	return strings.Contains(slash, "/cellar/tally/") ||
+		strings.Contains(slash, "/homebrew/bin/tally") ||
+		strings.Contains(slash, "/linuxbrew/bin/tally")
+}
+
+func looksLikeWingetPath(path string) bool {
+	slash := strings.ToLower(filepath.ToSlash(filepath.Clean(path)))
+	return strings.Contains(slash, "/microsoft/winget/packages/wharflab.tally") ||
+		strings.Contains(slash, "/microsoft/winget/links/tally")
+}
+
+func looksLikePythonPackagePath(path string) bool {
+	return pathHasSegment(path, "site-packages") ||
+		pathHasSegment(path, "dist-packages") ||
+		pathHasSegment(path, ".venv") ||
+		pathHasSegment(path, "venv")
+}
+
+func looksLikeGlobalBinaryPath(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	if base != "tally" && base != "tally.exe" {
+		return false
+	}
+	for _, segment := range []string{"bin", "sbin", "go", "tools", "packages"} {
+		if pathHasSegment(path, segment) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathHasSegment(pathValue, want string) bool {
+	for _, part := range strings.FieldsFunc(filepath.ToSlash(pathValue), func(r rune) bool { return r == '/' }) {
+		if strings.EqualFold(part, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func appendPathList(paths []string, value string) []string {
+	for _, part := range filepath.SplitList(strings.TrimSpace(value)) {
+		if part = strings.TrimSpace(part); part != "" {
+			paths = append(paths, part)
+		}
+	}
+	return paths
+}
+
+func cleanPathList(paths []string) []string {
+	out := paths[:0]
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		out = append(out, filepath.Clean(abs))
+	}
+	return out
+}

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -60,6 +60,7 @@ type dockerPluginRegistrar struct {
 	dockerConfig   string
 	args0          string
 	currentVersion string
+	virtualEnv     string
 	executable     func() (string, error)
 	lookPath       func(string) (string, error)
 	commandOut     func(string, ...string) (string, error)
@@ -152,6 +153,7 @@ func newDockerPluginRegistrar() dockerPluginRegistrar {
 		dockerConfig:   os.Getenv("DOCKER_CONFIG"),
 		args0:          os.Args[0],
 		currentVersion: version.RawVersion(),
+		virtualEnv:     os.Getenv("VIRTUAL_ENV"),
 		executable:     os.Executable,
 		lookPath:       exec.LookPath,
 		commandOut:     commandOutputWithTimeout,
@@ -420,6 +422,12 @@ func (r dockerPluginRegistrar) classifySource(source string) (string, error) {
 	if r.pathWithin(source, r.tempDir) {
 		return "", fmt.Errorf("%s is a temporary executable, not a persistent global install", source)
 	}
+	if r.isVirtualEnvPath(source) {
+		return "", fmt.Errorf(
+			"%s is inside the active Python virtual environment; use uv tool install tally-cli for automatic plugin registration",
+			source,
+		)
+	}
 	if r.isProjectLocalExecutable(source) {
 		return "", fmt.Errorf("%s is inside the current project; install tally globally before registering the Docker plugin", source)
 	}
@@ -544,8 +552,6 @@ func (r dockerPluginRegistrar) projectRoot() string {
 			"bun.lock",
 			"bun.lockb",
 			"node_modules",
-			".venv",
-			"venv",
 		} {
 			if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
 				return dir
@@ -622,6 +628,10 @@ func (r dockerPluginRegistrar) bunGlobalRoots() []string {
 		)
 	}
 	return cleanPathList(roots)
+}
+
+func (r dockerPluginRegistrar) isVirtualEnvPath(path string) bool {
+	return r.pathWithin(path, strings.TrimSpace(r.virtualEnv))
 }
 
 func (r dockerPluginRegistrar) isUVToolPath(path string) bool {
@@ -900,9 +910,7 @@ func looksLikeWingetPath(path string) bool {
 
 func looksLikePythonPackagePath(path string) bool {
 	return pathHasSegment(path, "site-packages") ||
-		pathHasSegment(path, "dist-packages") ||
-		pathHasSegment(path, ".venv") ||
-		pathHasSegment(path, "venv")
+		pathHasSegment(path, "dist-packages")
 }
 
 func looksLikeGlobalBinaryPath(path string) bool {

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -31,6 +31,7 @@ const (
 	installModeSymlink              = "symlink"
 	minimumDockerCLIVersion         = "20.10.0"
 	tallyDockerPluginVendor         = "Wharflab"
+	tallyExecutableBaseName         = "tally"
 	windowsGOOS                     = "windows"
 )
 
@@ -399,14 +400,14 @@ func stableHomebrewExecutable(path string) (string, bool) {
 	slash := filepath.ToSlash(filepath.Clean(path))
 	parts := strings.Split(slash, "/")
 	for idx := 0; idx+4 < len(parts); idx++ {
-		if parts[idx] != "Cellar" || parts[idx+1] != "tally" || parts[idx+3] != "bin" {
+		if parts[idx] != "Cellar" || parts[idx+1] != tallyExecutableBaseName || parts[idx+3] != "bin" {
 			continue
 		}
 		prefix := strings.Join(parts[:idx], "/")
 		if prefix == "" {
 			prefix = "/"
 		}
-		stable := filepath.FromSlash(strings.TrimRight(prefix, "/") + "/bin/tally")
+		stable := filepath.FromSlash(strings.TrimRight(prefix, "/") + "/bin/" + tallyExecutableBaseName)
 		if _, err := os.Stat(stable); err == nil {
 			return stable, true
 		}
@@ -951,7 +952,7 @@ func looksLikePythonPackagePath(path string) bool {
 
 func looksLikeGlobalBinaryPath(path string) bool {
 	base := strings.ToLower(filepath.Base(path))
-	if base != "tally" && base != "tally.exe" {
+	if base != tallyExecutableBaseName && base != tallyExecutableBaseName+".exe" {
 		return false
 	}
 	for _, segment := range []string{"bin", "sbin", "go", "tools", "packages"} {

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -13,6 +13,8 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 
 	home := filepath.Join(string(filepath.Separator), "Users", "me")
 	npmRoot := filepath.Join(home, ".nvm", "versions", "node", "v24.0.0", "lib", "node_modules")
+	bunRoot := filepath.Join(home, ".bun", "install", "global")
+	bunBin := filepath.Join(home, ".bun", "bin")
 	uvToolDir := filepath.Join(home, ".local", "share", "uv", "tools")
 	registrar := dockerPluginRegistrar{
 		goos:    "linux",
@@ -23,6 +25,8 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 			switch name + " " + strings.Join(args, " ") {
 			case "npm root -g":
 				return npmRoot, nil
+			case "bun pm bin -g":
+				return bunBin, nil
 			case "uv tool dir":
 				return uvToolDir, nil
 			default:
@@ -62,6 +66,25 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 			want: "global npm",
 		},
 		{
+			name: "bun global",
+			path: filepath.Join(
+				bunRoot,
+				"node_modules",
+				"tally-cli",
+				"node_modules",
+				"@wharflab",
+				"tally-darwin-arm64",
+				"bin",
+				"tally",
+			),
+			want: "global Bun",
+		},
+		{
+			name: "bun global bin",
+			path: filepath.Join(bunBin, "tally"),
+			want: "global Bun",
+		},
+		{
 			name: "npm local",
 			path: filepath.Join(
 				home,
@@ -76,6 +99,22 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 				"tally",
 			),
 			wantErr: "project-local npm",
+		},
+		{
+			name: "bun local",
+			path: filepath.Join(
+				home,
+				"work",
+				"project",
+				"node_modules",
+				"tally-cli",
+				"node_modules",
+				"@wharflab",
+				"tally-darwin-arm64",
+				"bin",
+				"tally",
+			),
+			wantErr: "project-local npm/Bun",
 		},
 		{
 			name: "uv tool",

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -235,8 +235,9 @@ func TestDockerPluginRegistrarTargetPathUsesExistingPluginDirectory(t *testing.T
 
 	pluginDir := filepath.Join(string(filepath.Separator), "Users", "me", ".docker", "cli-plugins")
 	registrar := dockerPluginRegistrar{
-		goos:    "linux",
-		homeDir: filepath.Join(string(filepath.Separator), "Users", "me"),
+		goos:        "linux",
+		homeDir:     filepath.Join(string(filepath.Separator), "Users", "me"),
+		dirWritable: func(string) bool { return true },
 	}
 	got, reason, err := registrar.targetPath(dockerCLIInfo{
 		Plugins: []dockerCLIPluginInfo{
@@ -253,6 +254,36 @@ func TestDockerPluginRegistrarTargetPathUsesExistingPluginDirectory(t *testing.T
 	}
 	if reason != "existing Docker CLI plugin directory" {
 		t.Fatalf("target reason = %q", reason)
+	}
+}
+
+func TestDockerPluginRegistrarTargetPathFallsBackWhenExistingPluginDirectoryIsNotWritable(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := filepath.Join(string(filepath.Separator), "usr", "libexec", "docker", "cli-plugins")
+	dockerConfig := filepath.Join(string(filepath.Separator), "Users", "me", ".docker")
+	registrar := dockerPluginRegistrar{
+		goos:         "linux",
+		homeDir:      filepath.Join(string(filepath.Separator), "Users", "me"),
+		dockerConfig: dockerConfig,
+		dirWritable:  func(string) bool { return false },
+	}
+	got, reason, err := registrar.targetPath(dockerCLIInfo{
+		Plugins: []dockerCLIPluginInfo{
+			{Name: "buildx", Path: filepath.Join(pluginDir, "docker-buildx")},
+			{Name: "compose", Path: filepath.Join(pluginDir, "docker-compose")},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("targetPath: %v", err)
+	}
+	want := filepath.Join(dockerConfig, "cli-plugins", "docker-lint")
+	if got != want {
+		t.Fatalf("targetPath = %q, want %q", got, want)
+	}
+	wantReason := "Docker per-user CLI plugin directory; inferred Docker CLI plugin directory is not writable"
+	if reason != wantReason {
+		t.Fatalf("target reason = %q, want %q", reason, wantReason)
 	}
 }
 

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -16,11 +16,13 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 	bunRoot := filepath.Join(home, ".bun", "install", "global")
 	bunBin := filepath.Join(home, ".bun", "bin")
 	uvToolDir := filepath.Join(home, ".local", "share", "uv", "tools")
+	virtualEnv := filepath.Join(home, "work", "project", ".custom-env")
 	registrar := dockerPluginRegistrar{
-		goos:    "linux",
-		homeDir: home,
-		cwd:     filepath.Join(home, "work", "project"),
-		tempDir: filepath.Join(string(filepath.Separator), "tmp"),
+		goos:       "linux",
+		homeDir:    home,
+		cwd:        filepath.Join(home, "work", "project"),
+		tempDir:    filepath.Join(string(filepath.Separator), "tmp"),
+		virtualEnv: virtualEnv,
 		commandOut: func(name string, args ...string) (string, error) {
 			switch name + " " + strings.Join(args, " ") {
 			case "npm root -g":
@@ -132,12 +134,12 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 			want: "uv tool",
 		},
 		{
-			name: "python venv",
+			name: "python package install",
 			path: filepath.Join(
 				home,
 				"work",
 				"project",
-				".venv",
+				"python-env",
 				"lib",
 				"python3.14",
 				"site-packages",
@@ -147,6 +149,16 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 				"tally",
 			),
 			wantErr: "Python virtual environment",
+		},
+		{
+			name:    "active virtualenv",
+			path:    filepath.Join(virtualEnv, "bin", "tally"),
+			wantErr: "active Python virtual environment",
+		},
+		{
+			name: "venv directory name without virtualenv",
+			path: filepath.Join(home, "tools", "venv", "bin", "tally"),
+			want: "global binary",
 		},
 		{
 			name:    "temporary go run",

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -499,7 +499,11 @@ func testDockerPluginRegistrar(t *testing.T, currentVersion string) dockerPlugin
 	t.Helper()
 
 	tmp := t.TempDir()
-	source := filepath.Join(tmp, "bin", "tally")
+	sourceName := tallyExecutableBaseName
+	if runtime.GOOS == windowsGOOS {
+		sourceName += ".exe"
+	}
+	source := filepath.Join(tmp, "bin", sourceName)
 	if err := os.MkdirAll(filepath.Dir(source), 0o750); err != nil {
 		t.Fatalf("mkdir source dir: %v", err)
 	}
@@ -507,7 +511,7 @@ func testDockerPluginRegistrar(t *testing.T, currentVersion string) dockerPlugin
 		t.Fatalf("write source: %v", err)
 	}
 	return dockerPluginRegistrar{
-		goos:           "linux",
+		goos:           runtime.GOOS,
 		homeDir:        tmp,
 		cwd:            filepath.Join(tmp, "outside"),
 		tempDir:        filepath.Join(tmp, "tmp"),

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -1,0 +1,435 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDockerPluginRegistrarClassifySource(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(string(filepath.Separator), "Users", "me")
+	npmRoot := filepath.Join(home, ".nvm", "versions", "node", "v24.0.0", "lib", "node_modules")
+	uvToolDir := filepath.Join(home, ".local", "share", "uv", "tools")
+	registrar := dockerPluginRegistrar{
+		goos:    "linux",
+		homeDir: home,
+		cwd:     filepath.Join(home, "work", "project"),
+		tempDir: filepath.Join(string(filepath.Separator), "tmp"),
+		commandOut: func(name string, args ...string) (string, error) {
+			switch name + " " + strings.Join(args, " ") {
+			case "npm root -g":
+				return npmRoot, nil
+			case "uv tool dir":
+				return uvToolDir, nil
+			default:
+				return "", os.ErrNotExist
+			}
+		},
+	}
+
+	cases := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "homebrew",
+			path: filepath.Join(string(filepath.Separator), "opt", "homebrew", "bin", "tally"),
+			want: "Homebrew",
+		},
+		{
+			name: "winget",
+			path: filepath.Join(
+				home,
+				"AppData",
+				"Local",
+				"Microsoft",
+				"WinGet",
+				"Packages",
+				"Wharflab.Tally_8wekyb3d8bbwe",
+				"tally.exe",
+			),
+			want: "WinGet",
+		},
+		{
+			name: "npm global",
+			path: filepath.Join(npmRoot, "tally-cli", "node_modules", "@wharflab", "tally-darwin-arm64", "bin", "tally"),
+			want: "global npm",
+		},
+		{
+			name: "npm local",
+			path: filepath.Join(
+				home,
+				"work",
+				"project",
+				"node_modules",
+				"tally-cli",
+				"node_modules",
+				"@wharflab",
+				"tally-darwin-arm64",
+				"bin",
+				"tally",
+			),
+			wantErr: "project-local npm",
+		},
+		{
+			name: "uv tool",
+			path: filepath.Join(
+				uvToolDir,
+				"tally-cli",
+				"lib",
+				"python3.14",
+				"site-packages",
+				"tally_cli",
+				"bin",
+				"tally-linux-x86_64",
+				"tally",
+			),
+			want: "uv tool",
+		},
+		{
+			name: "python venv",
+			path: filepath.Join(
+				home,
+				"work",
+				"project",
+				".venv",
+				"lib",
+				"python3.14",
+				"site-packages",
+				"tally_cli",
+				"bin",
+				"tally-linux-x86_64",
+				"tally",
+			),
+			wantErr: "Python virtual environment",
+		},
+		{
+			name:    "temporary go run",
+			path:    filepath.Join(string(filepath.Separator), "tmp", "go-build123", "b001", "exe", "tally"),
+			wantErr: "temporary executable",
+		},
+		{
+			name:    "already plugin",
+			path:    filepath.Join(home, ".docker", "cli-plugins", "docker-lint"),
+			wantErr: "already running as docker-lint",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := registrar.classifySource(tc.path)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("classifySource(%q) error = %v, want containing %q", tc.path, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("classifySource(%q): %v", tc.path, err)
+			}
+			if got != tc.want {
+				t.Fatalf("classifySource(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDockerPluginRegistrarTargetPath(t *testing.T) {
+	t.Parallel()
+
+	registrar := dockerPluginRegistrar{
+		goos:    "linux",
+		homeDir: filepath.Join(string(filepath.Separator), "Users", "me"),
+	}
+	got, reason, err := registrar.targetPath(dockerCLIInfo{}, nil)
+	if err != nil {
+		t.Fatalf("targetPath: %v", err)
+	}
+	want := filepath.Join(string(filepath.Separator), "Users", "me", ".docker", "cli-plugins", "docker-lint")
+	if got != want {
+		t.Fatalf("targetPath = %q, want %q", got, want)
+	}
+	if reason != "Docker per-user CLI plugin directory" {
+		t.Fatalf("target reason = %q", reason)
+	}
+}
+
+func TestDockerPluginRegistrarTargetPathUsesDockerConfig(t *testing.T) {
+	t.Parallel()
+
+	registrar := dockerPluginRegistrar{
+		goos:         windowsGOOS,
+		homeDir:      filepath.Join(string(filepath.Separator), "Users", "me"),
+		dockerConfig: filepath.Join(string(filepath.Separator), "tmp", "docker-config"),
+	}
+	got, _, err := registrar.targetPath(dockerCLIInfo{}, nil)
+	if err != nil {
+		t.Fatalf("targetPath: %v", err)
+	}
+	want := filepath.Join(string(filepath.Separator), "tmp", "docker-config", "cli-plugins", "docker-lint.exe")
+	if got != want {
+		t.Fatalf("targetPath = %q, want %q", got, want)
+	}
+}
+
+func TestDockerPluginRegistrarTargetPathUsesExistingPluginDirectory(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := filepath.Join(string(filepath.Separator), "Users", "me", ".docker", "cli-plugins")
+	registrar := dockerPluginRegistrar{
+		goos:    "linux",
+		homeDir: filepath.Join(string(filepath.Separator), "Users", "me"),
+	}
+	got, reason, err := registrar.targetPath(dockerCLIInfo{
+		Plugins: []dockerCLIPluginInfo{
+			{Name: "buildx", Path: filepath.Join(pluginDir, "docker-buildx")},
+			{Name: "compose", Path: filepath.Join(pluginDir, "docker-compose")},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("targetPath: %v", err)
+	}
+	want := filepath.Join(pluginDir, "docker-lint")
+	if got != want {
+		t.Fatalf("targetPath = %q, want %q", got, want)
+	}
+	if reason != "existing Docker CLI plugin directory" {
+		t.Fatalf("target reason = %q", reason)
+	}
+}
+
+func TestDockerPluginRegistrarPlanRejectsThirdPartyLintPlugin(t *testing.T) {
+	t.Parallel()
+
+	registrar := testDockerPluginRegistrar(t, "0.7.19")
+	_, err := registrar.plan(dockerCLIInfo{
+		Version: "29.4.1",
+		Plugins: []dockerCLIPluginInfo{{
+			Name:             "lint",
+			Vendor:           "Example Corp.",
+			ShortDescription: "Another Dockerfile linter",
+			Version:          "1.2.3",
+			Path:             filepath.Join(t.TempDir(), "docker-lint"),
+		}},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), "`lint` command is already registered for Example Corp.: Another Dockerfile linter") {
+		t.Fatalf("Plan error = %v, want third-party lint rejection", err)
+	}
+}
+
+func TestDockerPluginRegistrarPlanRejectsNewerTallyPlugin(t *testing.T) {
+	t.Parallel()
+
+	registrar := testDockerPluginRegistrar(t, "0.7.19")
+	_, err := registrar.plan(dockerCLIInfo{
+		Version: "29.4.1",
+		Plugins: []dockerCLIPluginInfo{{
+			Name:             "lint",
+			Vendor:           tallyDockerPluginVendor,
+			ShortDescription: "Lint Dockerfiles and Containerfiles",
+			Version:          "0.8.0",
+			Path:             filepath.Join(t.TempDir(), "docker-lint"),
+		}},
+	}, false)
+	if err == nil || !strings.Contains(err.Error(), "refusing to downgrade") {
+		t.Fatalf("Plan error = %v, want downgrade rejection", err)
+	}
+}
+
+func TestDockerPluginRegistrarPlanUpgradesExistingTallyPlugin(t *testing.T) {
+	t.Parallel()
+
+	registrar := testDockerPluginRegistrar(t, "0.7.19")
+	target := filepath.Join(t.TempDir(), "docker-lint")
+	plan, err := registrar.plan(dockerCLIInfo{
+		Version: "29.4.1",
+		Plugins: []dockerCLIPluginInfo{{
+			Name:             "lint",
+			Vendor:           tallyDockerPluginVendor,
+			ShortDescription: "Lint Dockerfiles and Containerfiles",
+			Version:          "0.5.6",
+			Path:             target,
+		}},
+	}, false)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.Action != registrationActionUpgrade {
+		t.Fatalf("Action = %q, want %q", plan.Action, registrationActionUpgrade)
+	}
+	if !plan.AllowReplaceTarget {
+		t.Fatal("AllowReplaceTarget = false, want true")
+	}
+	if plan.TargetPath != target {
+		t.Fatalf("TargetPath = %q, want %q", plan.TargetPath, target)
+	}
+}
+
+func TestDockerPluginRegistrarInspectDocker(t *testing.T) {
+	t.Parallel()
+
+	registrar := dockerPluginRegistrar{
+		lookPath: func(name string) (string, error) {
+			if name == "docker" {
+				return "/usr/local/bin/docker", nil
+			}
+			return "", os.ErrNotExist
+		},
+		commandOut: func(name string, args ...string) (string, error) {
+			if name+" "+strings.Join(args, " ") != "docker info --format json" {
+				return "", os.ErrNotExist
+			}
+			return `{"ClientInfo":{"Version":"29.4.1","Plugins":[{"Name":"compose","Vendor":"Docker Inc.","Path":"/p/docker-compose"}]}}`, nil
+		},
+	}
+	info, err := registrar.inspectDocker()
+	if err != nil {
+		t.Fatalf("inspectDocker: %v", err)
+	}
+	if info.Version != "29.4.1" {
+		t.Fatalf("Version = %q, want 29.4.1", info.Version)
+	}
+	if len(info.Plugins) != 1 || info.Plugins[0].Name != "compose" {
+		t.Fatalf("Plugins = %#v", info.Plugins)
+	}
+}
+
+func TestDockerPluginRegistrarRejectsProjectLocalBinaryFromNestedCWD(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	project := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(filepath.Join(project, "cmd"), 0o750); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "go.mod"), []byte("module example.com/project\n"), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	registrar := dockerPluginRegistrar{
+		goos:    "linux",
+		homeDir: tmp,
+		cwd:     filepath.Join(project, "cmd"),
+		tempDir: filepath.Join(tmp, "tmp"),
+	}
+	source := filepath.Join(project, "bin", "tally")
+
+	_, err := registrar.classifySource(source)
+	if err == nil || !strings.Contains(err.Error(), "inside the current project") {
+		t.Fatalf("classifySource(%q) error = %v, want current project rejection", source, err)
+	}
+}
+
+func TestDockerPluginRegistrarRegisterSymlink(t *testing.T) {
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("symlink registration is Unix-specific")
+	}
+	t.Parallel()
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "bin", "tally")
+	if err := os.MkdirAll(filepath.Dir(source), 0o750); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("binary"), 0o700); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	target := filepath.Join(tmp, ".docker", "cli-plugins", "docker-lint")
+	registrar := dockerPluginRegistrar{goos: "linux"}
+	plan := dockerPluginRegistrationPlan{
+		SourcePath: source,
+		TargetPath: target,
+		Mode:       installModeSymlink,
+		SourceKind: "global binary",
+	}
+
+	if err := registrar.register(plan, false); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	got, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("readlink target: %v", err)
+	}
+	if got != source {
+		t.Fatalf("symlink target = %q, want %q", got, source)
+	}
+}
+
+func TestDockerPluginRegistrarRegisterCopy(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "bin", "tally.exe")
+	if err := os.MkdirAll(filepath.Dir(source), 0o750); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("binary"), 0o700); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	target := filepath.Join(tmp, ".docker", "cli-plugins", "docker-lint.exe")
+	registrar := dockerPluginRegistrar{goos: windowsGOOS}
+	plan := dockerPluginRegistrationPlan{
+		SourcePath: source,
+		TargetPath: target,
+		Mode:       installModeCopy,
+		SourceKind: "WinGet",
+	}
+
+	if err := registrar.register(plan, false); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(got) != "binary" {
+		t.Fatalf("copied content = %q, want binary", got)
+	}
+	if err := registrar.register(plan, false); err != nil {
+		t.Fatalf("register second identical copy: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("new binary"), 0o700); err != nil {
+		t.Fatalf("rewrite source: %v", err)
+	}
+	if err := registrar.register(plan, false); err == nil {
+		t.Fatal("register with changed source succeeded without --force")
+	}
+	if err := registrar.register(plan, true); err != nil {
+		t.Fatalf("register with force: %v", err)
+	}
+	got, err = os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read forced target: %v", err)
+	}
+	if string(got) != "new binary" {
+		t.Fatalf("forced copied content = %q, want new binary", got)
+	}
+}
+
+func testDockerPluginRegistrar(t *testing.T, currentVersion string) dockerPluginRegistrar {
+	t.Helper()
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "bin", "tally")
+	if err := os.MkdirAll(filepath.Dir(source), 0o750); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("binary"), 0o700); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	return dockerPluginRegistrar{
+		goos:           "linux",
+		homeDir:        tmp,
+		cwd:            filepath.Join(tmp, "outside"),
+		tempDir:        filepath.Join(tmp, "tmp"),
+		args0:          source,
+		currentVersion: currentVersion,
+	}
+}

--- a/cmd/tally/cmd/docker_plugin_test.go
+++ b/cmd/tally/cmd/docker_plugin_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli-plugins/metadata"
+)
+
+func TestIsDockerLintPluginExecutable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "unix plugin", path: "/usr/local/lib/docker/cli-plugins/docker-lint", want: true},
+		{name: "windows plugin", path: `C:\Users\me\.docker\cli-plugins\docker-lint.exe`, want: true},
+		{name: "windows uppercase suffix", path: `C:\Users\me\.docker\cli-plugins\docker-lint.EXE`, want: true},
+		{name: "standalone", path: "/usr/local/bin/tally", want: false},
+		{name: "near miss", path: "/usr/local/bin/docker-tally", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsDockerLintPluginExecutable(tc.path); got != tc.want {
+				t.Fatalf("IsDockerLintPluginExecutable(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDockerPluginMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta := dockerPluginMetadata()
+	if meta.SchemaVersion != "0.1.0" {
+		t.Fatalf("SchemaVersion = %q, want 0.1.0", meta.SchemaVersion)
+	}
+	if meta.Vendor != "Wharflab" {
+		t.Fatalf("Vendor = %q, want Wharflab", meta.Vendor)
+	}
+	if meta.Version == "" {
+		t.Fatal("Version should not be empty")
+	}
+	if meta.ShortDescription == "" {
+		t.Fatal("ShortDescription should not be empty")
+	}
+	if meta.URL != "https://tally.wharflab.com/" {
+		t.Fatalf("URL = %q, want https://tally.wharflab.com/", meta.URL)
+	}
+}
+
+func TestDockerLintPluginCommandShape(t *testing.T) {
+	t.Parallel()
+
+	cmd := newDockerLintPluginCommand(nil)
+	if cmd.Name() != "lint" {
+		t.Fatalf("plugin command name = %q, want lint", cmd.Name())
+	}
+	if cmd.Version == "" {
+		t.Fatal("plugin command should expose a version")
+	}
+	for _, unsupported := range []string{"lsp", "version"} {
+		if sub, _, err := cmd.Find([]string{unsupported}); err == nil && sub != cmd {
+			t.Fatalf("plugin command should not expose standalone subcommand %q", unsupported)
+		}
+	}
+}
+
+func TestStandaloneRootDoesNotExposeDockerMetadata(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCommand()
+	if sub, _, err := root.Find([]string{metadata.MetadataSubcommandName}); err == nil && sub != root {
+		t.Fatalf("standalone root exposes %q", metadata.MetadataSubcommandName)
+	}
+}

--- a/cmd/tally/cmd/lint.go
+++ b/cmd/tally/cmd/lint.go
@@ -44,8 +44,13 @@ const (
 )
 
 func lintCommand() *cobra.Command {
-	opts := &lintOptions{}
+	return newLintCommand(&lintOptions{})
+}
 
+func newLintCommand(opts *lintOptions) *cobra.Command {
+	if opts == nil {
+		opts = &lintOptions{}
+	}
 	cmd := &cobra.Command{
 		Use:   "lint [DOCKERFILE...]",
 		Short: "Lint Dockerfile(s) for issues",

--- a/cmd/tally/cmd/options.go
+++ b/cmd/tally/cmd/options.go
@@ -60,6 +60,15 @@ type lintOptions struct {
 	// Complex (shell-quoted) AI flag: parsed then folded into the config.
 	acpCommand    string
 	acpCommandSet bool
+
+	// Optional metadata captured when tally is invoked as a Docker CLI plugin.
+	dockerPlugin *dockerPluginContext
+}
+
+type dockerPluginContext struct {
+	CurrentContext string
+	ConfigPath     string
+	EndpointHost   string
 }
 
 // addLintFlags registers all lint flags on the given FlagSet. The flags are

--- a/cmd/tally/cmd/root.go
+++ b/cmd/tally/cmd/root.go
@@ -53,6 +53,7 @@ Examples:
 	cmd.AddCommand(lintCommand())
 	cmd.AddCommand(lspCommand())
 	cmd.AddCommand(versionCommand())
+	cmd.AddCommand(registerDockerPluginCommand())
 
 	return cmd
 }

--- a/cmd/tally/cmd/root.go
+++ b/cmd/tally/cmd/root.go
@@ -61,3 +61,12 @@ Examples:
 func Execute() error {
 	return NewRootCommand().Execute()
 }
+
+// ExecuteForExecutable dispatches to the standalone CLI or Docker CLI plugin
+// mode based on the invoked executable name.
+func ExecuteForExecutable(executable string) error {
+	if IsDockerLintPluginExecutable(executable) {
+		return ExecuteDockerPlugin()
+	}
+	return Execute()
+}

--- a/design-docs/41-docker-cli-plugin.md
+++ b/design-docs/41-docker-cli-plugin.md
@@ -133,9 +133,8 @@ WinGet precedent is different from Homebrew:
 - `Docker.DockerCompose` is also a WinGet portable package with `Commands: docker-compose`; it likewise does not install into Docker's CLI plugin
   directory.
   Reference: <https://github.com/microsoft/winget-pkgs/blob/master/manifests/d/Docker/DockerCompose/5.1.3/Docker.DockerCompose.installer.yaml>
-- The WinGet installer schema allows up to 16 `Commands`, described as commands or aliases to run the package. That can expose `docker-lint` as a
-  direct command, but it is not by itself Docker CLI plugin registration.
-  Reference: <https://aka.ms/winget-manifest.installer.1.12.0.schema.json>
+- The WinGet portable installer validator currently accepts only zero or one `Commands` value per portable installer. Keep `tally` as that command;
+  `docker-lint` must be registered later with `tally register-docker-plugin`.
 
 Docker CLI plugin discovery looks for `docker-*` executables in the Docker config `cli-plugins` directory, configured `cliPluginsExtraDirs`, and
 platform system plugin directories. On Windows, the system plugin directory is `%ProgramFiles%\Docker\cli-plugins`; user installs should prefer
@@ -677,44 +676,23 @@ MVP recommendation:
 
 1. Keep the package identifier `Wharflab.Tally`.
 2. Keep `tally` as the primary WinGet command.
-3. Add `docker-lint` to the manifest `Commands` list after the plugin invocation mode exists:
-
-   ```yaml
-   Commands:
-   - tally
-   - docker-lint
-   ```
-
+3. Do not add `docker-lint` to the WinGet portable `Commands` list; WinGet validation rejects multiple portable commands.
 4. Do not try to make the WinGet manifest install directly into `%USERPROFILE%\.docker\cli-plugins`.
 5. Do not edit Docker's `config.json` from WinGet.
 6. Do not rely on Windows registry registration. Docker CLI plugin discovery does not consume registry entries.
 
-This mirrors Docker's own WinGet precedent for Buildx and Compose: WinGet exposes portable commands, while Docker CLI plugin discovery is handled
-by Docker plugin directories or `cliPluginsExtraDirs`.
+This mirrors Docker's own WinGet precedent for Buildx and Compose: WinGet exposes a portable command, while Docker CLI plugin discovery is handled
+by Docker plugin directories.
 
-Documentation should offer two Windows paths:
+Documentation should offer the simple Windows path:
 
-1. Simple and deterministic:
+```powershell
+winget install --id Wharflab.Tally -e
+tally register-docker-plugin
+docker lint --help
+```
 
-   ```powershell
-   winget install --id Wharflab.Tally -e
-   New-Item -ItemType Directory -Force "$env:USERPROFILE\.docker\cli-plugins"
-   Copy-Item (Get-Command tally.exe).Source "$env:USERPROFILE\.docker\cli-plugins\docker-lint.exe" -Force
-   docker lint --help
-   ```
-
-   Users must repeat the copy after `winget upgrade Wharflab.Tally` unless a future installer handles plugin placement.
-
-2. Advanced, if WinGet's `docker-lint` command alias is available and Docker can execute that alias directly:
-
-   ```powershell
-   $pluginDir = Split-Path (Get-Command docker-lint.exe).Source
-   ```
-
-   Add `$pluginDir` to Docker CLI `cliPluginsExtraDirs` in `%USERPROFILE%\.docker\config.json`.
-
-The implementation issue must validate the advanced path on a real Windows runner before documenting it as supported. If Docker cannot execute the
-WinGet alias directly, keep it as unsupported and document only the copy path.
+Users should rerun the registration after `winget upgrade Wharflab.Tally`.
 
 ---
 
@@ -941,7 +919,7 @@ Tasks:
 - add Homebrew `docker-lint` symlink under `lib/docker/cli-plugins`
 - add Homebrew caveats for `cliPluginsExtraDirs`
 - fix formula test to use `tally lint`
-- add `docker-lint` to generated WinGet `Commands` after validation
+- keep generated WinGet `Commands` limited to `tally`
 - update docs with Homebrew, WinGet, and manual install paths
 
 Acceptance criteria:
@@ -1007,15 +985,15 @@ Files:
 
 Tasks:
 
-- add `docker-lint` to generated WinGet `Commands`
-- update manifest tests to expect both `tally` and `docker-lint`
-- decide, after Windows validation, whether docs can support `cliPluginsExtraDirs` pointing at the WinGet alias directory
+- keep generated WinGet `Commands` limited to `tally`
+- update manifest tests to reject the invalid multi-command portable installer shape
+- document `tally register-docker-plugin` as the WinGet plugin setup path
 
 Acceptance criteria:
 
 - `winget validate --manifest` accepts the generated manifests
 - `winget install --manifest` exposes `tally`
-- `winget install --manifest` exposes `docker-lint` if the multiple-command alias path validates
+- `winget install --manifest` does not attempt to expose `docker-lint` as a second portable command
 - docs do not imply that `winget install Wharflab.Tally` alone makes `docker lint` work unless that exact path has been verified
 
 #### Documentation
@@ -1061,7 +1039,7 @@ Acceptance criteria:
 | Release metadata has wrong version | add release smoke asserting metadata `Version` against `RELEASE_VERSION` |
 | Plugin root drifts from `tally lint` flags | build plugin root from shared Cobra lint command/options and add representative flag tests |
 | Symlink invocation is not detected on Windows | trim `.exe` in detection and copy binary to `docker-lint.exe` in Windows tests |
-| WinGet exposes `docker-lint` but Docker does not discover it | document the copy-to-plugin-dir path; only document `cliPluginsExtraDirs` for WinGet after real Windows validation |
+| WinGet cannot expose both `tally` and `docker-lint` as portable commands | keep WinGet focused on `tally` and document `tally register-docker-plugin` |
 
 ---
 
@@ -1077,9 +1055,8 @@ Acceptance criteria:
 
 3. Should WinGet expose `docker-lint` in addition to `tally`?
 
-   Recommendation: yes, if local manifest validation confirms multiple portable command aliases work with the current WinGet client. This is
-   useful even before full Docker CLI discovery because it gives users a direct `docker-lint` command and gives Docker a possible
-   `cliPluginsExtraDirs` target.
+   Recommendation: no. Current WinGet validation rejects multiple `Commands` values for portable installers, so WinGet should expose `tally` and
+   users should run `tally register-docker-plugin` for Docker CLI registration.
 
 4. Should `docker lint --version` be guaranteed?
 
@@ -1112,6 +1089,6 @@ The feature is complete when:
 - Docker current context/config metadata is available to the plugin path without requiring daemon access
 - Homebrew installs a `docker-lint` symlink under `#{HOMEBREW_PREFIX}/lib/docker/cli-plugins`
 - Homebrew caveats explain `cliPluginsExtraDirs`
-- WinGet keeps `tally` as the primary command and, after validation, exposes `docker-lint` as an additional portable command alias
+- WinGet keeps `tally` as the primary command and plugin registration is handled by `tally register-docker-plugin`
 - docs include a dedicated Docker CLI plugin integration page
 - tests cover metadata, invocation detection, plugin root behavior, and release version injection

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/containerd/platforms v1.0.0-rc.4
 	github.com/distribution/reference v0.6.0
 	github.com/docker/buildx v0.33.0
+	github.com/docker/cli v29.4.0+incompatible
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/editorconfig/editorconfig-core-go/v2 v2.6.4
 	github.com/gkampitakis/ciinfo v0.3.4
@@ -46,6 +47,7 @@ require (
 	github.com/wharflab/tree-sitter-powershell v0.36.0
 	github.com/zricethezav/gitleaks/v8 v8.30.1
 	go.bug.st/lsp v0.1.3
+	go.opentelemetry.io/otel v1.40.0
 	go.podman.io/image/v5 v5.39.2
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/exp/jsonrpc2 v0.0.0-20250718183923-645b1fa84792
@@ -122,7 +124,6 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 // indirect
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
-	github.com/docker/cli v29.4.0+incompatible // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
@@ -294,7 +295,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
-	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/lipgloss/v2 v2.0.3
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/bluekeyes/go-gitdiff v0.8.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0
@@ -63,7 +64,6 @@ require (
 	github.com/BobuSumisu/aho-corasick v1.0.3 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,164 +1,172 @@
 amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 // Git hook manager: https://hk.jdx.dev
 // Install hooks for this repo: `hk install`
 // Preferred: `hk install --global` (requires Git 2.54+; uses config-based hooks).
 
 env {
-    ["GOEXPERIMENT"] = "jsonv2"
+  ["GOEXPERIMENT"] = "jsonv2"
 }
 
 local preCommitSteps = new Mapping<String, Step> {
-    ["format-go"] {
-        glob = List("**/*.go")
-        fix = "gofmt -w -s {{files}}"
-        stage = List("**/*.go")
-    }
-    ["lint-go"] {
-        glob = List("**/*.go")
-        fix = "make lint-fix"
-        stage = List("**/*.go")
-        depends = List("format-go")
-    }
-    ["ts-typecheck"] {
-        glob = List("_integrations/vscode-tally/**/*.ts")
-        dir = "_integrations/vscode-tally"
-        check = "bunx @typescript/native-preview --noEmit"
-    }
-    ["ts-lint"] {
-        glob = List("_integrations/vscode-tally/**/*.{js,ts,cjs,mjs,d.cts,d.mts}")
-        dir = "_integrations/vscode-tally"
-        fix = "bunx -y -q oxlint --type-aware --fix --fix-suggestions {{files}}"
-        stage = List("_integrations/vscode-tally/**/*.{js,ts,cjs,mjs,d.cts,d.mts}")
-    }
-    ["ts-format"] {
-        glob = List("_integrations/vscode-tally/**/*.{js,ts,cjs,mjs,mts,cts,jsx,tsx}")
-        dir = "_integrations/vscode-tally"
-        fix = "bunx -y -q oxfmt --no-error-on-unmatched-pattern --write {{files}}"
-        stage = List("_integrations/vscode-tally/**/*.{js,ts,cjs,mjs,mts,cts,jsx,tsx}")
-    }
-    ["ktlint-format"] {
-        glob = List("_integrations/intellij-tally/src/main/kotlin/**/*.kt")
-        fix = "bash _integrations/intellij-tally/build/ktlint.sh --format {{files}}"
-        stage = List("_integrations/intellij-tally/src/main/kotlin/**/*.kt")
-    }
-    ["ktlint-lint"] {
-        glob = List("_integrations/intellij-tally/src/main/kotlin/**/*.kt")
-        check = "bash _integrations/intellij-tally/build/ktlint.sh {{files}}"
-        depends = List("ktlint-format")
-    }
-    ["rust-fmt"] {
-        glob = List("_integrations/zed-tally/**/*.rs")
-        fix = "cargo fmt --manifest-path _integrations/zed-tally/Cargo.toml -- {{files}}"
-        stage = List("_integrations/zed-tally/**/*.rs")
-    }
-    ["rust-clippy"] {
-        glob = List("_integrations/zed-tally/**/*.rs")
-        check = "cargo clippy --manifest-path _integrations/zed-tally/Cargo.toml --target wasm32-wasip2 -- -D warnings"
-        depends = List("rust-fmt")
-    }
-    ["taplo"] {
-        glob = List("**/*.toml")
-        fix = "bunx -y -q @taplo/cli format {{files}}"
-        stage = List("**/*.toml")
-    }
-    ["rumdl"] {
-        glob = List("**/*.{md,mdx}")
-        exclude = List("**/__snapshots__/**")
-        fix = "uv tool run rumdl==0.1.84 fmt {{files}}"
-        stage = List("**/*.{md,mdx}")
-    }
-    ["mintlify-docs-verify"] {
-        glob = List("_docs/**")
-        dir = "_docs"
-        check = "bunx -y -q mint validate"
-    }
-    ["yamllint"] {
-        glob = List("**/*.{yml,yaml}")
-        check = "uvx yamllint {{files}}"
-    }
-    ["format-yml"] {
-        glob = List("**/{.yamlfmt,*.yml,*.yaml}")
-        fix = "yamlfmt {{files}}"
-        stage = List("**/{.yamlfmt,*.yml,*.yaml}")
-    }
-    ["typos"] {
-        glob = List("**/*.{py,js,ts,tsx,toml,yaml,yml,json,html,css,md,txt,rst,tex}")
-        check = "uv tool run typos==1.45.2 --force-exclude {{files}}"
-    }
-    ["codecov"] {
-        glob = List("codecov.yml", ".codecov.yml")
-        check = "curl --fail --data-binary @.codecov.yml https://codecov.io/validate"
-    }
-    ["actionlint"] {
-        glob = List(".github/workflows/*.{yaml,yml}")
-        check = "actionlint {{files}}"
-    }
-    ["commitlint-config"] {
-        glob = List(".commitlintrc.yaml")
-        check = "uvx check-jsonschema --schemafile https://json.schemastore.org/commitlintrc.json .commitlintrc.yaml"
-    }
-    ["hk-validate"] {
-        glob = List("hk.pkl")
-        check = "hk validate"
-    }
+  ["format-go"] = (Builtins.go_fmt) {
+    glob = List("**/*.go")
+  }
+  ["lint-go"] {
+    glob = List("**/*.go")
+    fix = "make lint-fix"
+    depends = List("format-go")
+  }
+  ["ts-typecheck"] {
+    glob = List("_integrations/vscode-tally/**/*.ts")
+    dir = "_integrations/vscode-tally"
+    check = "bunx @typescript/native-preview --noEmit"
+  }
+  ["ts-lint"] = (Builtins.ox_lint) {
+    glob =
+      List(
+        "_integrations/vscode-tally/**/*.js",
+        "_integrations/vscode-tally/**/*.ts",
+        "_integrations/vscode-tally/**/*.cjs",
+        "_integrations/vscode-tally/**/*.mjs",
+        "_integrations/vscode-tally/**/*.cts",
+        "_integrations/vscode-tally/**/*.mts",
+      )
+    dir = "_integrations/vscode-tally"
+    fix = "bunx -y -q oxlint --type-aware --fix --fix-suggestions {{files}}"
+  }
+  ["ts-format"] {
+    glob =
+      List(
+        "_integrations/vscode-tally/**/*.js",
+        "_integrations/vscode-tally/**/*.ts",
+        "_integrations/vscode-tally/**/*.cjs",
+        "_integrations/vscode-tally/**/*.mjs",
+        "_integrations/vscode-tally/**/*.cts",
+        "_integrations/vscode-tally/**/*.mts",
+      )
+    dir = "_integrations/vscode-tally"
+    fix = "bunx -y -q oxfmt --no-error-on-unmatched-pattern --write {{files}}"
+  }
+  ["ktlint-format"] {
+    glob = List("_integrations/intellij-tally/src/main/kotlin/**/*.kt")
+    fix = "bash _integrations/intellij-tally/build/ktlint.sh --format {{files}}"
+  }
+  ["ktlint-lint"] {
+    glob = List("_integrations/intellij-tally/src/main/kotlin/**/*.kt")
+    check = "bash _integrations/intellij-tally/build/ktlint.sh {{files}}"
+    depends = List("ktlint-format")
+  }
+  ["rust-fmt"] {
+    glob = List("_integrations/zed-tally/**/*.rs")
+    fix = "cargo fmt --manifest-path _integrations/zed-tally/Cargo.toml -- {{files}}"
+  }
+  ["rust-clippy"] {
+    glob = List("_integrations/zed-tally/**/*.rs")
+    check =
+      "cargo clippy --manifest-path _integrations/zed-tally/Cargo.toml --target wasm32-wasip2 -- -D warnings"
+    depends = List("rust-fmt")
+  }
+  ["taplo"] {
+    glob = List("**/*.toml")
+    fix = "bunx -y -q @taplo/cli format {{files}}"
+  }
+  ["rumdl"] {
+    glob = List("**/*.{md,mdx}")
+    exclude = List("**/__snapshots__/**")
+    fix = "uv tool run rumdl==0.1.84 fmt {{files}}"
+  }
+  ["mintlify-docs-verify"] {
+    glob = List("_docs/**")
+    dir = "_docs"
+    check = "bunx -y -q mint validate"
+  }
+  ["yamllint"] {
+    glob = List("**/*.{yml,yaml}")
+    check = "uvx yamllint {{files}}"
+  }
+  ["format-yml"] {
+    glob = List("**/{.yamlfmt,*.yml,*.yaml}")
+    fix = "yamlfmt {{files}}"
+  }
+  ["typos"] {
+    glob = List("**/*.{py,js,ts,tsx,toml,yaml,yml,json,html,css,md,txt,rst,tex}")
+    check = "uv tool run typos==1.45.2 --force-exclude {{files}}"
+  }
+  ["codecov"] {
+    glob = List("codecov.yml", ".codecov.yml")
+    check = "curl --fail --data-binary @.codecov.yml https://codecov.io/validate"
+  }
+  ["actionlint"] = (Builtins.actionlint) {}
+  ["commitlint-config"] {
+    glob = List(".commitlintrc.yaml")
+    check =
+      "uvx check-jsonschema --schemafile https://json.schemastore.org/commitlintrc.json .commitlintrc.yaml"
+  }
+  ["hk-validate"] {
+    glob = List("hk.pkl")
+    check = "hk validate"
+  }
+  ["pkl-format"] = (Builtins.pkl_format) {}
 }
 
 local commitMsgSteps = new Mapping<String, Step> {
-    ["commitlint"] {
-        check = "bunx -y -q commitlint --edit {{commit_msg_file}}"
-    }
-    ["typos-commit-msg"] {
-        check = "uv tool run typos==1.45.2 {{commit_msg_file}}"
-    }
+  ["commitlint"] {
+    check = "bunx -y -q commitlint --edit {{commit_msg_file}}"
+  }
+  ["typos-commit-msg"] {
+    check = "uv tool run typos==1.45.2 {{commit_msg_file}}"
+  }
 }
 
 local postMergeSteps = new Mapping<String, Step> {
-    ["delete-merged-branches"] {
-        shell = "bash -o errexit -o pipefail -c"
-        check = "git branch --merged | grep -Ev '\\*|master|main|dev|develop|development|stag|staging|prod|production' | xargs git branch -d 2>/dev/null || true; git fetch --prune"
-    }
+  ["delete-merged-branches"] {
+    shell = "bash -o errexit -o pipefail -c"
+    check =
+      "git branch --merged | grep -Ev '\\*|master|main|dev|develop|development|stag|staging|prod|production' | xargs git branch -d 2>/dev/null || true; git fetch --prune"
+  }
 }
 
 local prePushSteps = new Mapping<String, Step> {
-    ["build"] {
-        check = "make build"
-    }
-    ["deadcode"] {
-        check = "make deadcode"
-    }
-    ["test"] {
-        check = "make test"
-    }
-    ["validate-hadolint-status"] {
-        check = "./scripts/validate-hadolint-status.sh"
-    }
-    ["mintlify-docs-broken-links"] {
-        dir = "_docs"
-        check = "bunx -y -q mint broken-links"
-    }
+  ["build"] {
+    check = "make build"
+  }
+  ["deadcode"] {
+    check = "make deadcode"
+  }
+  ["test"] {
+    check = "make test"
+  }
+  ["validate-hadolint-status"] {
+    check = "./scripts/validate-hadolint-status.sh"
+  }
+  ["mintlify-docs-broken-links"] {
+    dir = "_docs"
+    check = "bunx -y -q mint broken-links"
+  }
 }
 
 hooks {
-    ["pre-commit"] {
-        fix = true
-        stash = "git"
-        steps = preCommitSteps
-    }
-    ["commit-msg"] {
-        steps = commitMsgSteps
-    }
-    ["post-merge"] {
-        steps = postMergeSteps
-    }
-    ["pre-push"] {
-        steps = prePushSteps
-    }
-    ["fix"] {
-        fix = true
-        steps = preCommitSteps
-    }
-    ["check"] {
-        steps = preCommitSteps
-    }
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = preCommitSteps
+  }
+  ["commit-msg"] {
+    steps = commitMsgSteps
+  }
+  ["post-merge"] {
+    steps = postMergeSteps
+  }
+  ["pre-push"] {
+    steps = prePushSteps
+  }
+  ["fix"] {
+    fix = true
+    steps = preCommitSteps
+  }
+  ["check"] {
+    steps = preCommitSteps
+  }
 }

--- a/internal/integration/docker_plugin_test.go
+++ b/internal/integration/docker_plugin_test.go
@@ -1,0 +1,145 @@
+package integration
+
+import (
+	"encoding/json/v2"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/cli-plugins/metadata"
+)
+
+func TestDockerCLIPluginMetadata(t *testing.T) {
+	t.Parallel()
+
+	pluginPath := dockerPluginPath(t)
+	cmd := exec.Command(pluginPath, metadata.MetadataSubcommandName)
+	cmd.Env = append(os.Environ(), "GOCOVERDIR="+coverageDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("metadata command failed: %v\noutput:\n%s", err, output)
+	}
+
+	var got metadata.Metadata
+	if err := json.Unmarshal(output, &got); err != nil {
+		t.Fatalf("parse metadata JSON: %v\noutput:\n%s", err, output)
+	}
+	if got.SchemaVersion != "0.1.0" {
+		t.Fatalf("SchemaVersion = %q, want 0.1.0", got.SchemaVersion)
+	}
+	if got.Vendor != "Wharflab" {
+		t.Fatalf("Vendor = %q, want Wharflab", got.Vendor)
+	}
+	if got.Version == "" {
+		t.Fatal("Version should not be empty")
+	}
+}
+
+func TestDockerCLIPluginLintCommand(t *testing.T) {
+	t.Parallel()
+
+	pluginPath := dockerPluginPath(t)
+	tmpDir := t.TempDir()
+	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte("FROM alpine:3.20\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	configPath := filepath.Join(tmpDir, ".tally.toml")
+	if err := os.WriteFile(configPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(pluginPath, "lint", "--config", configPath, "--format", "json", "--ignore", "*", dockerfilePath)
+	cmd.Env = append(os.Environ(), "GOCOVERDIR="+coverageDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("plugin lint failed: %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(string(output), `"files_scanned"`) {
+		t.Fatalf("expected JSON lint output with files_scanned, got:\n%s", output)
+	}
+}
+
+func TestDockerCLIPluginVersionFlag(t *testing.T) {
+	t.Parallel()
+
+	pluginPath := dockerPluginPath(t)
+	cmd := exec.Command(pluginPath, "lint", "--version")
+	cmd.Env = append(os.Environ(), "GOCOVERDIR="+coverageDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("plugin version failed: %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "docker-lint version ") {
+		t.Fatalf("expected docker-lint version output, got:\n%s", output)
+	}
+}
+
+func TestDockerCLIPluginSeparatesDockerAndTallyConfigFlags(t *testing.T) {
+	t.Parallel()
+
+	pluginPath := dockerPluginPath(t)
+	tmpDir := t.TempDir()
+	dockerConfigDir := filepath.Join(tmpDir, "docker-config")
+	if err := os.MkdirAll(dockerConfigDir, 0o755); err != nil {
+		t.Fatalf("create Docker config dir: %v", err)
+	}
+	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte("FROM alpine:3.20\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	tallyConfigPath := filepath.Join(tmpDir, ".tally.toml")
+	if err := os.WriteFile(tallyConfigPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("write tally config: %v", err)
+	}
+
+	cmd := exec.Command(
+		pluginPath,
+		"--config", dockerConfigDir,
+		"lint",
+		"--config", tallyConfigPath,
+		"--format", "json",
+		"--ignore", "*",
+		dockerfilePath,
+	)
+	cmd.Env = append(os.Environ(), "GOCOVERDIR="+coverageDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("plugin lint with Docker global --config failed: %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(string(output), `"files_scanned"`) {
+		t.Fatalf("expected JSON lint output with files_scanned, got:\n%s", output)
+	}
+}
+
+func dockerPluginPath(t *testing.T) string {
+	t.Helper()
+
+	pluginName := "docker-lint"
+	if runtime.GOOS == "windows" {
+		pluginName += ".exe"
+	}
+	pluginPath := filepath.Join(t.TempDir(), pluginName)
+	if runtime.GOOS == "windows" {
+		input, err := os.ReadFile(binaryPath)
+		if err != nil {
+			t.Fatalf("read integration binary: %v", err)
+		}
+		if err := os.WriteFile(pluginPath, input, 0o755); err != nil {
+			t.Fatalf("copy plugin binary: %v", err)
+		}
+		return pluginPath
+	}
+
+	if err := os.Symlink(binaryPath, pluginPath); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			t.Skipf("symlink not permitted: %v", err)
+		}
+		t.Fatalf("create plugin symlink: %v", err)
+	}
+	return pluginPath
+}

--- a/internal/integration/docker_plugin_test.go
+++ b/internal/integration/docker_plugin_test.go
@@ -85,7 +85,7 @@ func TestDockerCLIPluginSeparatesDockerAndTallyConfigFlags(t *testing.T) {
 	pluginPath := dockerPluginPath(t)
 	tmpDir := t.TempDir()
 	dockerConfigDir := filepath.Join(tmpDir, "docker-config")
-	if err := os.MkdirAll(dockerConfigDir, 0o755); err != nil {
+	if err := os.MkdirAll(dockerConfigDir, 0o750); err != nil {
 		t.Fatalf("create Docker config dir: %v", err)
 	}
 	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -9,10 +8,12 @@ import (
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
-		var exitErr *cmd.ExitError
-		if errors.As(err, &exitErr) {
-			os.Exit(exitErr.Code)
+	if err := cmd.ExecuteForExecutable(os.Args[0]); err != nil {
+		if code, message, ok := cmd.ExitStatus(err); ok {
+			if message != "" {
+				fmt.Fprintln(os.Stderr, message)
+			}
+			os.Exit(code)
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/packaging/homebrew/tally.rb.template
+++ b/packaging/homebrew/tally.rb.template
@@ -35,12 +35,16 @@ class Tally < Formula
 
   def caveats
     <<~EOS
-      tally is also installed as a Docker CLI plugin. For Docker to find the plugin,
-      add "cliPluginsExtraDirs" to ~/.docker/config.json:
+      To register tally as the per-user Docker CLI plugin:
 
-        "cliPluginsExtraDirs": [
-            "#{HOMEBREW_PREFIX}/lib/docker/cli-plugins"
-        ]
+        tally register-docker-plugin
+
+      A Homebrew-managed docker-lint symlink is also installed in:
+
+        #{HOMEBREW_PREFIX}/lib/docker/cli-plugins
+
+      If you prefer that path, add it to Docker's "cliPluginsExtraDirs" in
+      ~/.docker/config.json.
     EOS
   end
 
@@ -57,6 +61,31 @@ class Tally < Formula
 
     # Verify Docker CLI plugin metadata without requiring Docker itself
     metadata = shell_output("#{lib}/docker/cli-plugins/docker-lint docker-cli-plugin-metadata")
+    assert_match "\"SchemaVersion\": \"0.1.0\"", metadata
+    assert_match "\"Vendor\": \"Wharflab\"", metadata
+
+    fakebin = testpath/"fakebin"
+    fakebin.mkpath
+    (fakebin/"docker").write <<~SH
+      #!/bin/sh
+      if [ "$1" = "info" ] && [ "$2" = "--format" ] && [ "$3" = "json" ]; then
+        plugin="$DOCKER_CONFIG/cli-plugins/docker-lint"
+        if [ -e "$plugin" ]; then
+          printf '{"ClientInfo":{"Version":"29.4.1","Plugins":[{"Name":"lint","Vendor":"Wharflab","Version":"#{version}","ShortDescription":"Lint Dockerfiles and Containerfiles","Path":"%s"}]}}' "$plugin"
+        else
+          printf '{"ClientInfo":{"Version":"29.4.1","Plugins":[]}}'
+        fi
+        exit 0
+      fi
+      exit 1
+    SH
+    chmod 0755, fakebin/"docker"
+    ENV["DOCKER_CONFIG"] = testpath/".docker"
+    ENV.prepend_path "PATH", fakebin
+    system "#{bin}/tally", "register-docker-plugin"
+    plugin = testpath/".docker/cli-plugins/docker-lint"
+    assert_predicate plugin, :exist?
+    metadata = shell_output("#{plugin} docker-cli-plugin-metadata")
     assert_match "\"SchemaVersion\": \"0.1.0\"", metadata
     assert_match "\"Vendor\": \"Wharflab\"", metadata
 

--- a/packaging/homebrew/tally.rb.template
+++ b/packaging/homebrew/tally.rb.template
@@ -30,6 +30,18 @@ class Tally < Formula
 
   def install
     bin.install "tally"
+    (lib/"docker/cli-plugins").install_symlink bin/"tally" => "docker-lint"
+  end
+
+  def caveats
+    <<~EOS
+      tally is also installed as a Docker CLI plugin. For Docker to find the plugin,
+      add "cliPluginsExtraDirs" to ~/.docker/config.json:
+
+        "cliPluginsExtraDirs": [
+            "#{HOMEBREW_PREFIX}/lib/docker/cli-plugins"
+        ]
+    EOS
   end
 
   test do
@@ -40,8 +52,13 @@ class Tally < Formula
     DOCKERFILE
 
     # Run tally and check it executes successfully
-    output = shell_output("#{bin}/tally check #{testpath}/Dockerfile --format json")
+    output = shell_output("#{bin}/tally lint #{testpath}/Dockerfile --format json --ignore '*'")
     assert_match "files_scanned", output
+
+    # Verify Docker CLI plugin metadata without requiring Docker itself
+    metadata = shell_output("#{lib}/docker/cli-plugins/docker-lint docker-cli-plugin-metadata")
+    assert_match "\"SchemaVersion\": \"0.1.0\"", metadata
+    assert_match "\"Vendor\": \"Wharflab\"", metadata
 
     # Verify version output
     assert_match version.to_s, shell_output("#{bin}/tally version")

--- a/packaging/homebrew/tally.rb.template
+++ b/packaging/homebrew/tally.rb.template
@@ -49,6 +49,8 @@ class Tally < Formula
   end
 
   test do
+    require "json"
+
     # Create a simple Dockerfile to test
     (testpath/"Dockerfile").write <<~DOCKERFILE
       FROM alpine:latest
@@ -60,9 +62,9 @@ class Tally < Formula
     assert_match "files_scanned", output
 
     # Verify Docker CLI plugin metadata without requiring Docker itself
-    metadata = shell_output("#{lib}/docker/cli-plugins/docker-lint docker-cli-plugin-metadata")
-    assert_match "\"SchemaVersion\": \"0.1.0\"", metadata
-    assert_match "\"Vendor\": \"Wharflab\"", metadata
+    metadata = JSON.parse(shell_output("#{lib}/docker/cli-plugins/docker-lint docker-cli-plugin-metadata"))
+    assert_equal "0.1.0", metadata["SchemaVersion"]
+    assert_equal "Wharflab", metadata["Vendor"]
 
     fakebin = testpath/"fakebin"
     fakebin.mkpath
@@ -85,9 +87,9 @@ class Tally < Formula
     system "#{bin}/tally", "register-docker-plugin"
     plugin = testpath/".docker/cli-plugins/docker-lint"
     assert_predicate plugin, :exist?
-    metadata = shell_output("#{plugin} docker-cli-plugin-metadata")
-    assert_match "\"SchemaVersion\": \"0.1.0\"", metadata
-    assert_match "\"Vendor\": \"Wharflab\"", metadata
+    metadata = JSON.parse(shell_output("#{plugin} docker-cli-plugin-metadata"))
+    assert_equal "0.1.0", metadata["SchemaVersion"]
+    assert_equal "Wharflab", metadata["Vendor"]
 
     # Verify version output
     assert_match version.to_s, shell_output("#{bin}/tally version")

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -6,6 +6,8 @@ A fast, configurable linter for Dockerfiles and Containerfiles.
 
 ```bash
 npm install -g tally-cli
+# or
+bun add -g tally-cli
 ```
 
 ## Usage

--- a/scripts/release/generate_winget_manifests.rb
+++ b/scripts/release/generate_winget_manifests.rb
@@ -14,7 +14,7 @@ MANIFEST_VERSION = "1.9.0"
 SHORT_DESCRIPTION = "Dockerfile linter and formatter with first-class PowerShell and Windows container support."
 TAG_LIST = %w[docker dockerfile containerfile linter].freeze
 FILE_EXTENSION_LIST = %w[dockerfile containerfile].freeze
-COMMAND_LIST = %w[tally docker-lint].freeze
+COMMAND_LIST = %w[tally].freeze
 DOCUMENTATION_LIST = [
   {
     "DocumentLabel" => "Docs",

--- a/scripts/release/generate_winget_manifests.rb
+++ b/scripts/release/generate_winget_manifests.rb
@@ -14,6 +14,7 @@ MANIFEST_VERSION = "1.9.0"
 SHORT_DESCRIPTION = "Dockerfile linter and formatter with first-class PowerShell and Windows container support."
 TAG_LIST = %w[docker dockerfile containerfile linter].freeze
 FILE_EXTENSION_LIST = %w[dockerfile containerfile].freeze
+COMMAND_LIST = %w[tally docker-lint].freeze
 DOCUMENTATION_LIST = [
   {
     "DocumentLabel" => "Docs",
@@ -127,14 +128,14 @@ def installer_manifest(version, owner, repo, checksums, release_date = nil)
       "InstallerType" => "portable",
       "InstallerUrl" => github_release_url(owner, repo, version, filename),
       "InstallerSha256" => sha256,
-      "Commands" => ["tally"],
+      "Commands" => COMMAND_LIST,
     }
   end
 
   {
     "PackageIdentifier" => PACKAGE_IDENTIFIER,
     "PackageVersion" => version,
-    "Commands" => ["tally"],
+    "Commands" => COMMAND_LIST,
     "FileExtensions" => FILE_EXTENSION_LIST,
     "ReleaseDate" => release_date,
     "Installers" => installers,

--- a/scripts/release/test_generate_winget_manifests.rb
+++ b/scripts/release/test_generate_winget_manifests.rb
@@ -72,7 +72,8 @@ class GenerateWingetManifestsTest < Minitest::Test
       "2026-03-15",
     )
     assert_equal "portable", installer_manifest_data["Installers"][0]["InstallerType"]
-    assert_equal ["tally"], installer_manifest_data["Installers"][0]["Commands"]
+    assert_equal %w[tally docker-lint], installer_manifest_data["Commands"]
+    assert_equal %w[tally docker-lint], installer_manifest_data["Installers"][0]["Commands"]
     assert_equal %w[dockerfile containerfile], installer_manifest_data["FileExtensions"]
     assert_equal "2026-03-15", installer_manifest_data["ReleaseDate"]
     assert_equal(

--- a/scripts/release/test_generate_winget_manifests.rb
+++ b/scripts/release/test_generate_winget_manifests.rb
@@ -72,8 +72,8 @@ class GenerateWingetManifestsTest < Minitest::Test
       "2026-03-15",
     )
     assert_equal "portable", installer_manifest_data["Installers"][0]["InstallerType"]
-    assert_equal %w[tally docker-lint], installer_manifest_data["Commands"]
-    assert_equal %w[tally docker-lint], installer_manifest_data["Installers"][0]["Commands"]
+    assert_equal %w[tally], installer_manifest_data["Commands"]
+    assert_equal %w[tally], installer_manifest_data["Installers"][0]["Commands"]
     assert_equal %w[dockerfile containerfile], installer_manifest_data["FileExtensions"]
     assert_equal "2026-03-15", installer_manifest_data["ReleaseDate"]
     assert_equal(


### PR DESCRIPTION
## Summary
- add docker-lint executable dispatch using Docker CLI plugin helper and metadata
- expose only lint through the plugin while preserving standalone tally behavior
- add plugin metadata/version/integration coverage plus release smoke checks
- update Homebrew, WinGet, and Mintlify docs for Docker CLI plugin installation

## Testing
- GOEXPERIMENT=jsonv2 go test ./cmd/tally/cmd ./internal/config
- GOEXPERIMENT=jsonv2 go test ./internal/integration -run 'TestDockerCLIPlugin' -count=1
- ruby scripts/release/test_generate_winget_manifests.rb
- ruby -c packaging/homebrew/tally.rb.template
- mint validate
- mint broken-links
- pre-push hook: make build, make test, make deadcode, validate-hadolint-status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run tally as a Docker CLI plugin via docker lint plus a new register-docker-plugin flow; Homebrew installs a docker-lint plugin shim.

* **Documentation**
  * New Docker CLI plugin integration guide; installation, quickstart, and README updated to include Bun and uv and docker lint examples.

* **Packaging**
  * Homebrew exposes the docker-lint plugin; WinGet now uses post-install registration instead of shipping a separate docker-lint command.

* **Tests**
  * Added unit and integration tests covering plugin metadata, registration, and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->