### PR TITLE
deprecate BuildKit-covered Hadolint rules

### DIFF
--- a/_docs/docs.json
+++ b/_docs/docs.json
@@ -311,6 +311,7 @@
               "rules/hadolint/DL3057",
               "rules/hadolint/DL3059",
               "rules/hadolint/DL3061",
+              "rules/hadolint/DL3063",
               "rules/hadolint/DL4000",
               "rules/hadolint/DL4001",
               "rules/hadolint/DL4003",

--- a/_docs/rules/hadolint/DL3012.mdx
+++ b/_docs/rules/hadolint/DL3012.mdx
@@ -1,9 +1,9 @@
 ---
 title: "hadolint/DL3012"
-description: "Provide an exact tag for multiple `HEALTHCHECK` instructions."
+description: "Multiple `HEALTHCHECK` instructions."
 ---
 
-Provide an exact tag for multiple `HEALTHCHECK` instructions.
+Multiple `HEALTHCHECK` instructions.
 
 > **Superseded by
 > [`buildkit/MultipleInstructionsDisallowed`](../buildkit/MultipleInstructionsDisallowed)**,

--- a/_docs/rules/hadolint/DL3063.mdx
+++ b/_docs/rules/hadolint/DL3063.mdx
@@ -1,0 +1,30 @@
+---
+title: "hadolint/DL3063"
+description: "Stage name should not be a reserved word."
+---
+
+Stage name should not be a reserved word.
+
+> **Superseded by [`buildkit/ReservedStageName`](../buildkit/ReservedStageName)**, which provides the same check.
+
+## Description
+
+Stage aliases in `FROM ... AS <name>` must not use reserved Dockerfile stage names such as `scratch` or `context`.
+
+## Examples
+
+### Problematic code
+
+```dockerfile
+FROM alpine:3.21 AS scratch
+```
+
+### Correct code
+
+```dockerfile
+FROM alpine:3.21 AS builder
+```
+
+## Reference
+
+- [hadolint/DL3063](https://github.com/hadolint/hadolint/wiki/DL3063)

--- a/_docs/rules/hadolint/overview.mdx
+++ b/_docs/rules/hadolint/overview.mdx
@@ -78,6 +78,7 @@ coverage.
 | DL3029 | `buildkit/FromPlatformFlagConstDisallowed` + `tally/platform-mismatch` | `buildkit/FromPlatformFlagConstDisallowed` is off by default; `tally/platform-mismatch` provides a stricter registry-backed check |
 | DL3044 | `buildkit/UndefinedVar` | Covers referencing an ENV variable in the same ENV statement |
 | DL3059 | `tally/prefer-run-heredoc` 🔧 | Suggests heredoc syntax instead of consolidating consecutive RUN instructions |
+| DL3063 | `buildkit/ReservedStageName` | Covers reserved `scratch` and `context` FROM aliases |
 | DL4000 | `buildkit/MaintainerDeprecated` 🔧 | Covers deprecated MAINTAINER instruction |
 | DL4003 | `buildkit/MultipleInstructionsDisallowed` 🔧 | Covers multiple CMD instructions |
 | DL4004 | `buildkit/MultipleInstructionsDisallowed` 🔧 | Covers multiple ENTRYPOINT instructions |

--- a/cmd/tally/cmd/lint.go
+++ b/cmd/tally/cmd/lint.go
@@ -31,6 +31,7 @@ import (
 	"github.com/wharflab/tally/internal/psanalyzer"
 	"github.com/wharflab/tally/internal/registry"
 	"github.com/wharflab/tally/internal/reporter"
+	"github.com/wharflab/tally/internal/ruledeprecation"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/syntax"
 	"github.com/wharflab/tally/internal/version"
@@ -453,6 +454,7 @@ func lintStdinContent(ctx stdcontext.Context, opts *lintOptions, content []byte)
 func processViolations(res *lintResults, cfg *config.Config) []rules.Violation {
 	chain, inlineFilter := linter.CLIProcessors()
 	procCtx := processor.NewContext(res.fileConfigs, cfg, res.fileSources)
+	collectConfigRuleDeprecations(procCtx, res.fileConfigs, cfg)
 	allViolations := chain.Process(res.violations, procCtx)
 
 	additionalViolations := inlineFilter.AdditionalViolations()
@@ -462,7 +464,40 @@ func processViolations(res *lintResults, cfg *config.Config) []rules.Violation {
 		allViolations = append(allViolations, additionalViolations...)
 		allViolations = reporter.SortViolations(allViolations)
 	}
+	reportRuleDeprecationWarnings(os.Stderr, procCtx.RuleDeprecations.Notices())
 	return allViolations
+}
+
+func collectConfigRuleDeprecations(
+	procCtx *processor.Context,
+	fileConfigs map[string]*config.Config,
+	defaultCfg *config.Config,
+) {
+	if procCtx == nil || procCtx.RuleDeprecations == nil {
+		return
+	}
+	seen := make(map[*config.Config]struct{})
+	for _, cfg := range fileConfigs {
+		if cfg == nil {
+			continue
+		}
+		if _, ok := seen[cfg]; ok {
+			continue
+		}
+		seen[cfg] = struct{}{}
+		procCtx.RuleDeprecations.AddNotices(cfg.Rules.DeprecatedReferences())
+	}
+	if defaultCfg != nil {
+		if _, ok := seen[defaultCfg]; !ok {
+			procCtx.RuleDeprecations.AddNotices(defaultCfg.Rules.DeprecatedReferences())
+		}
+	}
+}
+
+func reportRuleDeprecationWarnings(w io.Writer, notices []ruledeprecation.Notice) {
+	for _, notice := range notices {
+		fmt.Fprintf(w, "Warning: %s\n", notice.Message())
+	}
 }
 
 // applyStdinFixes applies fixes and writes the result to stdout.

--- a/cmd/tally/cmd/lint_test.go
+++ b/cmd/tally/cmd/lint_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/wharflab/tally/internal/invocation"
 	"github.com/wharflab/tally/internal/psanalyzer"
+	"github.com/wharflab/tally/internal/ruledeprecation"
 	"github.com/wharflab/tally/internal/rules"
 )
 
@@ -116,6 +117,25 @@ func TestParseACPCmd(t *testing.T) {
 				t.Fatalf("parseACPCmd(%q) = %#v, want %#v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReportRuleDeprecationWarnings(t *testing.T) {
+	t.Parallel()
+
+	collector := ruledeprecation.NewCollector()
+	collector.AddCode("DL3063")
+	collector.AddCode("hadolint/DL3063")
+
+	var buf bytes.Buffer
+	reportRuleDeprecationWarnings(&buf, collector.Notices())
+
+	got := buf.String()
+	if strings.Count(got, "hadolint/DL3063") != 1 {
+		t.Fatalf("expected one deduplicated warning for hadolint/DL3063, got:\n%s", got)
+	}
+	if !strings.Contains(got, "use buildkit/ReservedStageName instead") {
+		t.Fatalf("expected replacement in warning, got:\n%s", got)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -648,6 +648,69 @@ func TestRulesConfigIncludeExclude(t *testing.T) {
 	}
 }
 
+func TestRulesConfigSupersededRuleAlias(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exclude by deprecated code disables replacement", func(t *testing.T) {
+		t.Parallel()
+		rc := RulesConfig{Exclude: []string{"hadolint/DL3063"}}
+		enabled := rc.IsEnabled("buildkit/ReservedStageName")
+		if enabled == nil || *enabled {
+			t.Fatalf("IsEnabled(buildkit/ReservedStageName) = %v, want false", enabled)
+		}
+	})
+
+	t.Run("bare deprecated code disables replacement", func(t *testing.T) {
+		t.Parallel()
+		rc := RulesConfig{Exclude: []string{"DL3063"}}
+		enabled := rc.IsEnabled("buildkit/ReservedStageName")
+		if enabled == nil || *enabled {
+			t.Fatalf("IsEnabled(buildkit/ReservedStageName) = %v, want false", enabled)
+		}
+	})
+
+	t.Run("deprecated wildcard does not match replacement", func(t *testing.T) {
+		t.Parallel()
+		rc := RulesConfig{Exclude: []string{"hadolint/*"}}
+		enabled := rc.IsEnabled("buildkit/ReservedStageName")
+		if enabled != nil {
+			t.Fatalf("IsEnabled(buildkit/ReservedStageName) = %v, want nil", enabled)
+		}
+	})
+
+	t.Run("deprecated table config applies to replacement", func(t *testing.T) {
+		t.Parallel()
+		rc := RulesConfig{}
+		rc.Set("hadolint/DL3063", RuleConfig{Severity: "off"})
+		if got := rc.GetSeverity("buildkit/ReservedStageName"); got != "off" {
+			t.Fatalf("GetSeverity(buildkit/ReservedStageName) = %q, want off", got)
+		}
+	})
+
+	t.Run("replacement table config wins over deprecated table config", func(t *testing.T) {
+		t.Parallel()
+		rc := RulesConfig{}
+		rc.Set("hadolint/DL3063", RuleConfig{Severity: "off"})
+		rc.Set("buildkit/ReservedStageName", RuleConfig{Severity: "error"})
+		if got := rc.GetSeverity("buildkit/ReservedStageName"); got != "error" {
+			t.Fatalf("GetSeverity(buildkit/ReservedStageName) = %q, want error", got)
+		}
+	})
+
+	t.Run("deprecated references are deduplicated", func(t *testing.T) {
+		t.Parallel()
+		rc := RulesConfig{Exclude: []string{"DL3063"}}
+		rc.Set("hadolint/DL3063", RuleConfig{Severity: "off"})
+		notices := rc.DeprecatedReferences()
+		if len(notices) != 1 {
+			t.Fatalf("got %d notices, want 1", len(notices))
+		}
+		if notices[0].Entry.Code != "hadolint/DL3063" {
+			t.Fatalf("notice code = %q, want hadolint/DL3063", notices[0].Entry.Code)
+		}
+	})
+}
+
 func TestRulesConfigPowerShellInternalErrorIncludeEnablesEngine(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -669,6 +669,15 @@ func TestRulesConfigSupersededRuleAlias(t *testing.T) {
 		}
 	})
 
+	t.Run("deprecated code with whitespace does not disable replacement", func(t *testing.T) {
+		t.Parallel()
+		rc := RulesConfig{Exclude: []string{" DL3063 "}}
+		enabled := rc.IsEnabled("buildkit/ReservedStageName")
+		if enabled != nil {
+			t.Fatalf("IsEnabled(buildkit/ReservedStageName) = %v, want nil", enabled)
+		}
+	})
+
 	t.Run("deprecated wildcard does not match replacement", func(t *testing.T) {
 		t.Parallel()
 		rc := RulesConfig{Exclude: []string{"hadolint/*"}}

--- a/internal/config/rules.go
+++ b/internal/config/rules.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/wharflab/tally/internal/ruledeprecation"
 	"github.com/wharflab/tally/internal/rules/configutil"
 )
 
@@ -104,13 +105,13 @@ func (rc *RulesConfig) Get(ruleCode string) *RuleConfig {
 	if rc == nil {
 		return nil
 	}
-	ns, name := parseRuleCode(ruleCode)
-	nsMap := rc.namespaceMap(ns)
-	if nsMap == nil {
-		return nil
+	if cfg := rc.getExact(ruleCode); cfg != nil {
+		return cfg
 	}
-	if cfg, ok := nsMap[name]; ok {
-		return &cfg
+	for _, alias := range ruledeprecation.DeprecatedCodesFor(ruleCode) {
+		if cfg := rc.getExact(alias); cfg != nil {
+			return cfg
+		}
 	}
 	return nil
 }
@@ -134,17 +135,29 @@ func (rc *RulesConfig) IsEnabled(ruleCode string) *bool {
 	}
 
 	// Check Include first (takes precedence)
-	if matchesAnyIncludePattern(ruleCode, rc.Include) {
+	if matchesAnyIncludePattern(ruleCode, rc.Include) ||
+		matchesAnyDeprecatedExactPattern(ruleCode, rc.Include) {
 		return new(true)
 	}
 
 	// Check Exclude
-	if matchesAnyPattern(ruleCode, rc.Exclude) {
+	if matchesAnyPattern(ruleCode, rc.Exclude) ||
+		matchesAnyDeprecatedExactPattern(ruleCode, rc.Exclude) {
 		return new(false)
 	}
 
 	// No explicit config - use rule default
 	return nil
+}
+
+func matchesAnyDeprecatedExactPattern(ruleCode string, patterns []string) bool {
+	aliases := ruledeprecation.DeprecatedCodesFor(ruleCode)
+	if len(aliases) == 0 {
+		return false
+	}
+	return slices.ContainsFunc(patterns, func(pattern string) bool {
+		return slices.Contains(aliases, strings.TrimSpace(pattern))
+	})
 }
 
 // matchesAnyPattern checks if ruleCode matches any pattern in the list.
@@ -286,6 +299,34 @@ func (rc *RulesConfig) EnablesPowerShellAnalyzer() bool {
 	return false
 }
 
+// DeprecatedReferences returns deprecation notices for explicitly configured rule codes.
+func (rc *RulesConfig) DeprecatedReferences() []ruledeprecation.Notice {
+	if rc == nil {
+		return nil
+	}
+
+	collector := ruledeprecation.NewCollector()
+	for _, pattern := range rc.Include {
+		collector.AddCode(pattern)
+	}
+	for _, pattern := range rc.Exclude {
+		collector.AddCode(pattern)
+	}
+
+	addNamespaceCodes := func(namespace string, entries map[string]RuleConfig) {
+		for name := range entries {
+			collector.AddCode(namespace + "/" + name)
+		}
+	}
+	addNamespaceCodes("tally", rc.Tally)
+	addNamespaceCodes("buildkit", rc.Buildkit)
+	addNamespaceCodes("hadolint", rc.Hadolint)
+	addNamespaceCodes("shellcheck", rc.Shellcheck)
+	addNamespaceCodes("powershell", rc.Powershell)
+
+	return collector.Notices()
+}
+
 func isPowerShellAnalyzerRuleName(name string) bool {
 	switch name {
 	case "", "PowerShell":
@@ -348,6 +389,18 @@ func (rc *RulesConfig) Set(ruleCode string, cfg RuleConfig) bool {
 	default:
 		return false
 	}
+}
+
+func (rc *RulesConfig) getExact(ruleCode string) *RuleConfig {
+	ns, name := parseRuleCode(ruleCode)
+	nsMap := rc.namespaceMap(ns)
+	if nsMap == nil {
+		return nil
+	}
+	if cfg, ok := nsMap[name]; ok {
+		return &cfg
+	}
+	return nil
 }
 
 // namespaceMap returns the map for a given namespace.

--- a/internal/config/rules.go
+++ b/internal/config/rules.go
@@ -156,7 +156,7 @@ func matchesAnyDeprecatedExactPattern(ruleCode string, patterns []string) bool {
 		return false
 	}
 	return slices.ContainsFunc(patterns, func(pattern string) bool {
-		return slices.Contains(aliases, strings.TrimSpace(pattern))
+		return slices.Contains(aliases, pattern)
 	})
 }
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/knadh/koanf/v2"
 
 	"github.com/wharflab/tally/internal/ruleconfig"
+	"github.com/wharflab/tally/internal/ruledeprecation"
 	schemasembed "github.com/wharflab/tally/internal/schemas"
 	generatedconfig "github.com/wharflab/tally/internal/schemas/generated/config"
 	schemavalidator "github.com/wharflab/tally/internal/schemas/runtime"
@@ -226,7 +227,11 @@ func validateRuleOptions(raw map[string]any, validator schemavalidator.Validator
 
 		for name, entry := range namespaceRaw {
 			ruleCode := ns + "/" + name
-			if !validator.HasRuleSchema(ruleCode) {
+			schemaRuleCode := ruleCode
+			if replacement, ok := ruledeprecation.ReplacementFor(ruleCode); ok {
+				schemaRuleCode = replacement
+			}
+			if !validator.HasRuleSchema(schemaRuleCode) {
 				opts := optionsFromRuleEntry(entry)
 				if len(opts) == 0 {
 					continue
@@ -240,7 +245,7 @@ func validateRuleOptions(raw map[string]any, validator schemavalidator.Validator
 			}
 
 			if opts := optionsFromRuleEntry(entry); len(opts) > 0 {
-				if err := validator.ValidateRuleOptions(ruleCode, opts); err != nil {
+				if err := validator.ValidateRuleOptions(schemaRuleCode, opts); err != nil {
 					return err
 				}
 			}

--- a/internal/directive/directive.go
+++ b/internal/directive/directive.go
@@ -13,6 +13,8 @@ package directive
 import (
 	"math"
 	"strings"
+
+	"github.com/wharflab/tally/internal/ruledeprecation"
 )
 
 // DirectiveType indicates the scope of a directive.
@@ -134,6 +136,10 @@ func matchesRule(pattern, ruleCode string) bool {
 		if ruleCode == pattern[idx+1:] {
 			return true
 		}
+	}
+
+	if ruledeprecation.IsDeprecatedAliasFor(pattern, ruleCode) {
+		return true
 	}
 
 	return false

--- a/internal/directive/directive_test.go
+++ b/internal/directive/directive_test.go
@@ -148,6 +148,15 @@ FROM ubuntu`
 	}
 }
 
+func TestDeprecatedDirectiveSuppressesReplacementRule(t *testing.T) {
+	t.Parallel()
+
+	d := Directive{Rules: []string{"DL3063"}}
+	if !d.SuppressesRule("buildkit/ReservedStageName") {
+		t.Fatal("expected deprecated DL3063 directive to suppress buildkit/ReservedStageName")
+	}
+}
+
 func TestParseCaseInsensitive(t *testing.T) {
 	t.Parallel()
 	content := `# TALLY IGNORE=DL3006

--- a/internal/integration/__snapshots__/TestLint_deprecated-rule-alias-inline_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_deprecated-rule-alias-inline_1.snap.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 0,
+    "info": 0,
+    "style": 0,
+    "total": 0,
+    "warnings": 0
+  }
+}

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -166,6 +166,18 @@ func lintCases(t *testing.T) []lintCase {
 				mustSelectRules("buildkit/ReservedStageName", "buildkit/StageNameCasing")...),
 			wantExit: 1,
 		},
+		{
+			name: "deprecated-rule-alias-inline",
+			dir:  "deprecated-rule-alias-inline",
+			args: append([]string{"--format", "json"},
+				mustSelectRules("buildkit/ReservedStageName")...),
+			afterLint: func(t *testing.T, stderr string) {
+				t.Helper()
+				if !strings.Contains(stderr, "rule hadolint/DL3063 is deprecated; use buildkit/ReservedStageName instead") {
+					t.Fatalf("expected deprecated rule warning in stderr, got:\n%s", stderr)
+				}
+			},
+		},
 
 		// Semantic model construction-time violations
 		{

--- a/internal/integration/testdata/deprecated-rule-alias-inline/Dockerfile
+++ b/internal/integration/testdata/deprecated-rule-alias-inline/Dockerfile
@@ -1,0 +1,2 @@
+# hadolint ignore=DL3063
+FROM alpine:3.21 AS scratch

--- a/internal/processor/directive.go
+++ b/internal/processor/directive.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/wharflab/tally/internal/directive"
+	"github.com/wharflab/tally/internal/ruledeprecation"
 	"github.com/wharflab/tally/internal/rules"
 )
 
@@ -142,13 +143,18 @@ func (p *InlineDirectiveFilter) processFile(
 	var validator directive.RuleValidator
 	if cfg.InlineDirectives.ValidateRules {
 		validator = func(code string) bool {
-			return p.registry.Has(code) || rules.IsDynamicRuleCode(code)
+			return p.registry.Has(code) || rules.IsDynamicRuleCode(code) || ruledeprecation.IsKnown(code)
 		}
 	}
 
 	// Parse directives
 	spanIndex := directive.NewInstructionSpanIndexFromSource(sm.Source(), sm)
 	directiveResult := directive.Parse(sm, validator, spanIndex)
+	for _, d := range directiveResult.Directives {
+		for _, code := range d.Rules {
+			ctx.RuleDeprecations.AddCode(code)
+		}
+	}
 
 	// Report parse errors as warnings
 	for _, parseErr := range directiveResult.Errors {

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/ruledeprecation"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/sourcemap"
 )
@@ -56,6 +57,9 @@ type Context struct {
 	// SourceMaps caches parsed source maps by file path.
 	// Lazily populated by GetSourceMap.
 	sourceMaps map[string]*sourcemap.SourceMap
+
+	// RuleDeprecations collects deprecated rule-code usage found while processing.
+	RuleDeprecations *ruledeprecation.Collector
 }
 
 // NewContext creates a new processor context.
@@ -67,10 +71,11 @@ func NewContext(
 	fileSources map[string][]byte,
 ) *Context {
 	return &Context{
-		FileConfigs:   fileConfigs,
-		DefaultConfig: defaultCfg,
-		FileSources:   fileSources,
-		sourceMaps:    make(map[string]*sourcemap.SourceMap),
+		FileConfigs:      fileConfigs,
+		DefaultConfig:    defaultCfg,
+		FileSources:      fileSources,
+		sourceMaps:       make(map[string]*sourcemap.SourceMap),
+		RuleDeprecations: ruledeprecation.NewCollector(),
 	}
 }
 

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -183,6 +183,69 @@ func TestPathExclusionFilter(t *testing.T) {
 	}
 }
 
+func TestPathExclusionFilter_DeprecatedRuleAlias(t *testing.T) {
+	t.Parallel()
+	violations := []rules.Violation{
+		rules.NewViolation(
+			rules.NewLineLocation("vendor/Dockerfile", 1),
+			"buildkit/ReservedStageName",
+			"msg",
+			rules.SeverityError,
+		),
+	}
+
+	cfg := config.Default()
+	cfg.Rules.Set("hadolint/DL3063", config.RuleConfig{
+		Exclude: config.ExcludeConfig{
+			Paths: []string{"vendor/**"},
+		},
+	})
+
+	p := NewPathExclusionFilter()
+	ctx := NewContext(nil, cfg, nil)
+
+	result := p.Process(violations, ctx)
+	if len(result) != 0 {
+		t.Fatalf("expected deprecated alias path exclusion to filter violation, got %d", len(result))
+	}
+}
+
+func TestInlineDirectiveFilter_DeprecatedRuleAlias(t *testing.T) {
+	t.Parallel()
+	const file = "Dockerfile"
+	source := []byte(`# hadolint ignore=DL3063
+FROM alpine:3.21 AS scratch
+`)
+	violations := []rules.Violation{
+		rules.NewViolation(
+			rules.NewLineLocation(file, 2),
+			"buildkit/ReservedStageName",
+			"msg",
+			rules.SeverityError,
+		),
+	}
+
+	cfg := config.Default()
+	cfg.InlineDirectives.ValidateRules = true
+	p := NewInlineDirectiveFilter()
+	ctx := NewContext(nil, cfg, map[string][]byte{file: source})
+
+	result := p.Process(violations, ctx)
+	if len(result) != 0 {
+		t.Fatalf("expected deprecated directive to suppress replacement violation, got %d", len(result))
+	}
+	notices := ctx.RuleDeprecations.Notices()
+	if len(notices) != 1 {
+		t.Fatalf("got %d deprecation notices, want 1", len(notices))
+	}
+	if notices[0].Entry.Code != "hadolint/DL3063" {
+		t.Fatalf("notice code = %q, want hadolint/DL3063", notices[0].Entry.Code)
+	}
+	if additional := p.AdditionalViolations(); len(additional) != 0 {
+		t.Fatalf("got %d additional violations, want 0", len(additional))
+	}
+}
+
 func TestSnippetAttachment(t *testing.T) {
 	t.Parallel()
 	source := []byte("line 1\nline 2\nline 3\n")

--- a/internal/ruledeprecation/deprecation.go
+++ b/internal/ruledeprecation/deprecation.go
@@ -1,0 +1,206 @@
+package ruledeprecation
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Kind describes how a deprecated rule should behave.
+type Kind string
+
+const (
+	// KindDeadEnd marks a rule name that should no longer be used and has no replacement.
+	KindDeadEnd Kind = "dead-end"
+
+	// KindSuperseded marks a rule name that is kept as a compatibility alias for another rule.
+	KindSuperseded Kind = "superseded"
+)
+
+// Entry describes one deprecated rule code.
+type Entry struct {
+	// Code is the canonical deprecated rule code.
+	Code string
+
+	// Aliases are additional spellings that should produce the same deprecation behavior.
+	Aliases []string
+
+	// Kind controls warning text and compatibility behavior.
+	Kind Kind
+
+	// Replacement is the rule code that supersedes Code. Only meaningful for KindSuperseded.
+	Replacement string
+
+	// RemoveIn optionally names the version where the deprecated spelling may be removed.
+	RemoveIn string
+
+	// Detail optionally explains why the rule was deprecated.
+	Detail string
+}
+
+// Notice is a user-facing deprecation observation.
+type Notice struct {
+	Entry Entry
+}
+
+// Message returns the warning message without the "Warning: " prefix.
+func (n Notice) Message() string {
+	entry := n.Entry
+	switch entry.Kind {
+	case KindSuperseded:
+		msg := fmt.Sprintf("rule %s is deprecated; use %s instead", entry.Code, entry.Replacement)
+		if entry.Detail != "" {
+			msg += ": " + entry.Detail
+		}
+		return msg
+	case KindDeadEnd:
+		msg := fmt.Sprintf("rule %s is deprecated; remove this rule setting or inline directive", entry.Code)
+		if entry.RemoveIn != "" {
+			msg += "; it may be removed in " + entry.RemoveIn
+		}
+		if entry.Detail != "" {
+			msg += ": " + entry.Detail
+		}
+		return msg
+	default:
+		return fmt.Sprintf("rule %s is deprecated", entry.Code)
+	}
+}
+
+// Key returns the stable deduplication key for this notice.
+func (n Notice) Key() string {
+	return n.Entry.Code
+}
+
+var entries = []Entry{
+	// Keep BuildKit supersessions aligned with internal/rules/hadolint-status.json
+	// entries whose status is "covered_by_buildkit"; tests enforce this.
+	supersededByBuildKit("DL3000", "WorkdirRelativePath", "relative WORKDIR paths"),
+	supersededByBuildKit("DL3012", "MultipleInstructionsDisallowed", "duplicate HEALTHCHECK instructions"),
+	supersededByBuildKit("DL3024", "DuplicateStageName", "duplicate stage names"),
+	supersededByBuildKit("DL3025", "JSONArgsRecommended", "shell-form CMD and ENTRYPOINT instructions"),
+	supersededByBuildKit("DL3029", "FromPlatformFlagConstDisallowed", "constant FROM --platform values"),
+	supersededByBuildKit("DL3044", "UndefinedVar", "undefined variable references"),
+	supersededByBuildKit("DL3063", "ReservedStageName", "reserved stage names"),
+	supersededByBuildKit("DL4000", "MaintainerDeprecated", "deprecated MAINTAINER instructions"),
+	supersededByBuildKit("DL4003", "MultipleInstructionsDisallowed", "duplicate CMD instructions"),
+	supersededByBuildKit("DL4004", "MultipleInstructionsDisallowed", "duplicate ENTRYPOINT instructions"),
+}
+
+var lookupByCode = buildLookup(entries)
+
+func supersededByBuildKit(code, ruleName, subject string) Entry {
+	return Entry{
+		Code:        "hadolint/" + code,
+		Aliases:     []string{code},
+		Kind:        KindSuperseded,
+		Replacement: "buildkit/" + ruleName,
+		Detail:      "tally uses the BuildKit implementation for " + subject,
+	}
+}
+
+func buildLookup(in []Entry) map[string]Entry {
+	out := make(map[string]Entry, len(in)*2)
+	for _, entry := range in {
+		out[entry.Code] = entry
+		for _, alias := range entry.Aliases {
+			out[alias] = entry
+		}
+	}
+	return out
+}
+
+// Lookup returns the deprecation entry for code or one of its aliases.
+func Lookup(code string) (Entry, bool) {
+	entry, ok := lookupByCode[strings.TrimSpace(code)]
+	return entry, ok
+}
+
+// IsKnown reports whether code is a deprecated code or alias.
+func IsKnown(code string) bool {
+	_, ok := Lookup(code)
+	return ok
+}
+
+// ReplacementFor returns the replacement rule for a superseded deprecated code.
+func ReplacementFor(code string) (string, bool) {
+	entry, ok := Lookup(code)
+	if !ok || entry.Kind != KindSuperseded || entry.Replacement == "" {
+		return "", false
+	}
+	return entry.Replacement, true
+}
+
+// DeprecatedCodesFor returns deprecated codes and aliases that target ruleCode.
+func DeprecatedCodesFor(ruleCode string) []string {
+	var out []string
+	for _, entry := range entries {
+		if entry.Kind != KindSuperseded || entry.Replacement != ruleCode {
+			continue
+		}
+		out = append(out, entry.Code)
+		out = append(out, entry.Aliases...)
+	}
+	return out
+}
+
+// IsDeprecatedAliasFor reports whether deprecatedCode is a superseded alias for ruleCode.
+func IsDeprecatedAliasFor(deprecatedCode, ruleCode string) bool {
+	replacement, ok := ReplacementFor(deprecatedCode)
+	return ok && replacement == ruleCode
+}
+
+// Collector stores deprecation notices and deduplicates them by canonical deprecated code.
+type Collector struct {
+	notices map[string]Notice
+}
+
+// NewCollector creates an empty deprecation notice collector.
+func NewCollector() *Collector {
+	return &Collector{notices: make(map[string]Notice)}
+}
+
+// AddCode records a deprecation notice if code is deprecated.
+func (c *Collector) AddCode(code string) {
+	if c == nil {
+		return
+	}
+	entry, ok := Lookup(code)
+	if !ok {
+		return
+	}
+	c.AddNotice(Notice{Entry: entry})
+}
+
+// AddNotice records a deprecation notice.
+func (c *Collector) AddNotice(notice Notice) {
+	if c == nil {
+		return
+	}
+	if c.notices == nil {
+		c.notices = make(map[string]Notice)
+	}
+	c.notices[notice.Key()] = notice
+}
+
+// AddNotices records multiple deprecation notices.
+func (c *Collector) AddNotices(notices []Notice) {
+	for _, notice := range notices {
+		c.AddNotice(notice)
+	}
+}
+
+// Notices returns deduplicated notices in stable order.
+func (c *Collector) Notices() []Notice {
+	if c == nil || len(c.notices) == 0 {
+		return nil
+	}
+	out := make([]Notice, 0, len(c.notices))
+	for _, notice := range c.notices {
+		out = append(out, notice)
+	}
+	slices.SortFunc(out, func(a, b Notice) int {
+		return strings.Compare(a.Entry.Code, b.Entry.Code)
+	})
+	return out
+}

--- a/internal/ruledeprecation/deprecation.go
+++ b/internal/ruledeprecation/deprecation.go
@@ -87,7 +87,10 @@ var entries = []Entry{
 	supersededByBuildKit("DL4004", "MultipleInstructionsDisallowed", "duplicate ENTRYPOINT instructions"),
 }
 
-var lookupByCode = buildLookup(entries)
+var (
+	lookupByCode        = buildLookup(entries)
+	lookupByReplacement = buildReplacementLookup(entries)
+)
 
 func supersededByBuildKit(code, ruleName, subject string) Entry {
 	return Entry{
@@ -110,9 +113,21 @@ func buildLookup(in []Entry) map[string]Entry {
 	return out
 }
 
+func buildReplacementLookup(in []Entry) map[string][]string {
+	out := make(map[string][]string)
+	for _, entry := range in {
+		if entry.Kind != KindSuperseded || entry.Replacement == "" {
+			continue
+		}
+		out[entry.Replacement] = append(out[entry.Replacement], entry.Code)
+		out[entry.Replacement] = append(out[entry.Replacement], entry.Aliases...)
+	}
+	return out
+}
+
 // Lookup returns the deprecation entry for code or one of its aliases.
 func Lookup(code string) (Entry, bool) {
-	entry, ok := lookupByCode[strings.TrimSpace(code)]
+	entry, ok := lookupByCode[code]
 	return entry, ok
 }
 
@@ -133,15 +148,7 @@ func ReplacementFor(code string) (string, bool) {
 
 // DeprecatedCodesFor returns deprecated codes and aliases that target ruleCode.
 func DeprecatedCodesFor(ruleCode string) []string {
-	var out []string
-	for _, entry := range entries {
-		if entry.Kind != KindSuperseded || entry.Replacement != ruleCode {
-			continue
-		}
-		out = append(out, entry.Code)
-		out = append(out, entry.Aliases...)
-	}
-	return out
+	return slices.Clone(lookupByReplacement[ruleCode])
 }
 
 // IsDeprecatedAliasFor reports whether deprecatedCode is a superseded alias for ruleCode.

--- a/internal/ruledeprecation/deprecation_test.go
+++ b/internal/ruledeprecation/deprecation_test.go
@@ -52,6 +52,28 @@ func TestLookupSupersededAlias(t *testing.T) {
 	}
 }
 
+func TestLookupUsesExactCode(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := Lookup(" DL3063 "); ok {
+		t.Fatal("Lookup accepted code with surrounding whitespace, want exact match only")
+	}
+}
+
+func TestDeprecatedCodesForReturnsClone(t *testing.T) {
+	t.Parallel()
+
+	codes := DeprecatedCodesFor("buildkit/ReservedStageName")
+	if !slices.Contains(codes, "hadolint/DL3063") || !slices.Contains(codes, "DL3063") {
+		t.Fatalf("DeprecatedCodesFor(buildkit/ReservedStageName) = %v, want DL3063 aliases", codes)
+	}
+
+	codes[0] = "mutated"
+	if got := DeprecatedCodesFor("buildkit/ReservedStageName"); slices.Contains(got, "mutated") {
+		t.Fatalf("DeprecatedCodesFor returned mutable backing storage: %v", got)
+	}
+}
+
 func TestCollectorDeduplicatesAliases(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ruledeprecation/deprecation_test.go
+++ b/internal/ruledeprecation/deprecation_test.go
@@ -1,0 +1,110 @@
+package ruledeprecation
+
+import (
+	jsonv2 "encoding/json/v2"
+	"maps"
+	"os"
+	"slices"
+	"testing"
+)
+
+func TestLookupSupersededAlias(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"DL3000": "buildkit/WorkdirRelativePath",
+		"DL3012": "buildkit/MultipleInstructionsDisallowed",
+		"DL3024": "buildkit/DuplicateStageName",
+		"DL3025": "buildkit/JSONArgsRecommended",
+		"DL3029": "buildkit/FromPlatformFlagConstDisallowed",
+		"DL3044": "buildkit/UndefinedVar",
+		"DL3063": "buildkit/ReservedStageName",
+		"DL4000": "buildkit/MaintainerDeprecated",
+		"DL4003": "buildkit/MultipleInstructionsDisallowed",
+		"DL4004": "buildkit/MultipleInstructionsDisallowed",
+	}
+	for _, code := range slices.Sorted(maps.Keys(tests)) {
+		t.Run(code, func(t *testing.T) {
+			t.Parallel()
+
+			entry, ok := Lookup(code)
+			if !ok {
+				t.Fatalf("expected %s to be known", code)
+			}
+			if entry.Code != "hadolint/"+code {
+				t.Fatalf("Code = %q, want hadolint/%s", entry.Code, code)
+			}
+			if entry.Kind != KindSuperseded {
+				t.Fatalf("Kind = %q, want %q", entry.Kind, KindSuperseded)
+			}
+			if entry.Replacement != tests[code] {
+				t.Fatalf("Replacement = %q, want %q", entry.Replacement, tests[code])
+			}
+			namespacedEntry, ok := Lookup("hadolint/" + code)
+			if !ok {
+				t.Fatalf("expected hadolint/%s to be known", code)
+			}
+			if namespacedEntry.Code != entry.Code || namespacedEntry.Kind != entry.Kind ||
+				namespacedEntry.Replacement != entry.Replacement {
+				t.Fatalf("Lookup(hadolint/%s) = %#v, want %#v", code, namespacedEntry, entry)
+			}
+		})
+	}
+}
+
+func TestCollectorDeduplicatesAliases(t *testing.T) {
+	t.Parallel()
+
+	collector := NewCollector()
+	collector.AddCode("DL3063")
+	collector.AddCode("hadolint/DL3063")
+
+	notices := collector.Notices()
+	if len(notices) != 1 {
+		t.Fatalf("got %d notices, want 1", len(notices))
+	}
+	if notices[0].Entry.Code != "hadolint/DL3063" {
+		t.Fatalf("notice code = %q, want hadolint/DL3063", notices[0].Entry.Code)
+	}
+}
+
+func TestBuildKitCoveredHadolintRulesAreDeprecated(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../rules/hadolint-status.json")
+	if err != nil {
+		t.Fatalf("read hadolint status: %v", err)
+	}
+
+	var status struct {
+		Rules map[string]struct {
+			Status       string `json:"status"`
+			BuildKitRule string `json:"buildkit_rule"`
+		} `json:"rules"`
+	}
+	if err := jsonv2.Unmarshal(data, &status); err != nil {
+		t.Fatalf("decode hadolint status: %v", err)
+	}
+
+	for _, code := range slices.Sorted(maps.Keys(status.Rules)) {
+		ruleStatus := status.Rules[code]
+		if ruleStatus.Status != "covered_by_buildkit" {
+			continue
+		}
+
+		entry, ok := Lookup(code)
+		if !ok {
+			t.Fatalf("%s is covered_by_buildkit but has no deprecation entry", code)
+		}
+		if entry.Code != "hadolint/"+code {
+			t.Fatalf("%s deprecation code = %q, want hadolint/%s", code, entry.Code, code)
+		}
+		if entry.Kind != KindSuperseded {
+			t.Fatalf("%s deprecation kind = %q, want %q", code, entry.Kind, KindSuperseded)
+		}
+		wantReplacement := "buildkit/" + ruleStatus.BuildKitRule
+		if entry.Replacement != wantReplacement {
+			t.Fatalf("%s replacement = %q, want %q", code, entry.Replacement, wantReplacement)
+		}
+	}
+}

--- a/internal/rules/hadolint-rules.json
+++ b/internal/rules/hadolint-rules.json
@@ -360,6 +360,12 @@
     "severity": "Warning"
   },
   {
+    "code": "DL3063",
+    "description": "Stage name should not be a reserved word.",
+    "wiki_url": "https://github.com/hadolint/hadolint/wiki/DL3063",
+    "severity": "Warning"
+  },
+  {
     "code": "DL4000",
     "description": "MAINTAINER is deprecated.",
     "wiki_url": "https://github.com/hadolint/hadolint/wiki/DL4000",

--- a/internal/rules/hadolint-status.json
+++ b/internal/rules/hadolint-status.json
@@ -165,6 +165,10 @@
       "status": "implemented",
       "tally_rule": "hadolint/DL3061"
     },
+    "DL3063": {
+      "status": "covered_by_buildkit",
+      "buildkit_rule": "ReservedStageName"
+    },
     "DL4000": {
       "status": "covered_by_buildkit",
       "buildkit_rule": "MaintainerDeprecated"


### PR DESCRIPTION
## Summary

Introduce a generic rule deprecation mechanism and use it to supersede Hadolint rule names that are already covered by BuildKit rules.

## What changed

- Added `internal/ruledeprecation` with dead-end and superseded deprecation metadata, deduplicated notices, alias lookup, and status-file guard tests.
- Wired deprecated rule references through config lookup, rule enable/disable selection, inline directive matching, directive validation, and CLI stderr warnings.
- Mapped all `covered_by_buildkit` Hadolint rules to their BuildKit replacements: DL3000, DL3012, DL3024, DL3025, DL3029, DL3044, DL3063, DL4000, DL4003, and DL4004.
- Added docs/status updates for DL3063 and fixed the DL3012 docs title/description while auditing the existing BuildKit-covered set.

## Validation

- `GOEXPERIMENT=jsonv2 go test ./...`
- `make cpd`
- `./scripts/validate-hadolint-status.sh`
- `jq empty internal/rules/hadolint-status.json internal/rules/hadolint-rules.json _docs/docs.json`
- `git diff --check -- . ':(exclude).codex/config.toml' ':(exclude).serena/project.yml'`
- Pre-push hook: `make build`, `make deadcode`, `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits aggregated deprecation warnings for deprecated rule codes and shows them after lint runs.
  * Treats deprecated rule aliases as equivalent to their replacements for directives, filters, and config lookup.

* **Documentation**
  * Added documentation for hadolint rule DL3063 and mapped it to its replacement.
  * Updated DL3012 wording and navigation to include the new rule entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->