### PR TITLE
[codex] Report tally version in docker plugin

### DIFF
--- a/cmd/tally/cmd/docker_plugin.go
+++ b/cmd/tally/cmd/docker_plugin.go
@@ -41,7 +41,7 @@ func newDockerLintPluginCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := &lintOptions{}
 	cmd := newLintCommand(opts)
 	cmd.Version = version.Version()
-	cmd.SetVersionTemplate("docker-lint version {{.Version}}\n")
+	cmd.SetVersionTemplate("tally version {{.Version}}\n")
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if err := plugin.PersistentPreRunE(cmd, args); err != nil {
 			return err

--- a/internal/integration/docker_plugin_test.go
+++ b/internal/integration/docker_plugin_test.go
@@ -74,8 +74,8 @@ func TestDockerCLIPluginVersionFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plugin version failed: %v\noutput:\n%s", err, output)
 	}
-	if !strings.Contains(string(output), "docker-lint version ") {
-		t.Fatalf("expected docker-lint version output, got:\n%s", output)
+	if !strings.Contains(string(output), "tally version ") {
+		t.Fatalf("expected tally version output, got:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Update the Docker CLI plugin `--version` template to identify the product as `tally`.
- Adjust the Docker plugin integration test to expect `tally version ...`.

## Root Cause

The Docker plugin command reused the lint command but overrode Cobra's version template with `docker-lint version {{.Version}}`, so `docker lint --version` exposed the plugin executable name instead of the tally product name.

## Validation

- `GOEXPERIMENT=jsonv2 go test ./cmd/tally/cmd ./internal/integration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The Docker CLI plugin's version command output now displays `tally version` instead of `docker-lint version`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->