### PR TITLE
docs: add mise install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Modern Dockerfiles deserve modern tooling. tally is opinionated in the right pla
   PowerShell-specific build patterns.
 - **Registry-aware without Docker**: uses a Podman-compatible registry client for image metadata checks (no daemon required).
 - **Editor + CI friendly**: VS Code extension (`wharflab.tally`, powered by `tally lsp`) and outputs for JSON, SARIF, and GitHub Actions annotations.
-- **Easy to install anywhere**: Homebrew, WinGet, Go, npm, Bun, uv, pip, and RubyGems.
+- **Easy to install anywhere**: Homebrew, mise, WinGet, Go, npm, Bun, uv, pip, and RubyGems.
 - **Written in Go**: single fast binary, built on production-grade libraries.
 
 Quality bar: **92% code coverage on Codecov** and **2,900+ Go tests executed in CI**.

--- a/_docs/index.mdx
+++ b/_docs/index.mdx
@@ -16,7 +16,7 @@ tally lint --fix Dockerfile
 
 <CardGroup cols={2}>
   <Card title="Installation" icon="download" href="/installation">
-    Install via Homebrew, npm, Bun, uv, pip, RubyGems, WinGet, Go, or Docker.
+    Install via Homebrew, mise, npm, Bun, uv, pip, RubyGems, WinGet, Go, or Docker.
   </Card>
   <Card title="Quick start" icon="rocket" href="/quickstart">
     Lint your first Dockerfile in under a minute.
@@ -68,6 +68,9 @@ tally lint --fix Dockerfile
     ```bash
     # Homebrew (macOS/Linux)
     brew install wharflab/tap/tally
+
+    # mise
+    mise use -g github:wharflab/tally@latest
 
     # npm
     npm install -g tally-cli

--- a/_docs/installation.mdx
+++ b/_docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install tally via Homebrew, WinGet, npm, Bun, uv, pip, RubyGems, Docker, Go, or from source."
+description: "Install tally via Homebrew, mise, WinGet, npm, Bun, uv, pip, RubyGems, Docker, Go, or from source."
 ---
 
 tally is a single self-contained binary. Pick the method that fits your environment.
@@ -9,6 +9,10 @@ tally is a single self-contained binary. Pick the method that fits your environm
 
 ```bash Homebrew
 brew install wharflab/tap/tally
+```
+
+```bash mise
+mise use -g github:wharflab/tally@latest
 ```
 
 ```powershell WinGet
@@ -51,6 +55,14 @@ Run `tally register-docker-plugin` if you want Docker to discover the plugin wit
 
 Homebrew also installs a `docker-lint` symlink under Homebrew's Docker plugin directory. See
 [Docker CLI plugin](/integrations/docker-cli-plugin) if you prefer to configure Docker's `cliPluginsExtraDirs`.
+
+## mise
+
+```bash
+mise use -g github:wharflab/tally@latest
+```
+
+This installs the latest tally release from GitHub and exposes the `tally` binary through mise's global tool shims.
 
 ## WinGet (Windows)
 

--- a/_docs/introduction.mdx
+++ b/_docs/introduction.mdx
@@ -17,7 +17,7 @@ tally lint --fix Dockerfile
 
 <CardGroup cols={2}>
   <Card title="Installation" icon="download" href="/installation">
-    Install via Homebrew, WinGet, npm, Bun, uv, pip, RubyGems, Docker, or Go.
+    Install via Homebrew, mise, WinGet, npm, Bun, uv, pip, RubyGems, Docker, or Go.
   </Card>
   <Card title="Quick start" icon="rocket" href="/quickstart">
     Lint your first Dockerfile in under a minute.
@@ -110,7 +110,7 @@ tools. The Markdown format is optimized for AI agents and token efficiency.
 
 <CardGroup cols={2}>
   <Card title="Install tally" icon="download" href="/installation">
-    Choose your package manager: Homebrew, WinGet, npm, Bun, uv, pip, RubyGems, Docker, or Go.
+    Choose your package manager: Homebrew, mise, WinGet, npm, Bun, uv, pip, RubyGems, Docker, or Go.
   </Card>
   <Card title="Run your first lint" icon="rocket" href="/quickstart">
     Lint a Dockerfile, read the output, apply fixes, and set up `.tally.toml`.

--- a/_docs/quickstart.mdx
+++ b/_docs/quickstart.mdx
@@ -11,6 +11,9 @@ description: "Lint your first Dockerfile in under a minute."
       ```bash Homebrew
       brew install wharflab/tap/tally
       ```
+      ```bash mise
+      mise use -g github:wharflab/tally@latest
+      ```
       ```bash npm
       npm install -g tally-cli
       ```


### PR DESCRIPTION
## Summary

Adds mise installation instructions using `mise use -g github:wharflab/tally@latest` to the installation docs, and updates the quickstart, landing docs, introduction, and README package-manager lists so mise is shown consistently.

## Validation

- `git diff --check`
- `PATH=/Users/tino/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npx --yes mintlify@latest broken-links` currently reports two existing broken links in `rules/powershell/PSUseUTF8EncodingForHelpFile.mdx`, unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * mise is now available as a supported installation method alongside existing package managers.
  * Installation documentation, quickstart guides, introduction pages, and README have been updated with mise installation instructions and setup commands for expanded platform coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->