### PR TITLE
feat(rules): add tally/ruby/jemalloc-installed-but-not-preloaded

### DIFF
--- a/_docs/docs.json
+++ b/_docs/docs.json
@@ -166,6 +166,12 @@
             ]
           },
           {
+            "group": "Ruby",
+            "pages": [
+              "rules/tally/ruby/jemalloc-installed-but-not-preloaded"
+            ]
+          },
+          {
             "group": "PowerShell",
             "pages": [
               "rules/powershell/PowerShell",

--- a/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
+++ b/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
@@ -69,16 +69,20 @@ ENV MALLOC_CONF="narenas:2,background_thread:true,thp:never,dirty_decay_ms:1000,
 ## Auto-fix
 
 When the violating install command uses `apt-get` or `apt`, the rule offers a `FixSuggestion` that inserts
-two lines on the line immediately following the install `RUN`:
+the missing pieces on the line immediately following the install `RUN`:
 
 ```dockerfile
-RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
 ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 ```
 
-The `$(uname -m)` form works on `amd64` and `arm64` Debian/Ubuntu images. Because the symlink target depends
-on the base image's multiarch path layout, the fix is `FixSuggestion` rather than `FixSafe` and requires
-`--fix-unsafe` to apply in batch mode.
+The `$(uname -m)` form works on `amd64` and `arm64` Debian/Ubuntu images. The fix uses `ln -sf` (force) so
+re-running on a layout that already has the symlink replaces it instead of failing the build with
+`File exists`. Because the symlink target depends on the base image's multiarch path layout, the fix is
+`FixSuggestion` rather than `FixSafe` and requires `--fix-unsafe` to apply in batch mode.
+
+If the stage already contains a `ln -s … libjemalloc.so` step and only forgot the `ENV LD_PRELOAD`, the fix
+emits **only** the missing `ENV` line — no redundant symlink.
 
 For Alpine, RHEL/Fedora, openSUSE, and other distros the canonical path differs, so no auto-fix is offered;
 the violation still fires. Add the equivalent symlink + `ENV LD_PRELOAD=…` (or `MALLOC_CONF`) for your

--- a/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
+++ b/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
@@ -1,0 +1,92 @@
+---
+title: "tally/ruby/jemalloc-installed-but-not-preloaded"
+description: "Final image installs a jemalloc package but does not preload it via LD_PRELOAD or MALLOC_CONF."
+---
+
+Final image installs a jemalloc package but does not preload it via `LD_PRELOAD` or `MALLOC_CONF`.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning |
+| Category | Performance |
+| Default | Enabled |
+| Auto-fix | Yes (`apt`/`apt-get` only, suggestion) |
+
+## Description
+
+Long-running Rails worker processes fragment glibc malloc heaps over time, which manifests as steadily growing
+RSS — the canonical "Rails memory leak" that often turns out to be allocator behavior. The Ruby community
+has converged on jemalloc as the workaround: the Rails 7.1+ generator, Mastodon, GitLab, Discourse, and most
+production Rails Dockerfiles either link `libjemalloc.so` and set `LD_PRELOAD`, or set jemalloc-specific
+`MALLOC_CONF` knobs.
+
+Installing a jemalloc package without doing one of those means glibc malloc is still in use — the package
+takes ~350 KiB of disk and never loads. This rule fires when a final stage installs `libjemalloc1`,
+`libjemalloc2`, `libjemalloc-dev` (Debian/Ubuntu) or `jemalloc`, `jemalloc-dev` (Alpine, RHEL/Fedora, etc.)
+without a matching `ENV LD_PRELOAD=…jemalloc…` or `ENV MALLOC_CONF=…` carrying a jemalloc-specific knob.
+
+The rule recognizes any of the following as evidence jemalloc is loaded:
+
+- `LD_PRELOAD` whose value contains `jemalloc` (case-insensitive).
+- `MALLOC_CONF` whose value contains any of these jemalloc-only options:
+  `narenas:`, `background_thread:`, `dirty_decay_ms:`, `muzzy_decay_ms:`, `thp:`.
+
+Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug` are skipped, as are
+non-final stages and Windows-based stages.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/*
+CMD ["bin/rails", "server"]
+```
+
+### After
+
+The Rails-generator-style fix links the architecture-correct `libjemalloc.so.2` into a stable path and
+preloads it:
+
+```dockerfile
+FROM ruby:3.3-slim
+RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/*
+RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+CMD ["bin/rails", "server"]
+```
+
+Mastodon's pattern — setting `MALLOC_CONF` to a tuning string — also satisfies the rule, because those knobs
+are only honored by jemalloc:
+
+```dockerfile
+ENV MALLOC_CONF="narenas:2,background_thread:true,thp:never,dirty_decay_ms:1000,muzzy_decay_ms:0"
+```
+
+## Auto-fix
+
+When the violating install command uses `apt-get` or `apt`, the rule offers a `FixSuggestion` that inserts
+two lines on the line immediately following the install `RUN`:
+
+```dockerfile
+RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+```
+
+The `$(uname -m)` form works on `amd64` and `arm64` Debian/Ubuntu images. Because the symlink target depends
+on the base image's multiarch path layout, the fix is `FixSuggestion` rather than `FixSafe` and requires
+`--fix-unsafe` to apply in batch mode.
+
+For Alpine, RHEL/Fedora, openSUSE, and other distros the canonical path differs, so no auto-fix is offered;
+the violation still fires. Add the equivalent symlink + `ENV LD_PRELOAD=…` (or `MALLOC_CONF`) for your
+distro.
+
+## References
+
+- [Rails 7.1 Dockerfile generator template](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt)
+- [Mastodon Dockerfile](https://github.com/mastodon/mastodon/blob/main/Dockerfile) — `MALLOC_CONF` tuning
+- [jemalloc tuning options](https://jemalloc.net/jemalloc.3.html#tuning)
+- [Nate Berkopec — Halve Your Memory Usage With These 12 Weird Tricks](https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html)

--- a/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
+++ b/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
@@ -85,6 +85,11 @@ re-running on a layout that already has the symlink replaces it instead of faili
 If the stage already contains a `ln -s … libjemalloc.so` step and only forgot the `ENV LD_PRELOAD`, the fix
 emits **only** the missing `ENV` line — no redundant symlink.
 
+The auto-fix is offered only for installs of `libjemalloc2` or `libjemalloc-dev`, which both ship
+`libjemalloc.so.2` at `/usr/lib/<arch>-linux-gnu/`. The legacy `libjemalloc1` package ships `libjemalloc.so.1`
+instead, so the canonical `.so.2` target does not exist there — the violation still fires but no auto-fix is
+emitted. Migrate to `libjemalloc2` for production images.
+
 For Alpine, RHEL/Fedora, openSUSE, and other distros the canonical path differs, so no auto-fix is offered;
 the violation still fires. Add the equivalent symlink + `ENV LD_PRELOAD=…` (or `MALLOC_CONF`) for your
 distro.

--- a/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
+++ b/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
@@ -22,8 +22,9 @@ production Rails Dockerfiles either link `libjemalloc.so` and set `LD_PRELOAD`, 
 
 Installing a jemalloc package without doing one of those means glibc malloc is still in use — the package
 takes ~350 KiB of disk and never loads. This rule fires when a final stage installs `libjemalloc1`,
-`libjemalloc2`, `libjemalloc-dev` (Debian/Ubuntu) or `jemalloc`, `jemalloc-dev` (Alpine, RHEL/Fedora, etc.)
-without a matching `ENV LD_PRELOAD=…jemalloc…` or `ENV MALLOC_CONF=…` carrying a jemalloc-specific knob.
+`libjemalloc2`, `libjemalloc-dev` (Debian/Ubuntu), `jemalloc`, `jemalloc-dev` (Alpine), or
+`jemalloc-devel` (RHEL/Fedora/CentOS) without a matching `ENV LD_PRELOAD=…jemalloc…` or
+`ENV MALLOC_CONF=…` carrying a jemalloc-specific knob.
 
 The rule recognizes any of the following as evidence jemalloc is loaded:
 

--- a/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
+++ b/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
@@ -55,7 +55,7 @@ preloads it:
 FROM ruby:3.3-slim
 RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
     && rm -rf /var/lib/apt/lists/*
-RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
 ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 CMD ["bin/rails", "server"]
 ```

--- a/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
+++ b/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
@@ -92,6 +92,15 @@ re-running on a layout that already has the symlink replaces it instead of faili
 If the stage already contains a `ln -s … libjemalloc.so` step and only forgot the `ENV LD_PRELOAD`, the fix
 emits **only** the missing `ENV` line — no redundant symlink.
 
+When the stage already sets a non-jemalloc `ENV LD_PRELOAD=…` (for example, an instrumentation/sanitizer
+preload), the fix **preserves** that value by prepending the jemalloc path instead of overwriting it. The
+dynamic linker honors space-separated LD_PRELOAD entries left-to-right, so jemalloc loads first while your
+existing preloads remain in effect:
+
+```dockerfile
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so /opt/instrumentation/libtrace.so"
+```
+
 The auto-fix is offered only for installs of `libjemalloc2` or `libjemalloc-dev`, which both ship
 `libjemalloc.so.2` at `/usr/lib/<arch>-linux-gnu/`. The legacy `libjemalloc1` package ships `libjemalloc.so.1`
 instead, so the canonical `.so.2` target does not exist there — the violation still fires but no auto-fix is

--- a/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
+++ b/_docs/rules/tally/ruby/jemalloc-installed-but-not-preloaded.mdx
@@ -35,6 +35,13 @@ The rule recognizes any of the following as evidence jemalloc is loaded:
 Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug` are skipped, as are
 non-final stages and Windows-based stages.
 
+Because the rule lives in the Ruby namespace and its remedy is Rails-flavored, it only fires on stages
+that look like a Ruby runtime: an official `ruby:*` base, a familiar name containing `ruby` or `rails`,
+a Ruby-runtime derivative (e.g. `phusion/passenger-ruby*`, `jruby`, `truffleruby`), a stage env carrying
+Ruby/Rails/Bundler signals (`RUBY_VERSION`, `RAILS_ENV`, `BUNDLE_*`, `GEM_HOME`, ...), or an
+ENTRYPOINT/CMD that invokes `ruby`, `rails`, `bundle`, `puma`, `unicorn`, `passenger`, `sidekiq`, etc.
+A non-Ruby image installing jemalloc for unrelated reasons does not trip this rule.
+
 ## Examples
 
 ### Before

--- a/internal/integration/__snapshots__/TestFix_ruby-jemalloc-installed-but-not-preloaded-apt-fix_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_ruby-jemalloc-installed-but-not-preloaded-apt-fix_1.snap.Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:3.3-slim
+RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/*
+RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+CMD ["bin/rails", "server"]

--- a/internal/integration/__snapshots__/TestFix_ruby-jemalloc-installed-but-not-preloaded-apt-fix_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_ruby-jemalloc-installed-but-not-preloaded-apt-fix_1.snap.Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.3-slim
 RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
     && rm -rf /var/lib/apt/lists/*
-RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
 ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 CMD ["bin/rails", "server"]

--- a/internal/integration/__snapshots__/TestFix_ruby-jemalloc-with-sort-packages_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_ruby-jemalloc-with-sort-packages_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.3-slim
+RUN apt-get install -y ca-certificates curl libjemalloc2
+RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"

--- a/internal/integration/__snapshots__/TestFix_ruby-jemalloc-with-sort-packages_1.snap.Dockerfile
+++ b/internal/integration/__snapshots__/TestFix_ruby-jemalloc-with-sort-packages_1.snap.Dockerfile
@@ -1,4 +1,4 @@
 FROM ruby:3.3-slim
 RUN apt-get install -y ca-certificates curl libjemalloc2
-RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
 ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"

--- a/internal/integration/__snapshots__/TestLint_ruby-jemalloc-installed-but-not-preloaded_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-jemalloc-installed-but-not-preloaded_1.snap.json
@@ -1,0 +1,60 @@
+{
+  "files": [
+    {
+      "file": "testdata/ruby-jemalloc-installed-but-not-preloaded/Dockerfile",
+      "violations": [
+        {
+          "detail": "Installing libjemalloc only adds the package to the image; it is not loaded by Ruby unless LD_PRELOAD points at libjemalloc.so or MALLOC_CONF carries jemalloc-specific knobs. Add `ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so` to the install RUN, then set `ENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"` so long-lived Rails workers actually use jemalloc.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/jemalloc-installed-but-not-preloaded/",
+          "location": {
+            "end": {
+              "column": 73,
+              "line": 26
+            },
+            "file": "testdata/ruby-jemalloc-installed-but-not-preloaded/Dockerfile",
+            "start": {
+              "column": 61,
+              "line": 26
+            }
+          },
+          "message": "Final image installs jemalloc but does not preload it via LD_PRELOAD or MALLOC_CONF",
+          "rule": "tally/ruby/jemalloc-installed-but-not-preloaded",
+          "severity": "warning",
+          "sourceCode": "RUN apt-get update \u0026\u0026 apt-get install -y --no-install-recommends libjemalloc2 \\",
+          "suggestedFix": {
+            "description": "Symlink libjemalloc.so and set LD_PRELOAD so jemalloc is actually loaded",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 28
+                  },
+                  "file": "testdata/ruby-jemalloc-installed-but-not-preloaded/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 28
+                  }
+                },
+                "newText": "RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\nENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 1,
+    "warnings": 1
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_ruby-jemalloc-installed-but-not-preloaded_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-jemalloc-installed-but-not-preloaded_1.snap.json
@@ -4,7 +4,7 @@
       "file": "testdata/ruby-jemalloc-installed-but-not-preloaded/Dockerfile",
       "violations": [
         {
-          "detail": "Installing libjemalloc only adds the package to the image; it is not loaded by Ruby unless LD_PRELOAD points at libjemalloc.so or MALLOC_CONF carries jemalloc-specific knobs. Add `ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so` to the install RUN, then set `ENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"` so long-lived Rails workers actually use jemalloc.",
+          "detail": "Installing libjemalloc only adds the package to the image; it is not loaded by Ruby unless LD_PRELOAD points at libjemalloc.so or MALLOC_CONF carries jemalloc-specific knobs. Add `ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so` to the install RUN, then set `ENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"` so long-lived Rails workers actually use jemalloc.",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/jemalloc-installed-but-not-preloaded/",
           "location": {
             "end": {
@@ -36,7 +36,7 @@
                     "line": 28
                   }
                 },
-                "newText": "RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\nENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"\n"
+                "newText": "RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\nENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"\n"
               }
             ],
             "isPreferred": true,

--- a/internal/integration/__snapshots__/TestLint_ruby-jemalloc-installed-but-not-preloaded_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-jemalloc-installed-but-not-preloaded_1.snap.json
@@ -8,12 +8,12 @@
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/jemalloc-installed-but-not-preloaded/",
           "location": {
             "end": {
-              "column": 73,
+              "column": 77,
               "line": 26
             },
             "file": "testdata/ruby-jemalloc-installed-but-not-preloaded/Dockerfile",
             "start": {
-              "column": 61,
+              "column": 65,
               "line": 26
             }
           },

--- a/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_total-rules-enabled_1.snap.json
@@ -1,7 +1,7 @@
 {
   "files": [],
   "files_scanned": 1,
-  "rules_enabled": 109,
+  "rules_enabled": 110,
   "summary": {
     "errors": 0,
     "files": 0,

--- a/internal/integration/fix_cases_test.go
+++ b/internal/integration/fix_cases_test.go
@@ -1668,6 +1668,36 @@ severity = "warning"
 				)...),
 			wantApplied: 2,
 		},
+		// Ruby: jemalloc-installed-but-not-preloaded inserts the canonical
+		// `RUN ln -s … && ENV LD_PRELOAD=…` pair on the line *after* the
+		// install RUN. Fix is FixSuggestion safety, so --fix-unsafe is needed
+		// to apply it in batch mode.
+		{
+			name: "ruby-jemalloc-installed-but-not-preloaded-apt-fix",
+			input: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \\\n" +
+				"    && rm -rf /var/lib/apt/lists/*\n" +
+				"CMD [\"bin/rails\", \"server\"]\n",
+			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules("tally/ruby/jemalloc-installed-but-not-preloaded")...),
+			wantApplied: 1,
+		},
+		// Ruby: jemalloc fix composed with sort-packages on the same install
+		// RUN. The jemalloc fix inserts a brand-new RUN/ENV block on the line
+		// after the install RUN, while sort-packages reorders tokens inside
+		// the install RUN itself — disjoint edit ranges, so both apply in a
+		// single --fix pass.
+		{
+			name: "ruby-jemalloc-with-sort-packages",
+			input: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 curl ca-certificates\n",
+			args: append([]string{"--fix", "--fix-unsafe", "--fail-level", "none"},
+				mustSelectRules(
+					"tally/ruby/jemalloc-installed-but-not-preloaded",
+					"tally/sort-packages",
+				)...),
+			wantApplied: 2,
+		},
 		// Full composition: two secret mounts (insertion) + two cache mounts
 		// (insertion) + cleanup removal (npm cache clean, --no-cache-dir)
 		// on the same RUN in a single --fix pass.

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -317,6 +317,13 @@ func lintCases(t *testing.T) []lintCase {
 			args:     append([]string{"--format", "json"}, mustSelectRules("tally/php/enable-opcache-in-production")...),
 			wantExit: 1,
 		},
+		{
+			name: "ruby-jemalloc-installed-but-not-preloaded",
+			dir:  "ruby-jemalloc-installed-but-not-preloaded",
+			args: append([]string{"--format", "json"},
+				mustSelectRules("tally/ruby/jemalloc-installed-but-not-preloaded")...),
+			wantExit: 1,
+		},
 
 		// Windows: RUN --mount not supported
 		{

--- a/internal/integration/testdata/ruby-jemalloc-installed-but-not-preloaded/Dockerfile
+++ b/internal/integration/testdata/ruby-jemalloc-installed-but-not-preloaded/Dockerfile
@@ -1,0 +1,28 @@
+# Builder: installs libjemalloc2 + build tooling but never loads it. Non-final
+# stage, so this rule does not fire here even though preload is missing.
+FROM ruby:3.3-slim AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libjemalloc2 build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Compliant final-named stage: installs jemalloc AND points LD_PRELOAD at the
+# canonical path. No violation.
+FROM ruby:3.3-slim AS app-compliant
+RUN apt-get update && apt-get install -y libjemalloc2 \
+    && ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so \
+    && rm -rf /var/lib/apt/lists/*
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+
+# Compliant via Mastodon-style MALLOC_CONF: the jemalloc-specific knobs are
+# evidence the allocator is loaded another way (e.g. via base-image LD_PRELOAD).
+FROM ruby:3.3-slim AS app-malloc-conf
+RUN apt-get install -y libjemalloc2
+ENV MALLOC_CONF="narenas:2,background_thread:true,thp:never"
+
+# Non-compliant final stage: installs libjemalloc2 but never preloads it.
+# This is the only stage that should produce a violation, with a fixable
+# canonical apt-style preload pair.
+FROM ruby:3.3-slim
+RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/*
+CMD ["bin/rails", "server"]

--- a/internal/rules/all/all.go
+++ b/internal/rules/all/all.go
@@ -16,5 +16,6 @@ import (
 	_ "github.com/wharflab/tally/internal/rules/tally/labels"
 	_ "github.com/wharflab/tally/internal/rules/tally/php"
 	_ "github.com/wharflab/tally/internal/rules/tally/powershell"
+	_ "github.com/wharflab/tally/internal/rules/tally/ruby"
 	_ "github.com/wharflab/tally/internal/rules/tally/windows"
 )

--- a/internal/rules/tally/php/helpers.go
+++ b/internal/rules/tally/php/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wharflab/tally/internal/rules/runcheck"
 	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/stagename"
 )
 
 const (
@@ -30,29 +31,12 @@ var phpExtensionCommandNames = []string{
 	cmdPecl,
 }
 
-var nonProductionStageTokens = []string{"dev", "development", "test", "testing", "ci", "debug"}
-
+// stageLooksLikeDev is a thin wrapper around stagename.LooksLikeDev so the PHP
+// rules continue to read naturally without leaking the import path. The
+// classification itself lives in internal/stagename so other rule packages
+// (e.g. tally/ruby) can share it.
 func stageLooksLikeDev(name string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(name))
-	if normalized == "" {
-		return false
-	}
-
-	parts := strings.FieldsFunc(normalized, func(r rune) bool {
-		switch r {
-		case '-', '_', '.', '/', ':':
-			return true
-		default:
-			return false
-		}
-	})
-	if len(parts) == 0 {
-		parts = []string{normalized}
-	}
-
-	return slices.ContainsFunc(parts, func(part string) bool {
-		return slices.Contains(nonProductionStageTokens, part)
-	})
+	return stagename.LooksLikeDev(name)
 }
 
 func composerNoDevEnabled(env facts.EnvFacts) bool {

--- a/internal/rules/tally/ruby/doc.go
+++ b/internal/rules/tally/ruby/doc.go
@@ -1,0 +1,4 @@
+// Package ruby contains tally rules that target Ruby and Rails Dockerfile
+// patterns. Rules in this package use the "tally/ruby/<rule-slug>" code
+// convention and live under _docs/rules/tally/ruby/ in the docs site.
+package ruby

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -1,0 +1,298 @@
+package ruby
+
+import (
+	"strings"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// JemallocInstalledButNotPreloadedRuleCode is the full rule code.
+const JemallocInstalledButNotPreloadedRuleCode = rules.TallyRulePrefix + "ruby/jemalloc-installed-but-not-preloaded"
+
+// Default fix priority — same tier as the PHP rules so cross-rule edit ordering
+// stays predictable when both fire on the same Dockerfile.
+const jemallocFixPriority = 88
+
+// JemallocInstalledButNotPreloadedRule flags final stages that install a
+// jemalloc package without setting LD_PRELOAD or jemalloc-knob MALLOC_CONF.
+type JemallocInstalledButNotPreloadedRule struct{}
+
+// NewJemallocInstalledButNotPreloadedRule creates the rule.
+func NewJemallocInstalledButNotPreloadedRule() *JemallocInstalledButNotPreloadedRule {
+	return &JemallocInstalledButNotPreloadedRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *JemallocInstalledButNotPreloadedRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            JemallocInstalledButNotPreloadedRuleCode,
+		Name:            "jemalloc must be preloaded when installed",
+		Description:     "Final image installs jemalloc but does not preload it via LD_PRELOAD or MALLOC_CONF",
+		DocURL:          rules.TallyDocURL(JemallocInstalledButNotPreloadedRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "performance",
+		FixPriority:     jemallocFixPriority,
+	}
+}
+
+// jemallocPackageManagers are the OS package managers whose package names follow
+// jemalloc distro conventions. Application managers (npm/pip/composer/...)
+// cannot install the system allocator even if they happen to vendor a package
+// with "jemalloc" in its name.
+var jemallocPackageManagers = map[string]bool{
+	"apt":      true,
+	"apt-get":  true,
+	"apk":      true,
+	"dnf":      true,
+	"microdnf": true,
+	"yum":      true,
+	"zypper":   true,
+}
+
+// aptPackageManagers are the apt-family managers whose canonical libjemalloc2
+// path is /usr/lib/<arch>-linux-gnu/libjemalloc.so.2 and for which we can
+// suggest the Rails-generator-style ln + LD_PRELOAD fix.
+var aptPackageManagers = map[string]bool{
+	"apt":     true,
+	"apt-get": true,
+}
+
+// jemallocPackageNames lists the distro package names that ship the jemalloc
+// allocator. Comparison is against the version-stripped, lowercased package
+// name (see shell.StripPackageVersion).
+var jemallocPackageNames = map[string]bool{
+	"libjemalloc1":    true, // Debian/Ubuntu legacy
+	"libjemalloc2":    true, // Debian/Ubuntu current
+	"libjemalloc-dev": true, // Debian/Ubuntu dev headers
+	"jemalloc":        true, // Alpine, Arch
+	"jemalloc-dev":    true, // Alpine dev headers
+}
+
+// jemallocMallocConfKnobs are the option keys that only have meaning to
+// jemalloc itself. If MALLOC_CONF carries any of these, jemalloc is loaded
+// somehow (often via base-image LD_PRELOAD or a `ln + LD_PRELOAD` step that
+// our heuristics could not see).
+var jemallocMallocConfKnobs = []string{
+	"narenas:",
+	"background_thread:",
+	"dirty_decay_ms:",
+	"muzzy_decay_ms:",
+	"thp:",
+}
+
+// Check runs the rule.
+func (r *JemallocInstalledButNotPreloadedRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil || !sf.IsLast {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+
+		if stageHasJemallocLoadSignal(sf) {
+			continue
+		}
+
+		violations = append(violations, r.checkStage(input.File, sf, input.SourceMap(), meta)...)
+	}
+	return violations
+}
+
+func (r *JemallocInstalledButNotPreloadedRule) checkStage(
+	file string,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	var violations []rules.Violation
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		for _, ic := range runFacts.InstallCommands {
+			if !installCommandInstallsJemalloc(ic) {
+				continue
+			}
+
+			loc := jemallocViolationLocation(file, runFacts, ic)
+			v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+				WithDocURL(meta.DocURL).
+				WithDetail(jemallocViolationDetail(ic.Manager))
+
+			if fix := buildJemallocPreloadFix(file, runFacts, ic, sm, meta.FixPriority); fix != nil {
+				v = v.WithSuggestedFix(fix)
+			}
+			violations = append(violations, v)
+		}
+	}
+	return violations
+}
+
+func jemallocViolationDetail(manager string) string {
+	if aptPackageManagers[strings.ToLower(manager)] {
+		return "Installing libjemalloc only adds the package to the image; it is not loaded by Ruby unless " +
+			"LD_PRELOAD points at libjemalloc.so or MALLOC_CONF carries jemalloc-specific knobs. " +
+			"Add `ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so` to the " +
+			"install RUN, then set `ENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"` so long-lived Rails workers " +
+			"actually use jemalloc."
+	}
+	return "Installing a jemalloc package only adds it to the image; it is not loaded by Ruby unless " +
+		"LD_PRELOAD points at the jemalloc shared object or MALLOC_CONF carries jemalloc-specific knobs " +
+		"(narenas:, background_thread:, dirty_decay_ms:, muzzy_decay_ms:, thp:)."
+}
+
+// stageHasJemallocLoadSignal returns true if the effective env for the stage
+// shows that jemalloc will be loaded — either via LD_PRELOAD pointing at a
+// jemalloc shared object, or via MALLOC_CONF carrying a jemalloc-specific knob.
+//
+// LD_PRELOAD detection is substring-based on "jemalloc" because the canonical
+// paths vary by distro (e.g. /usr/lib/x86_64-linux-gnu/libjemalloc.so.2,
+// /usr/local/lib/libjemalloc.so, /usr/lib/libjemalloc.so.2).
+//
+// MALLOC_CONF detection looks for option keys that only mean something to
+// jemalloc itself; glibc malloc and tcmalloc honor neither MALLOC_CONF nor
+// these specific knobs, so seeing them is strong evidence jemalloc is loaded.
+func stageHasJemallocLoadSignal(sf *facts.StageFacts) bool {
+	if sf == nil {
+		return false
+	}
+	if envContainsJemallocLDPreload(sf.EffectiveEnv.Values["LD_PRELOAD"]) {
+		return true
+	}
+	if mallocConfHasJemallocKnob(sf.EffectiveEnv.Values["MALLOC_CONF"]) {
+		return true
+	}
+	return false
+}
+
+func envContainsJemallocLDPreload(value string) bool {
+	if value == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(value), "jemalloc")
+}
+
+func mallocConfHasJemallocKnob(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, knob := range jemallocMallocConfKnobs {
+		if strings.Contains(value, knob) {
+			return true
+		}
+	}
+	return false
+}
+
+// installCommandInstallsJemalloc reports whether a parsed install command
+// contains a jemalloc-bearing distro package. Application-level package
+// managers (npm/pip/composer/...) are excluded because their packages cannot
+// install the system allocator even if a name collision exists.
+func installCommandInstallsJemalloc(ic shell.InstallCommand) bool {
+	if !jemallocPackageManagers[strings.ToLower(ic.Manager)] {
+		return false
+	}
+	for _, pkg := range ic.Packages {
+		if isJemallocPackage(pkg.Normalized) {
+			return true
+		}
+	}
+	return false
+}
+
+func isJemallocPackage(name string) bool {
+	stripped := strings.ToLower(shell.StripPackageVersion(name))
+	return jemallocPackageNames[stripped]
+}
+
+// jemallocViolationLocation returns the source location to attribute the
+// violation to: prefer the line of the package token itself, falling back to
+// the RUN instruction's first line if positions are unavailable.
+func jemallocViolationLocation(
+	file string,
+	runFacts *facts.RunFacts,
+	ic shell.InstallCommand,
+) rules.Location {
+	if runFacts == nil || runFacts.Run == nil {
+		return rules.NewFileLocation(file)
+	}
+
+	for _, pkg := range ic.Packages {
+		if !isJemallocPackage(pkg.Normalized) {
+			continue
+		}
+		runRanges := runFacts.Run.Location()
+		if len(runRanges) == 0 {
+			break
+		}
+		// PackageArg.Line is 0-based within the reconstructed source text
+		// returned by facts.RunFacts.SourceScript. The RUN's first line in
+		// the Dockerfile is the anchor.
+		line := runRanges[0].Start.Line + pkg.Line
+		return rules.NewRangeLocation(file, line, pkg.StartCol, line, pkg.EndCol)
+	}
+	return rules.NewLocationFromRanges(file, runFacts.Run.Location())
+}
+
+// buildJemallocPreloadFix returns the canonical Rails-style fix:
+// insert a new `RUN ln -s … && ENV LD_PRELOAD=…` block on the line *after*
+// the install RUN. Only emitted for the apt-family case where the path layout
+// is well-known. The edit is a single zero-width insertion at column 0 of
+// the line following the install RUN, so it does not collide with content
+// edits other rules might apply to the install RUN itself.
+func buildJemallocPreloadFix(
+	file string,
+	runFacts *facts.RunFacts,
+	ic shell.InstallCommand,
+	sm *sourcemap.SourceMap,
+	priority int,
+) *rules.SuggestedFix {
+	if runFacts == nil || runFacts.Run == nil || sm == nil {
+		return nil
+	}
+	if !aptPackageManagers[strings.ToLower(ic.Manager)] {
+		return nil
+	}
+
+	runRanges := runFacts.Run.Location()
+	if len(runRanges) == 0 {
+		return nil
+	}
+	endLine := sm.ResolveEndLine(runRanges[len(runRanges)-1].End.Line)
+	if endLine <= 0 {
+		return nil
+	}
+
+	insertLine := endLine + 1
+	const fixText = `RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+`
+	return &rules.SuggestedFix{
+		Description: "Symlink libjemalloc.so and set LD_PRELOAD so jemalloc is actually loaded",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(file, insertLine, 0, insertLine, 0),
+			NewText:  fixText,
+		}},
+	}
+}
+
+func init() {
+	rules.Register(NewJemallocInstalledButNotPreloadedRule())
+}

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -1,6 +1,7 @@
 package ruby
 
 import (
+	"path"
 	"strings"
 
 	"github.com/wharflab/tally/internal/facts"
@@ -10,6 +11,18 @@ import (
 	"github.com/wharflab/tally/internal/sourcemap"
 	"github.com/wharflab/tally/internal/stagename"
 )
+
+// jemallocSymlinkCreatingCommands are the parsed command names that can
+// materialize a libjemalloc.so file at the target path. Substring scans on the
+// raw script are too loose — `find`, `echo`, or stray references would falsely
+// suppress the symlink half of the fix, leaving LD_PRELOAD pointing at a
+// missing file.
+var jemallocSymlinkCreatingCommands = map[string]bool{
+	"ln":      true,
+	"cp":      true,
+	"mv":      true,
+	"install": true,
+}
 
 // JemallocInstalledButNotPreloadedRuleCode is the full rule code.
 const JemallocInstalledButNotPreloadedRuleCode = rules.TallyRulePrefix + "ruby/jemalloc-installed-but-not-preloaded"
@@ -327,10 +340,17 @@ ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 }
 
 // stageReferencesJemallocSymlink reports whether the stage already contains a
-// RUN that references the libjemalloc.so shared object — typically a `ln -s`
-// step that creates the canonical symlink. Distro package names (libjemalloc2,
-// libjemalloc1, libjemalloc-dev) do not contain ".so", so the substring check
-// does not false-fire on the install line itself.
+// RUN that creates a libjemalloc.so file — typically a `ln -s` step that
+// materializes the canonical symlink, or a `cp`/`mv`/`install` of an
+// equivalently-named file.
+//
+// The check inspects parsed command invocations (not raw text) and only
+// matches when a non-flag argument's basename is exactly `libjemalloc.so`.
+// This rejects unrelated references like `find / -name 'libjemalloc.so*'`,
+// `echo` of a docs string, or matches on `libjemalloc.so.2` (the apt-shipped
+// versioned library, not the symlink target). Without this narrowing, the
+// fix could emit only `ENV LD_PRELOAD=/usr/local/lib/libjemalloc.so` against
+// a stage that never creates that file, leaving jemalloc unloaded.
 func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 	if sf == nil {
 		return false
@@ -339,9 +359,18 @@ func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 		if rf == nil {
 			continue
 		}
-		if strings.Contains(rf.SourceScript, "libjemalloc.so") ||
-			strings.Contains(rf.CommandScript, "libjemalloc.so") {
-			return true
+		for _, ci := range rf.CommandInfos {
+			if !jemallocSymlinkCreatingCommands[ci.Name] {
+				continue
+			}
+			for _, arg := range ci.Args {
+				if strings.HasPrefix(arg, "-") {
+					continue
+				}
+				if path.Base(arg) == "libjemalloc.so" {
+					return true
+				}
+			}
 		}
 	}
 	return false

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -128,7 +128,7 @@ func (r *JemallocInstalledButNotPreloadedRule) checkStage(
 				continue
 			}
 
-			loc := jemallocViolationLocation(file, runFacts, ic)
+			loc := jemallocViolationLocation(file, runFacts, ic, sm)
 			v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
 				WithDocURL(meta.DocURL).
 				WithDetail(jemallocViolationDetail(ic.Manager))
@@ -223,10 +223,17 @@ func isJemallocPackage(name string) bool {
 // jemallocViolationLocation returns the source location to attribute the
 // violation to: prefer the line of the package token itself, falling back to
 // the RUN instruction's first line if positions are unavailable.
+//
+// On RUN line 0, PackageArg.StartCol/EndCol are shell-relative because
+// facts.RunFacts.SourceScript is reconstructed via shell.ReconstructSourceText,
+// which strips the `RUN <flags>` prefix. We translate back to Dockerfile
+// coordinates by adding shell.DockerfileRunCommandStartCol of the RUN's first
+// line. Continuation lines (pkg.Line > 0) are already Dockerfile-relative.
 func jemallocViolationLocation(
 	file string,
 	runFacts *facts.RunFacts,
 	ic shell.InstallCommand,
+	sm *sourcemap.SourceMap,
 ) rules.Location {
 	if runFacts == nil || runFacts.Run == nil {
 		return rules.NewFileLocation(file)
@@ -240,11 +247,14 @@ func jemallocViolationLocation(
 		if len(runRanges) == 0 {
 			break
 		}
-		// PackageArg.Line is 0-based within the reconstructed source text
-		// returned by facts.RunFacts.SourceScript. The RUN's first line in
-		// the Dockerfile is the anchor.
 		line := runRanges[0].Start.Line + pkg.Line
-		return rules.NewRangeLocation(file, line, pkg.StartCol, line, pkg.EndCol)
+		startCol, endCol := pkg.StartCol, pkg.EndCol
+		if pkg.Line == 0 && sm != nil {
+			offset := shell.DockerfileRunCommandStartCol(sm.Line(line - 1))
+			startCol += offset
+			endCol += offset
+		}
+		return rules.NewRangeLocation(file, line, startCol, line, endCol)
 	}
 	return rules.NewLocationFromRanges(file, runFacts.Run.Location())
 }

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -190,8 +190,9 @@ func mallocConfHasJemallocKnob(value string) bool {
 	if value == "" {
 		return false
 	}
+	lower := strings.ToLower(value)
 	for _, knob := range jemallocMallocConfKnobs {
-		if strings.Contains(value, knob) {
+		if strings.Contains(lower, knob) {
 			return true
 		}
 	}

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -133,7 +133,7 @@ func (r *JemallocInstalledButNotPreloadedRule) checkStage(
 				WithDocURL(meta.DocURL).
 				WithDetail(jemallocViolationDetail(ic.Manager))
 
-			if fix := buildJemallocPreloadFix(file, runFacts, ic, sm, meta.FixPriority); fix != nil {
+			if fix := buildJemallocPreloadFix(file, sf, runFacts, ic, sm, meta.FixPriority); fix != nil {
 				v = v.WithSuggestedFix(fix)
 			}
 			violations = append(violations, v)
@@ -146,7 +146,7 @@ func jemallocViolationDetail(manager string) string {
 	if aptPackageManagers[strings.ToLower(manager)] {
 		return "Installing libjemalloc only adds the package to the image; it is not loaded by Ruby unless " +
 			"LD_PRELOAD points at libjemalloc.so or MALLOC_CONF carries jemalloc-specific knobs. " +
-			"Add `ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so` to the " +
+			"Add `ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so` to the " +
 			"install RUN, then set `ENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"` so long-lived Rails workers " +
 			"actually use jemalloc."
 	}
@@ -249,14 +249,28 @@ func jemallocViolationLocation(
 	return rules.NewLocationFromRanges(file, runFacts.Run.Location())
 }
 
-// buildJemallocPreloadFix returns the canonical Rails-style fix:
-// insert a new `RUN ln -s … && ENV LD_PRELOAD=…` block on the line *after*
-// the install RUN. Only emitted for the apt-family case where the path layout
-// is well-known. The edit is a single zero-width insertion at column 0 of
-// the line following the install RUN, so it does not collide with content
-// edits other rules might apply to the install RUN itself.
+// buildJemallocPreloadFix returns the canonical Rails-style fix: insert a new
+// `RUN ln -sf … && ENV LD_PRELOAD=…` block on the line *after* the install RUN.
+// Only emitted for the apt-family case where the path layout is well-known.
+// The edit is a single zero-width insertion at column 0 of the line following
+// the install RUN, so it does not collide with content edits other rules might
+// apply to the install RUN itself.
+//
+// Two compositional concerns:
+//
+//  1. The rule also fires when a stage already runs `ln -s ... libjemalloc.so`
+//     and only forgot the `ENV LD_PRELOAD`. In that case adding a second
+//     unconditional `ln -s` would fail with `File exists` once the user runs
+//     `--fix-unsafe`. The fix detects an existing reference to the canonical
+//     `libjemalloc.so` shared object in the stage and emits only the missing
+//     `ENV` line in that case.
+//  2. As a defense in depth even when no symlink reference is detected (e.g.
+//     a base-image inherited link the rule cannot see), the emitted command
+//     uses `ln -sf` so a re-run on already-linked layouts replaces rather than
+//     fails.
 func buildJemallocPreloadFix(
 	file string,
+	sf *facts.StageFacts,
 	runFacts *facts.RunFacts,
 	ic shell.InstallCommand,
 	sm *sourcemap.SourceMap,
@@ -279,11 +293,19 @@ func buildJemallocPreloadFix(
 	}
 
 	insertLine := endLine + 1
-	const fixText = `RUN ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+	var fixText, description string
+	if stageReferencesJemallocSymlink(sf) {
+		fixText = `ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+`
+		description = "Set LD_PRELOAD so the jemalloc symlink already in this stage is actually loaded"
+	} else {
+		fixText = `RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
 ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 `
+		description = "Symlink libjemalloc.so and set LD_PRELOAD so jemalloc is actually loaded"
+	}
 	return &rules.SuggestedFix{
-		Description: "Symlink libjemalloc.so and set LD_PRELOAD so jemalloc is actually loaded",
+		Description: description,
 		Safety:      rules.FixSuggestion,
 		Priority:    priority,
 		IsPreferred: true,
@@ -292,6 +314,27 @@ ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 			NewText:  fixText,
 		}},
 	}
+}
+
+// stageReferencesJemallocSymlink reports whether the stage already contains a
+// RUN that references the libjemalloc.so shared object — typically a `ln -s`
+// step that creates the canonical symlink. Distro package names (libjemalloc2,
+// libjemalloc1, libjemalloc-dev) do not contain ".so", so the substring check
+// does not false-fire on the install line itself.
+func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
+	if sf == nil {
+		return false
+	}
+	for _, rf := range sf.Runs {
+		if rf == nil {
+			continue
+		}
+		if strings.Contains(rf.SourceScript, "libjemalloc.so") ||
+			strings.Contains(rf.CommandScript, "libjemalloc.so") {
+			return true
+		}
+	}
+	return false
 }
 
 func init() {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -130,7 +130,7 @@ func (r *JemallocInstalledButNotPreloadedRule) Check(input rules.LintInput) []ru
 		// Ruby-namespaced rule: only fire on stages that look like a Ruby
 		// runtime. A non-Ruby image (Node, Python, ...) installing jemalloc
 		// for unrelated reasons shouldn't get a Rails-flavored warning.
-		if !stageLooksLikeRuby(input.Semantic.StageInfo(stageIdx), stage, sf, input.MetaArgs) {
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf, input.MetaArgs) {
 			continue
 		}
 
@@ -188,17 +188,21 @@ var rubyDerivativeImages = map[string]bool{
 // runtime: an official ruby:* base (including ARG-templated forms like
 // `FROM ${RUBY_IMAGE}` resolved against meta ARGs), a known Ruby-runtime
 // derivative, a stage env with Ruby/Rails/Bundler signals, or a runtime
-// command that matches a Ruby app server. Stage refs (`FROM <stage>`)
-// inherit the signal from their parent via facts.StageFacts.EffectiveEnv
-// and the semantic model's resolved base image.
+// command that matches a Ruby app server.
+//
+// For stage refs (`FROM <stage>`) the classifier walks the StageRef
+// ancestry until it finds the original external base image — a final
+// stage `FROM builder` where `builder` is `FROM ruby:3.3-slim` is still
+// classified as Ruby even when the final stage carries no explicit Ruby
+// env or runtime command.
 func stageLooksLikeRuby(
-	info *semantic.StageInfo,
+	sem *semantic.Model,
+	stageIdx int,
 	stage instructions.Stage,
 	sf *facts.StageFacts,
 	metaArgs []instructions.ArgCommand,
 ) bool {
-	if info != nil && info.BaseImage != nil && !info.BaseImage.IsStageRef &&
-		baseImageLooksLikeRuby(info.BaseImage.Raw, metaArgs) {
+	if base := sem.ExternalBase(stageIdx); base != nil && baseImageLooksLikeRuby(base.Raw, metaArgs) {
 		return true
 	}
 	if sf != nil {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -279,9 +279,38 @@ func jemallocViolationLocation(
 	return rules.NewLocationFromRanges(file, runFacts.Run.Location())
 }
 
+// libjemalloc2ProvidingPackages are the apt-family packages that install
+// libjemalloc.so.2 — the file the canonical fix symlinks to. libjemalloc1
+// is intentionally excluded because it ships libjemalloc.so.1 instead, so
+// a generated `ln -sf … libjemalloc.so.2 …` would point at a non-existent
+// file and the suggested fix would not actually load jemalloc.
+var libjemalloc2ProvidingPackages = map[string]bool{
+	"libjemalloc2":    true, // ships /usr/lib/<arch>-linux-gnu/libjemalloc.so.2
+	"libjemalloc-dev": true, // depends on libjemalloc2 and adds the unversioned link
+}
+
+// installCommandProvidesLibjemalloc2 reports whether the install command
+// adds a package that ships /usr/lib/<arch>-linux-gnu/libjemalloc.so.2.
+func installCommandProvidesLibjemalloc2(ic shell.InstallCommand) bool {
+	if !aptPackageManagers[strings.ToLower(ic.Manager)] {
+		return false
+	}
+	for _, pkg := range ic.Packages {
+		stripped := strings.ToLower(shell.StripPackageVersion(pkg.Normalized))
+		if libjemalloc2ProvidingPackages[stripped] {
+			return true
+		}
+	}
+	return false
+}
+
 // buildJemallocPreloadFix returns the canonical Rails-style fix: insert a new
 // `RUN ln -sf … && ENV LD_PRELOAD=…` block on the line *after* the install RUN.
-// Only emitted for the apt-family case where the path layout is well-known.
+// Only emitted for apt-family installs of a package that actually ships
+// libjemalloc.so.2 (libjemalloc2 / libjemalloc-dev). For libjemalloc1 the
+// canonical fix would link to a non-existent `.so.2` file, so no fix is
+// offered there; the violation still fires.
+//
 // The edit is a single zero-width insertion at column 0 of the line following
 // the install RUN, so it does not collide with content edits other rules might
 // apply to the install RUN itself.
@@ -309,7 +338,7 @@ func buildJemallocPreloadFix(
 	if runFacts == nil || runFacts.Run == nil || sm == nil {
 		return nil
 	}
-	if !aptPackageManagers[strings.ToLower(ic.Manager)] {
+	if !installCommandProvidesLibjemalloc2(ic) {
 		return nil
 	}
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -683,23 +683,12 @@ var jemallocSymlinkRemovingCommands = map[string]bool{
 //   - unlink /usr/local/lib/libjemalloc.so      → any non-flag arg counts
 //   - mv /usr/local/lib/libjemalloc.so DST       → only the SOURCE counts;
 //     the target (last non-flag arg) means it was created, not removed
+//   - mv -t DIR /usr/local/lib/libjemalloc.so    → all args after the -t
+//     value are sources, even though they appear after the target
 func commandRemovesJemallocSymlink(ci shell.CommandInfo) bool {
 	if ci.Name == "mv" {
-		// All non-flag args except the last (target) are sources.
-		targetIdx := -1
-		for i, arg := range slices.Backward(ci.Args) {
-			if !strings.HasPrefix(arg, "-") {
-				targetIdx = i
-				break
-			}
-		}
-		if targetIdx <= 0 {
-			return false
-		}
-		for _, arg := range ci.Args[:targetIdx] {
-			if strings.HasPrefix(arg, "-") {
-				continue
-			}
+		sources := mvSourceArgs(ci)
+		for _, arg := range sources {
 			if path.Clean(arg) == jemallocCanonicalSymlinkPath {
 				return true
 			}
@@ -716,6 +705,73 @@ func commandRemovesJemallocSymlink(ci shell.CommandInfo) bool {
 		}
 	}
 	return false
+}
+
+// mvSourceArgs returns the non-flag arguments to a `mv` invocation that act
+// as sources (i.e. the files removed by the move). Two syntactic forms are
+// supported:
+//
+//   - `mv [OPTION...] SRC... DST`              → all non-flag args before the
+//     final non-flag (the destination) are sources.
+//   - `mv [OPTION...] -t DIR SRC...`           → DIR is the destination;
+//     all non-flag args other than DIR are sources. The long form
+//     `--target-directory[=DIR]` is also recognized.
+func mvSourceArgs(ci shell.CommandInfo) []string {
+	skipIdx, ok := targetDirectoryArgIndex(ci)
+	if ok {
+		var sources []string
+		for i, arg := range ci.Args {
+			if i == skipIdx {
+				continue
+			}
+			if strings.HasPrefix(arg, "-") {
+				continue
+			}
+			sources = append(sources, arg)
+		}
+		return sources
+	}
+	// Default form: last non-flag is destination, the rest are sources.
+	targetIdx := -1
+	for i, arg := range slices.Backward(ci.Args) {
+		if !strings.HasPrefix(arg, "-") {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx <= 0 {
+		return nil
+	}
+	var sources []string
+	for _, arg := range ci.Args[:targetIdx] {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		sources = append(sources, arg)
+	}
+	return sources
+}
+
+// targetDirectoryArgIndex returns the index of the args entry that supplies
+// the directory value to `-t` / `--target-directory` (the *value* token, not
+// the flag itself). For `--target-directory=DIR` and `-t=DIR` the value is
+// embedded in the same token and the returned index is -1 (nothing extra to
+// skip beyond the flag prefix, which is filtered out by the leading `-`
+// check). ok=false means the flag is not present.
+func targetDirectoryArgIndex(ci shell.CommandInfo) (int, bool) {
+	for i, arg := range ci.Args {
+		switch {
+		case arg == "-t" || arg == "--target-directory":
+			if i+1 < len(ci.Args) && !strings.HasPrefix(ci.Args[i+1], "-") {
+				return i + 1, true
+			}
+		case strings.HasPrefix(arg, "--target-directory="):
+			return -1, true
+		case strings.HasPrefix(arg, "-t="):
+			return -1, true
+		}
+	}
+	return 0, false
 }
 
 // lastNonFlagArg returns the last argument that does not start with `-`,

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -305,6 +305,10 @@ func jemallocViolationDetail(manager string) string {
 // shows that jemalloc will be loaded — either via LD_PRELOAD pointing at a
 // jemalloc shared object, or via MALLOC_CONF carrying a jemalloc-specific knob.
 //
+// Only values bound by an `ENV` instruction count: ARG-derived values live
+// in EffectiveEnv.Values but are build-time only and absent from the final
+// image runtime, so they do not actually load jemalloc at startup.
+//
 // LD_PRELOAD detection is substring-based on "jemalloc" because the canonical
 // paths vary by distro (e.g. /usr/lib/x86_64-linux-gnu/libjemalloc.so.2,
 // /usr/local/lib/libjemalloc.so, /usr/lib/libjemalloc.so.2).
@@ -316,13 +320,27 @@ func stageHasJemallocLoadSignal(sf *facts.StageFacts) bool {
 	if sf == nil {
 		return false
 	}
-	if envContainsJemallocLDPreload(sf.EffectiveEnv.Values["LD_PRELOAD"]) {
+	if envContainsJemallocLDPreload(envBoundValue(sf, "LD_PRELOAD")) {
 		return true
 	}
-	if mallocConfHasJemallocKnob(sf.EffectiveEnv.Values["MALLOC_CONF"]) {
+	if mallocConfHasJemallocKnob(envBoundValue(sf, "MALLOC_CONF")) {
 		return true
 	}
 	return false
+}
+
+// envBoundValue returns the value of an env key that was set by an `ENV`
+// instruction (or inherited from a parent stage's ENV). Values present only
+// in EffectiveEnv.Values via ARG promotion return "" — those are build-time
+// only and do not exist in the final image runtime.
+func envBoundValue(sf *facts.StageFacts, key string) string {
+	if sf == nil {
+		return ""
+	}
+	if binding, ok := sf.EffectiveEnv.Bindings[key]; ok {
+		return binding.Value
+	}
+	return ""
 }
 
 func envContainsJemallocLDPreload(value string) bool {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -394,18 +394,24 @@ func stageHasJemallocLoadSignal(sf *facts.StageFacts) bool {
 	return false
 }
 
-// envBoundValue returns the value of an env key that was set by an `ENV`
-// instruction (or inherited from a parent stage's ENV). Values present only
-// in EffectiveEnv.Values via ARG promotion return "" — those are build-time
-// only and do not exist in the final image runtime.
+// envBoundValue returns the *resolved* value of an env key that was set by
+// an `ENV` instruction (or inherited from a parent stage's ENV). Values
+// present only in EffectiveEnv.Values via ARG promotion return "" — those
+// are build-time only and do not exist in the final image runtime.
+//
+// The Bindings map confirms the key was actually written by an ENV
+// instruction; the resolved (variable-expanded) value comes from
+// EffectiveEnv.Values, since binding.Value is the literal right-hand side
+// of the ENV instruction (e.g. `$JEMALLOC_PATH`) and would miss valid
+// chained patterns like `ENV LD_PRELOAD=$JEMALLOC_PATH`.
 func envBoundValue(sf *facts.StageFacts, key string) string {
 	if sf == nil {
 		return ""
 	}
-	if binding, ok := sf.EffectiveEnv.Bindings[key]; ok {
-		return binding.Value
+	if _, ok := sf.EffectiveEnv.Bindings[key]; !ok {
+		return ""
 	}
-	return ""
+	return sf.EffectiveEnv.Values[key]
 }
 
 func envContainsJemallocLDPreload(value string) bool {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -515,11 +515,22 @@ func envBoundValue(sf *facts.StageFacts, key string) string {
 	return sf.EffectiveEnv.Values[key]
 }
 
+// envContainsJemallocLDPreload reports whether an LD_PRELOAD value loads a
+// jemalloc shared object. The dynamic linker accepts space- and
+// colon-separated entries, so we tokenize on both and verify the basename
+// of at least one entry matches the canonical jemalloc soname pattern.
+//
+// Substring matching used to false-suppress on lookalikes like
+// `LD_PRELOAD=/opt/libjemalloc-backups/libfoo.so` — directory contained
+// "libjemalloc" but the actual preloaded object was unrelated.
 func envContainsJemallocLDPreload(value string) bool {
 	if value == "" {
 		return false
 	}
-	return strings.Contains(strings.ToLower(value), "jemalloc")
+	entries := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ' ' || r == ':' || r == '\t'
+	})
+	return slices.ContainsFunc(entries, isJemallocSharedObjectPath)
 }
 
 func mallocConfHasJemallocKnob(value string) bool {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -542,9 +542,17 @@ func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 			if target == "" {
 				continue
 			}
-			if path.Clean(target) == jemallocCanonicalSymlinkPath {
-				return true
+			if path.Clean(target) != jemallocCanonicalSymlinkPath {
+				continue
 			}
+			// Source must reference a jemalloc shared object — otherwise a
+			// command like `cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so`
+			// would suppress the symlink half of the fix, leaving LD_PRELOAD
+			// pointing at a non-jemalloc library.
+			if !nonTargetArgsReferenceJemalloc(ci.Args) {
+				continue
+			}
+			return true
 		}
 	}
 	return false
@@ -559,6 +567,33 @@ func lastNonFlagArg(args []string) string {
 		}
 	}
 	return ""
+}
+
+// nonTargetArgsReferenceJemalloc reports whether any non-flag arg *other than
+// the last one* (the target of a create/move command) references a jemalloc
+// shared object. Used to verify that a `cp`/`mv`/`install`/`ln` writing into
+// /usr/local/lib/libjemalloc.so is actually copying jemalloc, not an
+// unrelated `.so`.
+func nonTargetArgsReferenceJemalloc(args []string) bool {
+	targetIdx := -1
+	for i, arg := range slices.Backward(args) {
+		if !strings.HasPrefix(arg, "-") {
+			targetIdx = i
+			break
+		}
+	}
+	if targetIdx <= 0 {
+		return false
+	}
+	for _, arg := range args[:targetIdx] {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if strings.Contains(strings.ToLower(arg), "libjemalloc") {
+			return true
+		}
+	}
+	return false
 }
 
 func init() {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -613,34 +613,105 @@ func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 	if sf == nil {
 		return false
 	}
+	// Walk the stage in source order and track whether the canonical
+	// symlink is *currently* present at the end of the stage. A later
+	// `rm /usr/local/lib/libjemalloc.so` (or `mv` away from it) undoes
+	// an earlier creation, so a single creation early in the stage is
+	// not sufficient evidence.
+	present := false
 	for _, rf := range sf.Runs {
 		if rf == nil {
 			continue
 		}
 		for _, ci := range rf.CommandInfos {
-			if !jemallocSymlinkCreatingCommands[ci.Name] {
+			switch {
+			case jemallocSymlinkCreatingCommands[ci.Name]:
+				if commandCreatesJemallocSymlink(ci) {
+					present = true
+				}
+				if ci.Name == "mv" && commandRemovesJemallocSymlink(ci) {
+					// `mv /usr/local/lib/libjemalloc.so DST` removes the
+					// source. The target check above does NOT match this
+					// shape (target is DST), so the present flag stays
+					// untouched there; this branch handles the removal.
+					present = false
+				}
+			case jemallocSymlinkRemovingCommands[ci.Name]:
+				if commandRemovesJemallocSymlink(ci) {
+					present = false
+				}
+			}
+		}
+	}
+	return present
+}
+
+// commandCreatesJemallocSymlink reports whether the parsed command writes
+// the canonical /usr/local/lib/libjemalloc.so file with a jemalloc source.
+func commandCreatesJemallocSymlink(ci shell.CommandInfo) bool {
+	// `install -d /path` creates a directory at /path, not a file —
+	// LD_PRELOAD pointing at a directory does not load jemalloc.
+	if ci.Name == "install" && (ci.HasFlag("-d") || ci.HasFlag("--directory")) {
+		return false
+	}
+	target := lastNonFlagArg(ci.Args)
+	if target == "" {
+		return false
+	}
+	if path.Clean(target) != jemallocCanonicalSymlinkPath {
+		return false
+	}
+	// Source must reference a jemalloc shared object — otherwise a
+	// command like `cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so`
+	// would suppress the symlink half of the fix, leaving LD_PRELOAD
+	// pointing at a non-jemalloc library.
+	return nonTargetArgsReferenceJemalloc(ci.Args)
+}
+
+// jemallocSymlinkRemovingCommands are command names that, when invoked
+// with the canonical path as a non-flag arg, remove the symlink.
+var jemallocSymlinkRemovingCommands = map[string]bool{
+	"rm":     true,
+	"unlink": true,
+}
+
+// commandRemovesJemallocSymlink reports whether the parsed command takes
+// the canonical /usr/local/lib/libjemalloc.so as one of its non-flag args
+// in a position that causes removal:
+//
+//   - rm /usr/local/lib/libjemalloc.so          → any non-flag arg counts
+//   - unlink /usr/local/lib/libjemalloc.so      → any non-flag arg counts
+//   - mv /usr/local/lib/libjemalloc.so DST       → only the SOURCE counts;
+//     the target (last non-flag arg) means it was created, not removed
+func commandRemovesJemallocSymlink(ci shell.CommandInfo) bool {
+	if ci.Name == "mv" {
+		// All non-flag args except the last (target) are sources.
+		targetIdx := -1
+		for i, arg := range slices.Backward(ci.Args) {
+			if !strings.HasPrefix(arg, "-") {
+				targetIdx = i
+				break
+			}
+		}
+		if targetIdx <= 0 {
+			return false
+		}
+		for _, arg := range ci.Args[:targetIdx] {
+			if strings.HasPrefix(arg, "-") {
 				continue
 			}
-			// `install -d /path` creates a directory at /path, not a file —
-			// LD_PRELOAD pointing at a directory does not load jemalloc, so
-			// the symlink half of the fix must still run.
-			if ci.Name == "install" && (ci.HasFlag("-d") || ci.HasFlag("--directory")) {
-				continue
+			if path.Clean(arg) == jemallocCanonicalSymlinkPath {
+				return true
 			}
-			target := lastNonFlagArg(ci.Args)
-			if target == "" {
-				continue
-			}
-			if path.Clean(target) != jemallocCanonicalSymlinkPath {
-				continue
-			}
-			// Source must reference a jemalloc shared object — otherwise a
-			// command like `cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so`
-			// would suppress the symlink half of the fix, leaving LD_PRELOAD
-			// pointing at a non-jemalloc library.
-			if !nonTargetArgsReferenceJemalloc(ci.Args) {
-				continue
-			}
+		}
+		return false
+	}
+	// rm / unlink: any non-flag arg pointing at the canonical path removes it.
+	for _, arg := range ci.Args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if path.Clean(arg) == jemallocCanonicalSymlinkPath {
 			return true
 		}
 	}

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -327,7 +327,7 @@ func (r *JemallocInstalledButNotPreloadedRule) checkStage(
 			loc := jemallocViolationLocation(file, runFacts, ic, sm)
 			v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
 				WithDocURL(meta.DocURL).
-				WithDetail(jemallocViolationDetail(ic.Manager))
+				WithDetail(jemallocViolationDetail(ic))
 
 			if fix := buildJemallocPreloadFix(file, sf, runFacts, ic, sm, meta.FixPriority); fix != nil {
 				v = v.WithSuggestedFix(fix)
@@ -338,13 +338,28 @@ func (r *JemallocInstalledButNotPreloadedRule) checkStage(
 	return violations
 }
 
-func jemallocViolationDetail(manager string) string {
-	if aptPackageManagers[strings.ToLower(manager)] {
+// jemallocViolationDetail returns the human-readable detail attached to a
+// violation. The canonical `ln -sf … libjemalloc.so.2 …` suggestion is only
+// included when the install actually ships libjemalloc.so.2 — otherwise the
+// advice would create a dangling symlink (e.g. libjemalloc1 ships .so.1).
+func jemallocViolationDetail(ic shell.InstallCommand) string {
+	if installCommandProvidesLibjemalloc2(ic) {
 		return "Installing libjemalloc only adds the package to the image; it is not loaded by Ruby unless " +
 			"LD_PRELOAD points at libjemalloc.so or MALLOC_CONF carries jemalloc-specific knobs. " +
 			"Add `ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so` to the " +
 			"install RUN, then set `ENV LD_PRELOAD=\"/usr/local/lib/libjemalloc.so\"` so long-lived Rails workers " +
 			"actually use jemalloc."
+	}
+	if aptPackageManagers[strings.ToLower(ic.Manager)] {
+		// libjemalloc1 (and any future apt variant we don't recognize as
+		// libjemalloc.so.2-providing) ships a different .so version. Don't
+		// suggest a hardcoded path here — that would steer users toward a
+		// dangling symlink. Recommend migrating to libjemalloc2 instead.
+		return "Installing libjemalloc only adds the package to the image; it is not loaded by Ruby unless " +
+			"LD_PRELOAD points at the matching libjemalloc shared object in the runtime environment. " +
+			"This package (e.g. libjemalloc1) is legacy and ships a different .so version than the " +
+			"canonical Rails-generator pattern targets — migrate to libjemalloc2 so the standard symlink + " +
+			"LD_PRELOAD recipe applies."
 	}
 	return "Installing a jemalloc package only adds it to the image; it is not loaded by Ruby unless " +
 		"LD_PRELOAD points at the jemalloc shared object or MALLOC_CONF carries jemalloc-specific knobs " +

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -2,6 +2,7 @@ package ruby
 
 import (
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/wharflab/tally/internal/facts"
@@ -12,11 +13,16 @@ import (
 	"github.com/wharflab/tally/internal/stagename"
 )
 
+// jemallocCanonicalSymlinkPath is the path our suggested fix points
+// LD_PRELOAD at. The "stage already creates the symlink" guardrail must
+// verify this exact path is the *target* of an existing create/move, not just
+// that the path appears anywhere in the script.
+const jemallocCanonicalSymlinkPath = "/usr/local/lib/libjemalloc.so"
+
 // jemallocSymlinkCreatingCommands are the parsed command names that can
-// materialize a libjemalloc.so file at the target path. Substring scans on the
-// raw script are too loose — `find`, `echo`, or stray references would falsely
-// suppress the symlink half of the fix, leaving LD_PRELOAD pointing at a
-// missing file.
+// materialize a file at a target path. Substring scans on the raw script are
+// too loose — `find`, `echo`, or stray references would falsely suppress the
+// symlink half of the fix, leaving LD_PRELOAD pointing at a missing file.
 var jemallocSymlinkCreatingCommands = map[string]bool{
 	"ln":      true,
 	"cp":      true,
@@ -340,17 +346,24 @@ ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 }
 
 // stageReferencesJemallocSymlink reports whether the stage already contains a
-// RUN that creates a libjemalloc.so file — typically a `ln -s` step that
-// materializes the canonical symlink, or a `cp`/`mv`/`install` of an
-// equivalently-named file.
+// RUN that creates the canonical /usr/local/lib/libjemalloc.so file — i.e.
+// the exact path our suggested fix points LD_PRELOAD at. Typically this is a
+// `ln -s SRC /usr/local/lib/libjemalloc.so` step, but `cp`, `mv`, and
+// `install` with the same target are also accepted.
 //
 // The check inspects parsed command invocations (not raw text) and only
-// matches when a non-flag argument's basename is exactly `libjemalloc.so`.
-// This rejects unrelated references like `find / -name 'libjemalloc.so*'`,
-// `echo` of a docs string, or matches on `libjemalloc.so.2` (the apt-shipped
-// versioned library, not the symlink target). Without this narrowing, the
-// fix could emit only `ENV LD_PRELOAD=/usr/local/lib/libjemalloc.so` against
-// a stage that never creates that file, leaving jemalloc unloaded.
+// matches when the LAST non-flag argument of a create/move command resolves
+// to /usr/local/lib/libjemalloc.so under path.Clean. Earlier non-flag args
+// are intentionally ignored: they are the source(s), and matching them would
+// cause `cp /opt/libjemalloc.so /tmp/backup.so` or
+// `mv /usr/local/lib/libjemalloc.so /tmp/old.so` to be treated as "the
+// symlink exists" — the latter actually removes the canonical file, so
+// suppressing the symlink half of the fix would leave LD_PRELOAD pointing at
+// a missing file.
+//
+// References that are not create/move (find, echo, ls, ...) and references to
+// libjemalloc.so.2 (the apt-shipped versioned library, not the symlink
+// target) are rejected by construction.
 func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 	if sf == nil {
 		return false
@@ -363,17 +376,27 @@ func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 			if !jemallocSymlinkCreatingCommands[ci.Name] {
 				continue
 			}
-			for _, arg := range ci.Args {
-				if strings.HasPrefix(arg, "-") {
-					continue
-				}
-				if path.Base(arg) == "libjemalloc.so" {
-					return true
-				}
+			target := lastNonFlagArg(ci.Args)
+			if target == "" {
+				continue
+			}
+			if path.Clean(target) == jemallocCanonicalSymlinkPath {
+				return true
 			}
 		}
 	}
 	return false
+}
+
+// lastNonFlagArg returns the last argument that does not start with `-`,
+// or "" if every arg is a flag.
+func lastNonFlagArg(args []string) string {
+	for _, arg := range slices.Backward(args) {
+		if !strings.HasPrefix(arg, "-") {
+			return arg
+		}
+	}
+	return ""
 }
 
 func init() {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -754,7 +754,8 @@ func mvSourceArgs(ci shell.CommandInfo) []string {
 
 // targetDirectoryArgIndex returns the index of the args entry that supplies
 // the directory value to `-t` / `--target-directory` (the *value* token, not
-// the flag itself). For `--target-directory=DIR` and `-t=DIR` the value is
+// the flag itself). For `--target-directory=DIR`, `-t=DIR`, and the GNU
+// short form `-tDIR` (value attached directly to the flag) the value is
 // embedded in the same token and the returned index is -1 (nothing extra to
 // skip beyond the flag prefix, which is filtered out by the leading `-`
 // check). ok=false means the flag is not present.
@@ -768,6 +769,12 @@ func targetDirectoryArgIndex(ci shell.CommandInfo) (int, bool) {
 		case strings.HasPrefix(arg, "--target-directory="):
 			return -1, true
 		case strings.HasPrefix(arg, "-t="):
+			return -1, true
+		// GNU short flag with attached value: `-tDIR` (no `=` separator).
+		// Only matches when the character after `-t` is non-empty and not
+		// itself a flag separator, to avoid confusing `-t` followed by
+		// other clustered short flags.
+		case len(arg) > 2 && strings.HasPrefix(arg, "-t") && arg[2] != '-':
 			return -1, true
 		}
 	}

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	dfshell "github.com/moby/buildkit/frontend/dockerfile/shell"
 
 	"github.com/wharflab/tally/internal/facts"
 	"github.com/wharflab/tally/internal/rules"
@@ -129,7 +130,7 @@ func (r *JemallocInstalledButNotPreloadedRule) Check(input rules.LintInput) []ru
 		// Ruby-namespaced rule: only fire on stages that look like a Ruby
 		// runtime. A non-Ruby image (Node, Python, ...) installing jemalloc
 		// for unrelated reasons shouldn't get a Rails-flavored warning.
-		if !stageLooksLikeRuby(input.Semantic.StageInfo(stageIdx), stage, sf) {
+		if !stageLooksLikeRuby(input.Semantic.StageInfo(stageIdx), stage, sf, input.MetaArgs) {
 			continue
 		}
 
@@ -184,13 +185,20 @@ var rubyDerivativeImages = map[string]bool{
 }
 
 // stageLooksLikeRuby reports whether the stage looks like a Ruby/Rails
-// runtime: an official ruby:* base, a known Ruby-runtime derivative,
-// a stage env with Ruby/Rails/Bundler signals, or a runtime command that
-// matches a Ruby app server. Stage refs (`FROM <stage>`) inherit the
-// signal from their parent via facts.StageFacts.EffectiveEnv and the
-// semantic model's resolved base image.
-func stageLooksLikeRuby(info *semantic.StageInfo, stage instructions.Stage, sf *facts.StageFacts) bool {
-	if info != nil && info.BaseImage != nil && !info.BaseImage.IsStageRef && baseImageLooksLikeRuby(info.BaseImage.Raw) {
+// runtime: an official ruby:* base (including ARG-templated forms like
+// `FROM ${RUBY_IMAGE}` resolved against meta ARGs), a known Ruby-runtime
+// derivative, a stage env with Ruby/Rails/Bundler signals, or a runtime
+// command that matches a Ruby app server. Stage refs (`FROM <stage>`)
+// inherit the signal from their parent via facts.StageFacts.EffectiveEnv
+// and the semantic model's resolved base image.
+func stageLooksLikeRuby(
+	info *semantic.StageInfo,
+	stage instructions.Stage,
+	sf *facts.StageFacts,
+	metaArgs []instructions.ArgCommand,
+) bool {
+	if info != nil && info.BaseImage != nil && !info.BaseImage.IsStageRef &&
+		baseImageLooksLikeRuby(info.BaseImage.Raw, metaArgs) {
 		return true
 	}
 	if sf != nil {
@@ -210,9 +218,25 @@ func stageLooksLikeRuby(info *semantic.StageInfo, stage instructions.Stage, sf *
 
 // baseImageLooksLikeRuby reports whether a base image reference points at
 // a Ruby or Rails runtime — the official ruby:* image, a familiar name
-// that mentions "ruby" or "rails", or a known derivative.
-func baseImageLooksLikeRuby(raw string) bool {
-	named, err := reference.ParseNormalizedNamed(strings.ToLower(raw))
+// that mentions "ruby" or "rails", or a known derivative. ARG-templated
+// references like `FROM ${RUBY_IMAGE}` are resolved against meta ARGs
+// (the ones declared before the first FROM) so the classification still
+// works on Dockerfiles that parameterize the base image.
+func baseImageLooksLikeRuby(raw string, metaArgs []instructions.ArgCommand) bool {
+	if rawLooksLikeRuby(raw) {
+		return true
+	}
+	if expanded, ok := expandWithMetaArgs(raw, metaArgs); ok && expanded != raw {
+		return rawLooksLikeRuby(expanded)
+	}
+	return false
+}
+
+// rawLooksLikeRuby parses a base image reference and matches against the
+// known Ruby/Rails name set. Returns false when the reference is unparsable
+// (e.g. still contains a `${VAR}` placeholder).
+func rawLooksLikeRuby(s string) bool {
+	named, err := reference.ParseNormalizedNamed(strings.ToLower(s))
 	if err != nil {
 		return false
 	}
@@ -221,6 +245,32 @@ func baseImageLooksLikeRuby(raw string) bool {
 		return true
 	}
 	return strings.Contains(familiar, "ruby") || strings.Contains(familiar, "rails")
+}
+
+// expandWithMetaArgs resolves `${VAR}`/`$VAR` references in `raw` against
+// the default values of meta ARGs (those declared before the first FROM,
+// which are the only ARGs in scope for FROM expansion). Returns the
+// expanded string and ok=true when expansion succeeded with no unmatched
+// references.
+func expandWithMetaArgs(raw string, metaArgs []instructions.ArgCommand) (string, bool) {
+	if raw == "" || !strings.ContainsAny(raw, "$") {
+		return raw, false
+	}
+	env := make([]string, 0, len(metaArgs))
+	for _, arg := range metaArgs {
+		for _, kv := range arg.Args {
+			if kv.Value == nil {
+				continue
+			}
+			env = append(env, kv.Key+"="+*kv.Value)
+		}
+	}
+	lex := dfshell.NewLex('\\')
+	res, err := lex.ProcessWordWithMatches(raw, dfshell.EnvsFromSlice(env))
+	if err != nil || len(res.Unmatched) > 0 || res.Result == "" {
+		return raw, false
+	}
+	return res.Result, true
 }
 
 // stageRuntimeCommandBasenames returns the lowercased basename of the first

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -402,6 +402,35 @@ func stageHasJemallocLoadSignal(sf *facts.StageFacts) bool {
 	return false
 }
 
+// buildJemallocLDPreloadEnvLine returns the `ENV LD_PRELOAD=…` line the fix
+// should emit. When the stage already has an explicit ENV-bound LD_PRELOAD
+// value (one that doesn't already mention jemalloc — otherwise the rule
+// wouldn't have fired), the canonical jemalloc path is *prepended* to that
+// value so the existing preload chain is preserved instead of being
+// silently dropped. The dynamic linker honors space-separated LD_PRELOAD
+// entries and applies them left-to-right, so prepending puts jemalloc
+// first while keeping the user's preload(s) in effect.
+//
+// If the existing value contains characters that would break a simple
+// double-quoted ENV literal (a `"` or trailing backslash), the fix falls
+// back to setting just the canonical path — the user can hand-merge their
+// preload chain afterwards.
+func buildJemallocLDPreloadEnvLine(sf *facts.StageFacts) string {
+	const canonical = jemallocCanonicalSymlinkPath
+	existing := strings.TrimSpace(envBoundValue(sf, "LD_PRELOAD"))
+	if existing == "" || envValueIsAwkwardToQuote(existing) {
+		return "ENV LD_PRELOAD=\"" + canonical + "\"\n"
+	}
+	return "ENV LD_PRELOAD=\"" + canonical + " " + existing + "\"\n"
+}
+
+// envValueIsAwkwardToQuote reports whether an ENV value contains characters
+// that would require non-trivial Dockerfile escaping inside a simple
+// double-quoted literal. Conservatively skips merging in those cases.
+func envValueIsAwkwardToQuote(s string) bool {
+	return strings.ContainsAny(s, "\"\\")
+}
+
 // lastJemallocSymlinkRemovalRunEndLine returns the (1-based, multi-line-aware)
 // end line of the *last* RUN in the stage whose parsed commands include a
 // removal of the canonical /usr/local/lib/libjemalloc.so path (rm, unlink,
@@ -654,15 +683,14 @@ func buildJemallocPreloadFix(
 	if line := lastJemallocSymlinkRemovalRunEndLine(sf, sm); line > endLine && line+1 > insertLine {
 		insertLine = line + 1
 	}
+	envLine := buildJemallocLDPreloadEnvLine(sf)
 	var fixText, description string
 	if stageReferencesJemallocSymlink(sf) {
-		fixText = `ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
-`
+		fixText = envLine
 		description = "Set LD_PRELOAD so the jemalloc symlink already in this stage is actually loaded"
 	} else {
-		fixText = `RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
-ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
-`
+		fixText = "RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+			envLine
 		description = "Symlink libjemalloc.so and set LD_PRELOAD so jemalloc is actually loaded"
 	}
 	return &rules.SuggestedFix{

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -205,8 +205,12 @@ func stageLooksLikeRuby(
 	if base := sem.ExternalBase(stageIdx); base != nil && baseImageLooksLikeRuby(base.Raw, metaArgs) {
 		return true
 	}
+	// Ruby env signals must come from an actual ENV instruction. ARG values
+	// are also visible in EffectiveEnv.Values, but they are build-time only
+	// and don't make a stage a Ruby runtime — `FROM debian` +
+	// `ARG RAILS_ENV=production` should not be classified as Ruby.
 	if sf != nil {
-		for key := range sf.EffectiveEnv.Values {
+		for key := range sf.EffectiveEnv.Bindings {
 			if rubyEnvSignals[key] || strings.HasPrefix(key, "BUNDLE_") {
 				return true
 			}

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -376,6 +376,12 @@ func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 			if !jemallocSymlinkCreatingCommands[ci.Name] {
 				continue
 			}
+			// `install -d /path` creates a directory at /path, not a file —
+			// LD_PRELOAD pointing at a directory does not load jemalloc, so
+			// the symlink half of the fix must still run.
+			if ci.Name == "install" && (ci.HasFlag("-d") || ci.HasFlag("--directory")) {
+				continue
+			}
 			target := lastNonFlagArg(ci.Args)
 			if target == "" {
 				continue

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -5,6 +5,9 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
 	"github.com/wharflab/tally/internal/facts"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/semantic"
@@ -123,6 +126,13 @@ func (r *JemallocInstalledButNotPreloadedRule) Check(input rules.LintInput) []ru
 			continue
 		}
 
+		// Ruby-namespaced rule: only fire on stages that look like a Ruby
+		// runtime. A non-Ruby image (Node, Python, ...) installing jemalloc
+		// for unrelated reasons shouldn't get a Rails-flavored warning.
+		if !stageLooksLikeRuby(input.Semantic.StageInfo(stageIdx), stage, sf) {
+			continue
+		}
+
 		if stageHasJemallocLoadSignal(sf) {
 			continue
 		}
@@ -130,6 +140,122 @@ func (r *JemallocInstalledButNotPreloadedRule) Check(input rules.LintInput) []ru
 		violations = append(violations, r.checkStage(input.File, sf, input.SourceMap(), meta)...)
 	}
 	return violations
+}
+
+// rubyEnvSignals are environment variable keys that strongly suggest a Ruby
+// or Rails workload is the target of the stage.
+var rubyEnvSignals = map[string]bool{
+	"RUBY_VERSION":      true,
+	"RUBY_MAJOR":        true,
+	"RUBY_YJIT_ENABLE":  true,
+	"RAILS_ENV":         true,
+	"BUNDLER_VERSION":   true,
+	"BUNDLE_PATH":       true,
+	"BUNDLE_DEPLOYMENT": true,
+	"BUNDLE_WITHOUT":    true,
+	"GEM_HOME":          true,
+}
+
+// rubyRuntimeCommandNames are executable basenames whose presence as
+// ENTRYPOINT or CMD strongly suggests a Ruby runtime.
+var rubyRuntimeCommandNames = map[string]bool{
+	"ruby":      true,
+	"rails":     true,
+	"bundle":    true,
+	"rake":      true,
+	"rackup":    true,
+	"puma":      true,
+	"unicorn":   true,
+	"thin":      true,
+	"passenger": true,
+	"falcon":    true,
+	"sidekiq":   true,
+	"iodine":    true,
+}
+
+// rubyDerivativeImages are non-official image repositories widely used as
+// Ruby/Rails runtime bases. Matched against the familiar name (no domain,
+// no tag).
+var rubyDerivativeImages = map[string]bool{
+	"jruby":                  true,
+	"truffleruby":            true,
+	"rubylang/ruby":          true,
+	"phusion/passenger-ruby": true,
+}
+
+// stageLooksLikeRuby reports whether the stage looks like a Ruby/Rails
+// runtime: an official ruby:* base, a known Ruby-runtime derivative,
+// a stage env with Ruby/Rails/Bundler signals, or a runtime command that
+// matches a Ruby app server. Stage refs (`FROM <stage>`) inherit the
+// signal from their parent via facts.StageFacts.EffectiveEnv and the
+// semantic model's resolved base image.
+func stageLooksLikeRuby(info *semantic.StageInfo, stage instructions.Stage, sf *facts.StageFacts) bool {
+	if info != nil && info.BaseImage != nil && !info.BaseImage.IsStageRef && baseImageLooksLikeRuby(info.BaseImage.Raw) {
+		return true
+	}
+	if sf != nil {
+		for key := range sf.EffectiveEnv.Values {
+			if rubyEnvSignals[key] || strings.HasPrefix(key, "BUNDLE_") {
+				return true
+			}
+		}
+	}
+	for _, name := range stageRuntimeCommandBasenames(stage) {
+		if rubyRuntimeCommandNames[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// baseImageLooksLikeRuby reports whether a base image reference points at
+// a Ruby or Rails runtime — the official ruby:* image, a familiar name
+// that mentions "ruby" or "rails", or a known derivative.
+func baseImageLooksLikeRuby(raw string) bool {
+	named, err := reference.ParseNormalizedNamed(strings.ToLower(raw))
+	if err != nil {
+		return false
+	}
+	familiar := reference.FamiliarName(named)
+	if familiar == "ruby" || rubyDerivativeImages[familiar] {
+		return true
+	}
+	return strings.Contains(familiar, "ruby") || strings.Contains(familiar, "rails")
+}
+
+// stageRuntimeCommandBasenames returns the lowercased basename of the first
+// executable in the stage's last ENTRYPOINT and CMD, in declaration order.
+// Returns an empty slice when neither ENTRYPOINT nor CMD is present.
+func stageRuntimeCommandBasenames(stage instructions.Stage) []string {
+	var lastEntrypoint *instructions.EntrypointCommand
+	var lastCmd *instructions.CmdCommand
+	for _, c := range stage.Commands {
+		switch cc := c.(type) {
+		case *instructions.EntrypointCommand:
+			lastEntrypoint = cc
+		case *instructions.CmdCommand:
+			lastCmd = cc
+		}
+	}
+	var out []string
+	if lastEntrypoint != nil && len(lastEntrypoint.CmdLine) > 0 {
+		out = append(out, commandBasename(lastEntrypoint.CmdLine[0]))
+	}
+	if lastCmd != nil && len(lastCmd.CmdLine) > 0 {
+		out = append(out, commandBasename(lastCmd.CmdLine[0]))
+	}
+	return out
+}
+
+func commandBasename(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if fields := strings.Fields(s); len(fields) > 0 {
+		s = fields[0]
+	}
+	return strings.ToLower(path.Base(s))
 }
 
 func (r *JemallocInstalledButNotPreloadedRule) checkStage(

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -2,6 +2,7 @@ package ruby
 
 import (
 	"path"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -15,6 +16,19 @@ import (
 	"github.com/wharflab/tally/internal/sourcemap"
 	"github.com/wharflab/tally/internal/stagename"
 )
+
+// jemallocSourceBasenamePattern matches the canonical jemalloc shared-object
+// filenames. Anchored on the basename (path.Base) of a source argument:
+//
+//   - libjemalloc.so       — the unversioned symlink target
+//   - libjemalloc.so.1     — legacy ABI
+//   - libjemalloc.so.2     — current ABI
+//   - libjemalloc.so.2.x.y — fully-versioned variants
+//
+// Excludes lookalikes such as `libjemalloc.so.2-backup` or
+// `libjemalloc.so.bak`: anything after `libjemalloc.so.` must be a
+// dot-separated numeric version.
+var jemallocSourceBasenamePattern = regexp.MustCompile(`^libjemalloc\.so(?:\.\d+(?:\.\d+)*)?$`)
 
 // jemallocCanonicalSymlinkPath is the path our suggested fix points
 // LD_PRELOAD at. The "stage already creates the symlink" guardrail must
@@ -904,6 +918,11 @@ func lastNonFlagArg(args []string) string {
 // shared object. Used to verify that a `cp`/`mv`/`install`/`ln` writing into
 // /usr/local/lib/libjemalloc.so is actually copying jemalloc, not an
 // unrelated `.so`.
+//
+// Matching is anchored on the source's basename rather than a substring scan
+// of the full path, so directory names that contain "libjemalloc" (for
+// example `cp /opt/libjemalloc-backups/libfoo.so /usr/local/lib/libjemalloc.so`)
+// don't fool the check into accepting an unrelated source.
 func nonTargetArgsReferenceJemalloc(args []string) bool {
 	targetIdx := -1
 	for i, arg := range slices.Backward(args) {
@@ -919,11 +938,18 @@ func nonTargetArgsReferenceJemalloc(args []string) bool {
 		if strings.HasPrefix(arg, "-") {
 			continue
 		}
-		if strings.Contains(strings.ToLower(arg), "libjemalloc") {
+		if isJemallocSharedObjectPath(arg) {
 			return true
 		}
 	}
 	return false
+}
+
+// isJemallocSharedObjectPath reports whether a source argument's basename
+// matches a canonical jemalloc shared-object filename — `libjemalloc.so`
+// optionally followed by a dot-separated numeric version.
+func isJemallocSharedObjectPath(arg string) bool {
+	return jemallocSourceBasenamePattern.MatchString(strings.ToLower(path.Base(arg)))
 }
 
 func init() {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -402,6 +402,50 @@ func stageHasJemallocLoadSignal(sf *facts.StageFacts) bool {
 	return false
 }
 
+// lastJemallocSymlinkRemovalRunEndLine returns the (1-based, multi-line-aware)
+// end line of the *last* RUN in the stage whose parsed commands include a
+// removal of the canonical /usr/local/lib/libjemalloc.so path (rm, unlink,
+// or mv away from it). Returns 0 when no such RUN exists.
+func lastJemallocSymlinkRemovalRunEndLine(sf *facts.StageFacts, sm *sourcemap.SourceMap) int {
+	if sf == nil || sm == nil {
+		return 0
+	}
+	last := 0
+	for _, rf := range sf.Runs {
+		if rf == nil || rf.Run == nil {
+			continue
+		}
+		removes := false
+		for _, ci := range rf.CommandInfos {
+			switch {
+			case jemallocSymlinkRemovingCommands[ci.Name]:
+				if commandRemovesJemallocSymlink(ci) {
+					removes = true
+				}
+			case ci.Name == "mv":
+				if commandRemovesJemallocSymlink(ci) {
+					removes = true
+				}
+			}
+			if removes {
+				break
+			}
+		}
+		if !removes {
+			continue
+		}
+		locs := rf.Run.Location()
+		if len(locs) == 0 {
+			continue
+		}
+		end := sm.ResolveEndLine(locs[len(locs)-1].End.Line)
+		if end > last {
+			last = end
+		}
+	}
+	return last
+}
+
 // lastEnvWriteEndLine returns the (1-based, multi-line-aware) end line of
 // the last ENV instruction that wrote `key` in the stage, or 0 when no such
 // binding exists. The Bindings map records the final write, so a single
@@ -594,15 +638,21 @@ func buildJemallocPreloadFix(
 	}
 
 	// Insert after the install RUN by default, but push past any later
-	// ENV writes that would neutralize the inserted LD_PRELOAD —
-	// `ENV LD_PRELOAD=""` or `ENV LD_PRELOAD=/some/other/path` later in
-	// the stage would otherwise overwrite our suggestion and the next
-	// lint run would still fire.
+	// instructions that would neutralize the fix:
+	//
+	//   - `ENV LD_PRELOAD=""` (or any non-jemalloc value) after the
+	//     install RUN would otherwise overwrite our ENV write.
+	//   - A later `rm /usr/local/lib/libjemalloc.so` (or `mv` away from
+	//     it) would otherwise delete the symlink we just created,
+	//     leaving LD_PRELOAD pointing at a missing file.
 	insertLine := endLine + 1
 	for _, key := range []string{"LD_PRELOAD", "MALLOC_CONF"} {
 		if line := lastEnvWriteEndLine(sf, key, sm); line > endLine && line+1 > insertLine {
 			insertLine = line + 1
 		}
+	}
+	if line := lastJemallocSymlinkRemovalRunEndLine(sf, sm); line > endLine && line+1 > insertLine {
+		insertLine = line + 1
 	}
 	var fixText, description string
 	if stageReferencesJemallocSymlink(sf) {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -713,8 +713,19 @@ func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 		for _, ci := range rf.CommandInfos {
 			switch {
 			case jemallocSymlinkCreatingCommands[ci.Name]:
-				if commandCreatesJemallocSymlink(ci) {
-					present = true
+				if commandTargetsCanonicalSymlinkPath(ci) {
+					// Any write to the canonical target redefines what
+					// lives there. Set present only when the source is
+					// jemalloc; clear it otherwise — e.g.
+					// `cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so`
+					// overwrites a previously-valid symlink with an
+					// unrelated `.so`, so the runtime LD_PRELOAD would
+					// load the wrong library.
+					if nonTargetArgsReferenceJemalloc(ci.Args) {
+						present = true
+					} else {
+						present = false
+					}
 				}
 				if ci.Name == "mv" && commandRemovesJemallocSymlink(ci) {
 					// `mv /usr/local/lib/libjemalloc.so DST` removes the
@@ -733,11 +744,12 @@ func stageReferencesJemallocSymlink(sf *facts.StageFacts) bool {
 	return present
 }
 
-// commandCreatesJemallocSymlink reports whether the parsed command writes
-// the canonical /usr/local/lib/libjemalloc.so file with a jemalloc source.
-func commandCreatesJemallocSymlink(ci shell.CommandInfo) bool {
-	// `install -d /path` creates a directory at /path, not a file —
-	// LD_PRELOAD pointing at a directory does not load jemalloc.
+// commandTargetsCanonicalSymlinkPath reports whether the command's
+// destination — the last non-flag arg under the standard
+// `cmd [OPTION...] SRC... DST` form — resolves to the canonical
+// /usr/local/lib/libjemalloc.so path. Skips `install -d` (which creates
+// a directory at the target, not a file).
+func commandTargetsCanonicalSymlinkPath(ci shell.CommandInfo) bool {
 	if ci.Name == "install" && (ci.HasFlag("-d") || ci.HasFlag("--directory")) {
 		return false
 	}
@@ -745,14 +757,7 @@ func commandCreatesJemallocSymlink(ci shell.CommandInfo) bool {
 	if target == "" {
 		return false
 	}
-	if path.Clean(target) != jemallocCanonicalSymlinkPath {
-		return false
-	}
-	// Source must reference a jemalloc shared object — otherwise a
-	// command like `cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so`
-	// would suppress the symlink half of the fix, leaving LD_PRELOAD
-	// pointing at a non-jemalloc library.
-	return nonTargetArgsReferenceJemalloc(ci.Args)
+	return path.Clean(target) == jemallocCanonicalSymlinkPath
 }
 
 // jemallocSymlinkRemovingCommands are command names that, when invoked

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
-	dfshell "github.com/moby/buildkit/frontend/dockerfile/shell"
 
 	"github.com/wharflab/tally/internal/facts"
 	"github.com/wharflab/tally/internal/rules"
@@ -130,7 +129,7 @@ func (r *JemallocInstalledButNotPreloadedRule) Check(input rules.LintInput) []ru
 		// Ruby-namespaced rule: only fire on stages that look like a Ruby
 		// runtime. A non-Ruby image (Node, Python, ...) installing jemalloc
 		// for unrelated reasons shouldn't get a Rails-flavored warning.
-		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf, input.MetaArgs) {
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
 			continue
 		}
 
@@ -186,7 +185,8 @@ var rubyDerivativeImages = map[string]bool{
 
 // stageLooksLikeRuby reports whether the stage looks like a Ruby/Rails
 // runtime: an official ruby:* base (including ARG-templated forms like
-// `FROM ${RUBY_IMAGE}` resolved against meta ARGs), a known Ruby-runtime
+// `FROM ${RUBY_IMAGE}` resolved against meta-ARG defaults *and* any
+// --build-arg overrides the linter received), a known Ruby-runtime
 // derivative, a stage env with Ruby/Rails/Bundler signals, or a runtime
 // command that matches a Ruby app server.
 //
@@ -200,9 +200,8 @@ func stageLooksLikeRuby(
 	stageIdx int,
 	stage instructions.Stage,
 	sf *facts.StageFacts,
-	metaArgs []instructions.ArgCommand,
 ) bool {
-	if base := sem.ExternalBase(stageIdx); base != nil && baseImageLooksLikeRuby(base.Raw, metaArgs) {
+	if base := sem.ExternalBase(stageIdx); base != nil && baseImageLooksLikeRuby(base) {
 		return true
 	}
 	// Ruby env signals must come from an actual ENV instruction. ARG values
@@ -226,18 +225,22 @@ func stageLooksLikeRuby(
 
 // baseImageLooksLikeRuby reports whether a base image reference points at
 // a Ruby or Rails runtime — the official ruby:* image, a familiar name
-// that mentions "ruby" or "rails", or a known derivative. ARG-templated
-// references like `FROM ${RUBY_IMAGE}` are resolved against meta ARGs
-// (the ones declared before the first FROM) so the classification still
-// works on Dockerfiles that parameterize the base image.
-func baseImageLooksLikeRuby(raw string, metaArgs []instructions.ArgCommand) bool {
-	if rawLooksLikeRuby(raw) {
+// that mentions "ruby" or "rails", or a known derivative.
+//
+// The Effective field on BaseImageRef carries the FROM value resolved
+// through meta-ARG defaults *and* any --build-arg overrides the linter
+// received via the invocation context, so ARG-templated bases like
+// `FROM ${RUBY_IMAGE}` classify correctly whether the value comes from
+// an in-file default or a CLI override.
+func baseImageLooksLikeRuby(base *semantic.BaseImageRef) bool {
+	if base == nil {
+		return false
+	}
+	if base.Effective != "" && rawLooksLikeRuby(base.Effective) {
 		return true
 	}
-	if expanded, ok := expandWithMetaArgs(raw, metaArgs); ok && expanded != raw {
-		return rawLooksLikeRuby(expanded)
-	}
-	return false
+	// Fallback for the unusual case where Effective wasn't populated.
+	return base.Effective == "" && rawLooksLikeRuby(base.Raw)
 }
 
 // rawLooksLikeRuby parses a base image reference and matches against the
@@ -253,32 +256,6 @@ func rawLooksLikeRuby(s string) bool {
 		return true
 	}
 	return strings.Contains(familiar, "ruby") || strings.Contains(familiar, "rails")
-}
-
-// expandWithMetaArgs resolves `${VAR}`/`$VAR` references in `raw` against
-// the default values of meta ARGs (those declared before the first FROM,
-// which are the only ARGs in scope for FROM expansion). Returns the
-// expanded string and ok=true when expansion succeeded with no unmatched
-// references.
-func expandWithMetaArgs(raw string, metaArgs []instructions.ArgCommand) (string, bool) {
-	if raw == "" || !strings.ContainsAny(raw, "$") {
-		return raw, false
-	}
-	env := make([]string, 0, len(metaArgs))
-	for _, arg := range metaArgs {
-		for _, kv := range arg.Args {
-			if kv.Value == nil {
-				continue
-			}
-			env = append(env, kv.Key+"="+*kv.Value)
-		}
-	}
-	lex := dfshell.NewLex('\\')
-	res, err := lex.ProcessWordWithMatches(raw, dfshell.EnvsFromSlice(env))
-	if err != nil || len(res.Unmatched) > 0 || res.Result == "" {
-		return raw, false
-	}
-	return res.Result, true
 }
 
 // stageRuntimeCommandBasenames returns the lowercased basename of the first

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -808,21 +808,70 @@ var jemallocSymlinkRemovingCommands = map[string]bool{
 //     value are sources, even though they appear after the target
 func commandRemovesJemallocSymlink(ci shell.CommandInfo) bool {
 	if ci.Name == "mv" {
-		sources := mvSourceArgs(ci)
-		for _, arg := range sources {
-			if path.Clean(arg) == jemallocCanonicalSymlinkPath {
+		// `mv DIR DST` (default form) and `mv -t DST DIR` (target-dir form)
+		// both move the whole subtree, so a SOURCE that is the canonical
+		// path *or any ancestor directory* of it counts as a removal.
+		return slices.ContainsFunc(mvSourceArgs(ci), isJemallocCanonicalOrAncestor)
+	}
+	if ci.Name == "rm" {
+		recursive := rmIsRecursive(ci)
+		for _, arg := range ci.Args {
+			if strings.HasPrefix(arg, "-") {
+				continue
+			}
+			cleaned := path.Clean(arg)
+			if cleaned == jemallocCanonicalSymlinkPath {
+				return true
+			}
+			// `rm DIR` without -r/-R fails on a directory; only count
+			// ancestor-path removals when recursive deletion was requested.
+			if recursive && isJemallocCanonicalOrAncestor(arg) {
 				return true
 			}
 		}
 		return false
 	}
-	// rm / unlink: any non-flag arg pointing at the canonical path removes it.
+	// unlink: single-file removal, no recursion. Exact path only.
 	for _, arg := range ci.Args {
 		if strings.HasPrefix(arg, "-") {
 			continue
 		}
 		if path.Clean(arg) == jemallocCanonicalSymlinkPath {
 			return true
+		}
+	}
+	return false
+}
+
+// isJemallocCanonicalOrAncestor reports whether p resolves to the canonical
+// libjemalloc.so path or to any ancestor directory of it. Used by recursive
+// removals (`rm -rf /usr/local/lib`) and by mv (which moves whole subtrees).
+func isJemallocCanonicalOrAncestor(p string) bool {
+	cleaned := path.Clean(p)
+	if cleaned == jemallocCanonicalSymlinkPath {
+		return true
+	}
+	if cleaned == "/" {
+		return true
+	}
+	return strings.HasPrefix(jemallocCanonicalSymlinkPath, cleaned+"/")
+}
+
+// rmIsRecursive reports whether a `rm` invocation requested recursive
+// deletion via -r, -R, --recursive, or any combined short-flag token
+// containing 'r' or 'R' (-rf, -Rf, -fr, …).
+func rmIsRecursive(ci shell.CommandInfo) bool {
+	if ci.HasFlag("-r") || ci.HasFlag("-R") || ci.HasFlag("--recursive") {
+		return true
+	}
+	for _, arg := range ci.Args {
+		if !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
+			continue
+		}
+		for _, c := range arg[1:] {
+			if c == 'r' || c == 'R' {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -398,6 +398,25 @@ func stageHasJemallocLoadSignal(sf *facts.StageFacts) bool {
 	return false
 }
 
+// lastEnvWriteEndLine returns the (1-based, multi-line-aware) end line of
+// the last ENV instruction that wrote `key` in the stage, or 0 when no such
+// binding exists. The Bindings map records the final write, so a single
+// lookup is sufficient even when multiple ENV instructions touch the key.
+func lastEnvWriteEndLine(sf *facts.StageFacts, key string, sm *sourcemap.SourceMap) int {
+	if sf == nil || sm == nil {
+		return 0
+	}
+	binding, ok := sf.EffectiveEnv.Bindings[key]
+	if !ok || binding.Command == nil {
+		return 0
+	}
+	locs := binding.Command.Location()
+	if len(locs) == 0 {
+		return 0
+	}
+	return sm.ResolveEndLine(locs[len(locs)-1].End.Line)
+}
+
 // envBoundValue returns the *resolved* value of an env key that was set by
 // an `ENV` instruction (or inherited from a parent stage's ENV). Values
 // present only in EffectiveEnv.Values via ARG promotion return "" — those
@@ -570,7 +589,17 @@ func buildJemallocPreloadFix(
 		return nil
 	}
 
+	// Insert after the install RUN by default, but push past any later
+	// ENV writes that would neutralize the inserted LD_PRELOAD —
+	// `ENV LD_PRELOAD=""` or `ENV LD_PRELOAD=/some/other/path` later in
+	// the stage would otherwise overwrite our suggestion and the next
+	// lint run would still fire.
 	insertLine := endLine + 1
+	for _, key := range []string{"LD_PRELOAD", "MALLOC_CONF"} {
+		if line := lastEnvWriteEndLine(sf, key, sm); line > endLine && line+1 > insertLine {
+			insertLine = line + 1
+		}
+	}
 	var fixText, description string
 	if stageReferencesJemallocSymlink(sf) {
 		fixText = `ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -431,11 +431,18 @@ func envValueIsAwkwardToQuote(s string) bool {
 	return strings.ContainsAny(s, "\"\\")
 }
 
-// lastJemallocSymlinkRemovalRunEndLine returns the (1-based, multi-line-aware)
-// end line of the *last* RUN in the stage whose parsed commands include a
-// removal of the canonical /usr/local/lib/libjemalloc.so path (rm, unlink,
-// or mv away from it). Returns 0 when no such RUN exists.
-func lastJemallocSymlinkRemovalRunEndLine(sf *facts.StageFacts, sm *sourcemap.SourceMap) int {
+// lastJemallocSymlinkInvalidatingRunEndLine returns the (1-based,
+// multi-line-aware) end line of the *last* RUN in the stage whose parsed
+// commands invalidate the canonical /usr/local/lib/libjemalloc.so path —
+// either by removing it (rm, unlink, mv-away) or by overwriting it with a
+// non-jemalloc source (cp/mv/install/ln targeting the canonical path with
+// a source that does not reference jemalloc). Returns 0 when no such RUN
+// exists.
+//
+// An overwrite with a *jemalloc* source is intentionally not counted: the
+// canonical path remains valid jemalloc afterwards, so there's nothing to
+// recover and pushing the fix past it would be cosmetic noise.
+func lastJemallocSymlinkInvalidatingRunEndLine(sf *facts.StageFacts, sm *sourcemap.SourceMap) int {
 	if sf == nil || sm == nil {
 		return 0
 	}
@@ -444,23 +451,26 @@ func lastJemallocSymlinkRemovalRunEndLine(sf *facts.StageFacts, sm *sourcemap.So
 		if rf == nil || rf.Run == nil {
 			continue
 		}
-		removes := false
+		invalidates := false
 		for _, ci := range rf.CommandInfos {
 			switch {
 			case jemallocSymlinkRemovingCommands[ci.Name]:
 				if commandRemovesJemallocSymlink(ci) {
-					removes = true
+					invalidates = true
 				}
-			case ci.Name == "mv":
-				if commandRemovesJemallocSymlink(ci) {
-					removes = true
+			case jemallocSymlinkCreatingCommands[ci.Name]:
+				if ci.Name == "mv" && commandRemovesJemallocSymlink(ci) {
+					invalidates = true
+				}
+				if commandTargetsCanonicalSymlinkPath(ci) && !nonTargetArgsReferenceJemalloc(ci.Args) {
+					invalidates = true
 				}
 			}
-			if removes {
+			if invalidates {
 				break
 			}
 		}
-		if !removes {
+		if !invalidates {
 			continue
 		}
 		locs := rf.Run.Location()
@@ -680,7 +690,7 @@ func buildJemallocPreloadFix(
 			insertLine = line + 1
 		}
 	}
-	if line := lastJemallocSymlinkRemovalRunEndLine(sf, sm); line > endLine && line+1 > insertLine {
+	if line := lastJemallocSymlinkInvalidatingRunEndLine(sf, sm); line > endLine && line+1 > insertLine {
 		insertLine = line + 1
 	}
 	envLine := buildJemallocLDPreloadEnvLine(sf)

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -88,8 +88,9 @@ var jemallocPackageNames = map[string]bool{
 	"libjemalloc1":    true, // Debian/Ubuntu legacy
 	"libjemalloc2":    true, // Debian/Ubuntu current
 	"libjemalloc-dev": true, // Debian/Ubuntu dev headers
-	"jemalloc":        true, // Alpine, Arch
+	"jemalloc":        true, // Alpine, Arch, RHEL/Fedora/CentOS
 	"jemalloc-dev":    true, // Alpine dev headers
+	"jemalloc-devel":  true, // RHEL/Fedora/CentOS dev headers
 }
 
 // jemallocMallocConfKnobs are the option keys that only have meaning to

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded.go
@@ -830,8 +830,7 @@ func commandRemovesJemallocSymlink(ci shell.CommandInfo) bool {
 			if strings.HasPrefix(arg, "-") {
 				continue
 			}
-			cleaned := path.Clean(arg)
-			if cleaned == jemallocCanonicalSymlinkPath {
+			if argHitsJemallocCanonicalFile(arg) {
 				return true
 			}
 			// `rm DIR` without -r/-R fails on a directory; only count
@@ -842,30 +841,62 @@ func commandRemovesJemallocSymlink(ci shell.CommandInfo) bool {
 		}
 		return false
 	}
-	// unlink: single-file removal, no recursion. Exact path only.
+	// unlink: single-file removal, no recursion.
 	for _, arg := range ci.Args {
 		if strings.HasPrefix(arg, "-") {
 			continue
 		}
-		if path.Clean(arg) == jemallocCanonicalSymlinkPath {
+		if argHitsJemallocCanonicalFile(arg) {
 			return true
 		}
 	}
 	return false
 }
 
+// argHitsJemallocCanonicalFile reports whether `arg` names the canonical
+// libjemalloc.so file — either exactly, or via a shell glob like
+// `/usr/local/lib/libjemalloc*` that matches it. Glob characters that
+// cross `/` are not handled (Go's path.Match doesn't support `**`), but
+// flat patterns within a single path segment cover the common
+// `rm -f /usr/local/lib/libjemalloc*` cleanup form.
+func argHitsJemallocCanonicalFile(arg string) bool {
+	if path.Clean(arg) == jemallocCanonicalSymlinkPath {
+		return true
+	}
+	matched, err := path.Match(arg, jemallocCanonicalSymlinkPath)
+	return err == nil && matched
+}
+
+// jemallocCanonicalAncestorDirs lists the ancestor directories of the
+// canonical symlink path. Used by isJemallocCanonicalOrAncestor for glob
+// matching like `rm -rf /usr/local/li*`.
+var jemallocCanonicalAncestorDirs = []string{
+	"/usr/local/lib",
+	"/usr/local",
+	"/usr",
+}
+
 // isJemallocCanonicalOrAncestor reports whether p resolves to the canonical
 // libjemalloc.so path or to any ancestor directory of it. Used by recursive
 // removals (`rm -rf /usr/local/lib`) and by mv (which moves whole subtrees).
+// Glob forms (e.g. `/usr/local/lib*`) match against each candidate path.
 func isJemallocCanonicalOrAncestor(p string) bool {
-	cleaned := path.Clean(p)
-	if cleaned == jemallocCanonicalSymlinkPath {
+	if argHitsJemallocCanonicalFile(p) {
 		return true
 	}
+	cleaned := path.Clean(p)
 	if cleaned == "/" {
 		return true
 	}
-	return strings.HasPrefix(jemallocCanonicalSymlinkPath, cleaned+"/")
+	if strings.HasPrefix(jemallocCanonicalSymlinkPath, cleaned+"/") {
+		return true
+	}
+	for _, ancestor := range jemallocCanonicalAncestorDirs {
+		if matched, err := path.Match(p, ancestor); err == nil && matched {
+			return true
+		}
+	}
+	return false
 }
 
 // rmIsRecursive reports whether a `rm` invocation requested recursive

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -210,6 +210,87 @@ func TestJemallocInstalledButNotPreloadedRule_AptFix(t *testing.T) {
 	if !strings.Contains(edit.NewText, "libjemalloc.so.2") || !strings.Contains(edit.NewText, "LD_PRELOAD") {
 		t.Errorf("NewText missing canonical fix elements: %q", edit.NewText)
 	}
+	// Use idempotent `ln -sf` so a re-run on already-linked layouts replaces
+	// the symlink rather than failing the build with `File exists`.
+	if !strings.Contains(edit.NewText, "ln -sf ") {
+		t.Errorf("NewText must use idempotent `ln -sf`, got %q", edit.NewText)
+	}
+}
+
+// Regression: when the stage already creates the libjemalloc.so symlink and
+// only forgot to set LD_PRELOAD, the fix must NOT add a second `ln -s`. Adding
+// it would make `--fix-unsafe` rebuilds fail with `File exists`.
+func TestJemallocInstalledButNotPreloadedRule_FixSkipsSymlinkWhenAlreadyPresent(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\n" +
+		"RUN apt-get install -y libjemalloc2 \\\n" +
+		"    && ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix when stage already symlinked but missing LD_PRELOAD")
+	}
+	if len(fix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	}
+	got := fix.Edits[0].NewText
+	if strings.Contains(got, "ln -s") {
+		t.Errorf("fix added a redundant ln -s when the stage already has one: %q", got)
+	}
+	if !strings.Contains(got, `ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"`) {
+		t.Errorf("fix must still emit the missing ENV LD_PRELOAD line: %q", got)
+	}
+}
+
+func TestStageReferencesJemallocSymlink(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "stage with ln -s libjemalloc.so",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n",
+			want: true,
+		},
+		{
+			name: "stage without symlink",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2\n",
+			want: false,
+		},
+		{
+			name: "package name libjemalloc2 alone does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 libjemalloc-dev\n",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := testutil.MakeLintInput(t, "Dockerfile", tt.content)
+			sf := input.Facts.Stage(input.FinalStageIndex())
+			if got := stageReferencesJemallocSymlink(sf); got != tt.want {
+				t.Errorf("stageReferencesJemallocSymlink = %v, want %v", got, tt.want)
+			}
+		})
+	}
+	t.Run("nil stage facts", func(t *testing.T) {
+		t.Parallel()
+		if got := stageReferencesJemallocSymlink(nil); got {
+			t.Errorf("stageReferencesJemallocSymlink(nil) = true, want false")
+		}
+	})
 }
 
 func TestJemallocInstalledButNotPreloadedRule_AptFixAfterMultiLineRun(t *testing.T) {
@@ -388,11 +469,11 @@ func TestJemallocViolationDetail_AptVsOther(t *testing.T) {
 	t.Parallel()
 
 	apt := jemallocViolationDetail("apt-get")
-	if !strings.Contains(apt, "ln -s /usr/lib/$(uname -m)") {
-		t.Errorf("apt detail missing canonical ln command: %q", apt)
+	if !strings.Contains(apt, "ln -sf /usr/lib/$(uname -m)") {
+		t.Errorf("apt detail missing canonical ln -sf command: %q", apt)
 	}
 	apk := jemallocViolationDetail("apk")
-	if strings.Contains(apk, "ln -s /usr/lib/$(uname -m)") {
-		t.Errorf("non-apt detail should not suggest a debian-multiarch ln command: %q", apk)
+	if strings.Contains(apk, "ln -sf /usr/lib/$(uname -m)") {
+		t.Errorf("non-apt detail should not suggest a debian-multiarch ln -sf command: %q", apk)
 	}
 }

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -274,6 +274,32 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 				"RUN apt-get install -y libjemalloc2 libjemalloc-dev\n",
 			want: false,
 		},
+		{
+			// Regression: a script that only echoes/finds the path must not
+			// suppress the symlink half of the fix.
+			name: "find/echo references do not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2\n" +
+				"RUN find / -name 'libjemalloc.so*' && echo 'see libjemalloc.so docs'\n",
+			want: false,
+		},
+		{
+			// Regression: a reference to libjemalloc.so.2 (the apt-shipped
+			// versioned library) is NOT the symlink target — basename is
+			// "libjemalloc.so.2", not "libjemalloc.so".
+			name: "reference to libjemalloc.so.2 only does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2\n" +
+				"RUN ls -l /usr/lib/x86_64-linux-gnu/libjemalloc.so.2\n",
+			want: false,
+		},
+		{
+			name: "cp creating libjemalloc.so counts",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && cp /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n",
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -330,19 +330,52 @@ func TestJemallocInstalledButNotPreloadedRule_NoFixForApk(t *testing.T) {
 func TestJemallocInstalledButNotPreloadedRule_ViolationLocation(t *testing.T) {
 	t.Parallel()
 
-	content := "FROM ruby:3.3-slim\nRUN apt-get install -y libjemalloc2\n"
+	const runLine = "RUN apt-get install -y libjemalloc2"
+	content := "FROM ruby:3.3-slim\n" + runLine + "\n"
 	input := testutil.MakeLintInput(t, "Dockerfile", content)
 	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d", len(violations))
 	}
 	loc := violations[0].Location
-	if loc.Start.Line != 2 {
-		t.Errorf("violation line = %d, want 2 (the install RUN)", loc.Start.Line)
+	if loc.Start.Line != 2 || loc.End.Line != 2 {
+		t.Errorf("violation line range = %d-%d, want 2-2", loc.Start.Line, loc.End.Line)
 	}
-	// The location should point to the package token, not to column 0 of RUN.
-	if loc.Start.Column == 0 {
-		t.Errorf("violation column = 0, expected non-zero (anchored on package token)")
+	// PackageArg columns on RUN line 0 are shell-relative; the rule must
+	// translate them to Dockerfile coordinates so the range covers exactly
+	// "libjemalloc2" in the Dockerfile source line.
+	wantStart := strings.Index(runLine, "libjemalloc2")
+	wantEnd := wantStart + len("libjemalloc2")
+	if loc.Start.Column != wantStart || loc.End.Column != wantEnd {
+		t.Errorf("violation columns = %d-%d, want %d-%d (covering %q)",
+			loc.Start.Column, loc.End.Column, wantStart, wantEnd, "libjemalloc2")
+	}
+}
+
+// Regression: when the package token sits on a continuation line (pkg.Line > 0),
+// the columns are already Dockerfile-relative and must NOT be offset by the
+// RUN-prefix translation. This guards against accidentally re-applying the
+// shell→dockerfile offset in the wrong branch.
+func TestJemallocInstalledButNotPreloadedRule_ViolationLocationOnContinuation(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\n" +
+		"RUN apt-get install -y \\\n" +
+		"    libjemalloc2\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	loc := violations[0].Location
+	if loc.Start.Line != 3 {
+		t.Errorf("violation line = %d, want 3 (continuation line)", loc.Start.Line)
+	}
+	wantStart := 4 // 4 spaces before libjemalloc2
+	wantEnd := wantStart + len("libjemalloc2")
+	if loc.Start.Column != wantStart || loc.End.Column != wantEnd {
+		t.Errorf("violation columns = %d-%d, want %d-%d",
+			loc.Start.Column, loc.End.Column, wantStart, wantEnd)
 	}
 }
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -369,6 +369,8 @@ func TestMallocConfHasJemallocKnob(t *testing.T) {
 		{name: "narenas only", value: "narenas:2", want: true},
 		{name: "full mastodon-style", value: "narenas:2,background_thread:true,thp:never,dirty_decay_ms:1000,muzzy_decay_ms:0", want: true},
 		{name: "thp alone", value: "thp:never", want: true},
+		{name: "uppercased knob (case-insensitive)", value: "NARENAS:2", want: true},
+		{name: "mixed case knob", value: "Background_Thread:true", want: true},
 		{name: "no jemalloc keys", value: "M_MMAP_MAX=0", want: false},
 		{name: "empty", value: "", want: false},
 	}

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -1,0 +1,396 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestJemallocInstalledButNotPreloadedRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewJemallocInstalledButNotPreloadedRule().Metadata()
+	if meta.Code != JemallocInstalledButNotPreloadedRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, JemallocInstalledButNotPreloadedRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityWarning {
+		t.Errorf("DefaultSeverity = %v, want Warning", meta.DefaultSeverity)
+	}
+	if meta.Category != "performance" {
+		t.Errorf("Category = %q, want %q", meta.Category, "performance")
+	}
+	if meta.FixPriority != jemallocFixPriority {
+		t.Errorf("FixPriority = %d, want %d", meta.FixPriority, jemallocFixPriority)
+	}
+	if !strings.HasPrefix(meta.DocURL, "https://tally.wharflab.com/rules/tally/ruby/") {
+		t.Errorf("DocURL = %q, want tally/ruby/ prefix", meta.DocURL)
+	}
+}
+
+func TestJemallocInstalledButNotPreloadedRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewJemallocInstalledButNotPreloadedRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "apt-get install libjemalloc2 without preload triggers",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get update && apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "apt-get versioned libjemalloc2 triggers",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc2=5.3.0-1
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "apt-get install libjemalloc-dev triggers",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc-dev
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "apt-get install libjemalloc1 (legacy) triggers",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc1
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "apk add jemalloc on alpine triggers",
+			Content: `FROM ruby:3.3-alpine
+RUN apk add --no-cache jemalloc
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "dnf install jemalloc on UBI triggers",
+			Content: `FROM registry.access.redhat.com/ubi9/ruby-33
+RUN dnf install -y jemalloc
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "multi-stage final stage violates only once",
+			Content: `FROM ruby:3.3-slim AS builder
+RUN apt-get install -y libjemalloc2 build-essential
+
+FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
+		// --- Guardrails: no violation ---
+		{
+			Name: "LD_PRELOAD set to canonical path suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc2 \
+    && ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so
+ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "LD_PRELOAD with raw libjemalloc.so.2 path suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc2
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "MALLOC_CONF with narenas knob suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc2
+ENV MALLOC_CONF="narenas:2,background_thread:true,thp:never"
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "MALLOC_CONF with thp knob alone suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc2
+ENV MALLOC_CONF="thp:never"
+`,
+			WantViolations: 0,
+		},
+		// --- No violation: skipped stages ---
+		{
+			Name: "non-final builder stage skipped",
+			Content: `FROM ruby:3.3-slim AS builder
+RUN apt-get install -y libjemalloc2 build-essential
+
+FROM ruby:3.3-slim
+RUN echo done
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "stage named dev skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "stage named test skipped",
+			Content: `FROM ruby:3.3-slim AS test
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 0,
+		},
+		// --- No jemalloc install, no violation ---
+		{
+			Name: "apt-get without jemalloc no violation",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y curl ca-certificates
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "npm package with jemalloc-like name does not count",
+			Content: `FROM node:20
+RUN npm install jemalloc
+`,
+			WantViolations: 0,
+		},
+		// --- Windows base skipped ---
+		{
+			Name: "windows base image skipped",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestJemallocInstalledButNotPreloadedRule_AptFix(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN apt-get install -y libjemalloc2\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix for apt variant")
+	}
+	if fix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", fix.Safety)
+	}
+	if !fix.IsPreferred {
+		t.Error("expected IsPreferred = true")
+	}
+	if fix.Priority != jemallocFixPriority {
+		t.Errorf("Priority = %d, want %d", fix.Priority, jemallocFixPriority)
+	}
+	if len(fix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	}
+	edit := fix.Edits[0]
+	// Zero-width insertion at the line after the install RUN.
+	if edit.Location.Start.Line != 3 || edit.Location.End.Line != 3 {
+		t.Errorf("edit location = %+v, want line 3", edit.Location)
+	}
+	if edit.Location.Start.Column != 0 || edit.Location.End.Column != 0 {
+		t.Errorf("edit location columns = (%d,%d), want (0,0) (zero-width insert)",
+			edit.Location.Start.Column, edit.Location.End.Column)
+	}
+	if !strings.Contains(edit.NewText, "libjemalloc.so.2") || !strings.Contains(edit.NewText, "LD_PRELOAD") {
+		t.Errorf("NewText missing canonical fix elements: %q", edit.NewText)
+	}
+}
+
+func TestJemallocInstalledButNotPreloadedRule_AptFixAfterMultiLineRun(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN apt-get update \\\n    && apt-get install -y libjemalloc2 \\\n    && rm -rf /var/lib/apt/lists/*\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix for multi-line apt RUN")
+	}
+	// The continuation goes from line 2 to line 4; insert anchor must be line 5.
+	got := fix.Edits[0].Location.Start.Line
+	if got != 5 {
+		t.Errorf("insert anchor line = %d, want 5 (after multi-line RUN)", got)
+	}
+}
+
+func TestJemallocInstalledButNotPreloadedRule_NoFixForApk(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-alpine\nRUN apk add --no-cache jemalloc\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Error("expected no SuggestedFix for apk variant (path differs from apt)")
+	}
+}
+
+func TestJemallocInstalledButNotPreloadedRule_ViolationLocation(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN apt-get install -y libjemalloc2\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	loc := violations[0].Location
+	if loc.Start.Line != 2 {
+		t.Errorf("violation line = %d, want 2 (the install RUN)", loc.Start.Line)
+	}
+	// The location should point to the package token, not to column 0 of RUN.
+	if loc.Start.Column == 0 {
+		t.Errorf("violation column = 0, expected non-zero (anchored on package token)")
+	}
+}
+
+// --- Helper-level tests for coverage ---
+
+func TestIsJemallocPackage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "libjemalloc2", want: true},
+		{name: "libjemalloc1", want: true},
+		{name: "libjemalloc-dev", want: true},
+		{name: "jemalloc", want: true},
+		{name: "jemalloc-dev", want: true},
+		{name: "libjemalloc2=5.3.0-1", want: true},
+		{name: "libjemalloc2:amd64", want: true},
+		{name: "LIBJEMALLOC2", want: true},
+		{name: "libfoo", want: false},
+		{name: "ruby", want: false},
+		{name: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isJemallocPackage(tt.name); got != tt.want {
+				t.Errorf("isJemallocPackage(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallCommandInstallsJemalloc(t *testing.T) {
+	t.Parallel()
+
+	makeIC := func(manager string, names ...string) shell.InstallCommand {
+		pkgs := make([]shell.PackageArg, 0, len(names))
+		for _, n := range names {
+			pkgs = append(pkgs, shell.PackageArg{Normalized: n})
+		}
+		return shell.InstallCommand{Manager: manager, Packages: pkgs}
+	}
+
+	tests := []struct {
+		name string
+		ic   shell.InstallCommand
+		want bool
+	}{
+		{name: "apt libjemalloc2", ic: makeIC("apt-get", "libjemalloc2"), want: true},
+		{name: "apk jemalloc", ic: makeIC("apk", "jemalloc"), want: true},
+		{name: "dnf jemalloc", ic: makeIC("dnf", "jemalloc"), want: true},
+		{name: "yum jemalloc", ic: makeIC("yum", "jemalloc"), want: true},
+		{name: "zypper jemalloc", ic: makeIC("zypper", "jemalloc"), want: true},
+		{name: "microdnf jemalloc", ic: makeIC("microdnf", "jemalloc"), want: true},
+		{name: "apt-get mixed", ic: makeIC("apt-get", "curl", "libjemalloc2"), want: true},
+		{name: "apt no jemalloc", ic: makeIC("apt-get", "curl", "git"), want: false},
+		{name: "npm jemalloc-named pkg ignored", ic: makeIC("npm", "jemalloc"), want: false},
+		{name: "pip jemalloc-named pkg ignored", ic: makeIC("pip", "jemalloc"), want: false},
+		{name: "empty", ic: shell.InstallCommand{}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := installCommandInstallsJemalloc(tt.ic); got != tt.want {
+				t.Errorf("installCommandInstallsJemalloc(%v) = %v, want %v", tt.ic.Packages, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnvContainsJemallocLDPreload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "canonical path", value: "/usr/local/lib/libjemalloc.so", want: true},
+		{name: "debian multiarch path", value: "/usr/lib/x86_64-linux-gnu/libjemalloc.so.2", want: true},
+		{name: "uppercase path", value: "/USR/LIB/libJemalloc.so", want: true},
+		{name: "non-jemalloc preload", value: "/usr/lib/libfoo.so", want: false},
+		{name: "empty", value: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := envContainsJemallocLDPreload(tt.value); got != tt.want {
+				t.Errorf("envContainsJemallocLDPreload(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMallocConfHasJemallocKnob(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "narenas only", value: "narenas:2", want: true},
+		{name: "full mastodon-style", value: "narenas:2,background_thread:true,thp:never,dirty_decay_ms:1000,muzzy_decay_ms:0", want: true},
+		{name: "thp alone", value: "thp:never", want: true},
+		{name: "no jemalloc keys", value: "M_MMAP_MAX=0", want: false},
+		{name: "empty", value: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mallocConfHasJemallocKnob(tt.value); got != tt.want {
+				t.Errorf("mallocConfHasJemallocKnob(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJemallocViolationDetail_AptVsOther(t *testing.T) {
+	t.Parallel()
+
+	apt := jemallocViolationDetail("apt-get")
+	if !strings.Contains(apt, "ln -s /usr/lib/$(uname -m)") {
+		t.Errorf("apt detail missing canonical ln command: %q", apt)
+	}
+	apk := jemallocViolationDetail("apk")
+	if strings.Contains(apk, "ln -s /usr/lib/$(uname -m)") {
+		t.Errorf("non-apt detail should not suggest a debian-multiarch ln command: %q", apk)
+	}
+}

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -737,6 +737,56 @@ func TestJemallocInstalledButNotPreloadedRule_FixInsertsAfterLaterSymlinkRemoval
 	}
 }
 
+// Regression: a later `cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so`
+// overwrites the canonical path with an unrelated .so. The fix must
+// land *after* that overwrite so the recreated symlink survives.
+func TestJemallocInstalledButNotPreloadedRule_FixInsertsAfterLaterCpOverwrite(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\n" + // L1
+		"RUN apt-get install -y libjemalloc2\n" + // L2
+		"RUN cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so\n" + // L3 — overwrites
+		"CMD [\"bin/rails\", \"server\"]\n" // L4
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if got := fix.Edits[0].Location.Start.Line; got != 4 {
+		t.Errorf("insert anchor line = %d, want 4 (after the cp overwrite at L3)", got)
+	}
+	if !strings.Contains(fix.Edits[0].NewText, "ln -sf") {
+		t.Errorf("expected ln -sf in fix text after invalidation, got %q", fix.Edits[0].NewText)
+	}
+}
+
+// A jemalloc-sourced overwrite is fine — canonical path stays valid, so
+// the fix anchor does NOT need to be pushed past it.
+func TestJemallocInstalledButNotPreloadedRule_FixDoesNotPushPastJemallocOverwrite(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\n" + // L1
+		"RUN apt-get install -y libjemalloc2\n" + // L2
+		"RUN cp /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" + // L3 — valid recreate
+		"CMD [\"bin/rails\", \"server\"]\n" // L4
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	// The L3 RUN counts as a creation (jemalloc-sourced), so present is
+	// true at the end → fix is the ENV-only branch and lands at L3 (right
+	// after the install RUN at L2). It must NOT be pushed to L4 by the
+	// invalidating-run logic.
+	if got := violations[0].SuggestedFix.Edits[0].Location.Start.Line; got != 3 {
+		t.Errorf("insert anchor line = %d, want 3 (jemalloc overwrite is not invalidating)", got)
+	}
+}
+
 func TestJemallocInstalledButNotPreloadedRule_FixInsertsAfterLaterMvAway(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -128,6 +128,25 @@ ENV MALLOC_CONF="thp:never"
 `,
 			WantViolations: 0,
 		},
+		// Regression: ARG values are build-time only and absent from the
+		// final image runtime, so an ARG-only LD_PRELOAD must NOT suppress
+		// the violation — the running process still uses glibc malloc.
+		{
+			Name: "ARG-only LD_PRELOAD does not suppress",
+			Content: `FROM ruby:3.3-slim
+ARG LD_PRELOAD=/usr/local/lib/libjemalloc.so
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ARG-only MALLOC_CONF does not suppress",
+			Content: `FROM ruby:3.3-slim
+ARG MALLOC_CONF=narenas:2,background_thread:true
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
 		// --- No violation: skipped stages ---
 		{
 			Name: "non-final builder stage skipped",

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -427,6 +427,73 @@ func TestJemallocInstalledButNotPreloadedRule_NoFixForApk(t *testing.T) {
 	}
 }
 
+// Regression: libjemalloc1 ships libjemalloc.so.1, not .so.2, so the
+// canonical fix would link to a non-existent file. The rule still fires,
+// but the auto-fix must be omitted for that legacy package.
+func TestJemallocInstalledButNotPreloadedRule_NoFixForLibjemalloc1(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN apt-get install -y libjemalloc1\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix != nil {
+		t.Errorf("expected no SuggestedFix for libjemalloc1 (.so.2 target does not exist), got fix with NewText=%q",
+			violations[0].SuggestedFix.Edits[0].NewText)
+	}
+}
+
+func TestJemallocInstalledButNotPreloadedRule_FixForLibjemallocDev(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN apt-get install -y libjemalloc-dev\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].SuggestedFix == nil {
+		t.Fatal("expected SuggestedFix for libjemalloc-dev (depends on libjemalloc2)")
+	}
+}
+
+func TestInstallCommandProvidesLibjemalloc2(t *testing.T) {
+	t.Parallel()
+
+	makeIC := func(manager string, names ...string) shell.InstallCommand {
+		pkgs := make([]shell.PackageArg, 0, len(names))
+		for _, n := range names {
+			pkgs = append(pkgs, shell.PackageArg{Normalized: n})
+		}
+		return shell.InstallCommand{Manager: manager, Packages: pkgs}
+	}
+
+	tests := []struct {
+		name string
+		ic   shell.InstallCommand
+		want bool
+	}{
+		{name: "apt-get libjemalloc2", ic: makeIC("apt-get", "libjemalloc2"), want: true},
+		{name: "apt-get libjemalloc-dev", ic: makeIC("apt-get", "libjemalloc-dev"), want: true},
+		{name: "apt-get libjemalloc2 versioned", ic: makeIC("apt-get", "libjemalloc2=5.3.0-1"), want: true},
+		{name: "apt-get mixed with libjemalloc2", ic: makeIC("apt-get", "curl", "libjemalloc2"), want: true},
+		{name: "apt-get libjemalloc1 only", ic: makeIC("apt-get", "libjemalloc1"), want: false},
+		{name: "apt-get other packages only", ic: makeIC("apt-get", "curl"), want: false},
+		{name: "apk jemalloc not apt family", ic: makeIC("apk", "jemalloc"), want: false},
+		{name: "dnf jemalloc not apt family", ic: makeIC("dnf", "jemalloc"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := installCommandProvidesLibjemalloc2(tt.ic); got != tt.want {
+				t.Errorf("installCommandProvidesLibjemalloc2(%v) = %v, want %v", tt.ic.Packages, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestJemallocInstalledButNotPreloadedRule_ViolationLocation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -176,6 +176,47 @@ RUN apt-get install -y libjemalloc2
 `,
 			WantViolations: 0,
 		},
+		// --- Non-Ruby stage is out of scope for this Ruby-namespaced rule ---
+		{
+			Name: "python image installing libjemalloc2 is not a Ruby concern",
+			Content: `FROM python:3.12-slim
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "node image installing libjemalloc2 is not a Ruby concern",
+			Content: `FROM node:20
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 0,
+		},
+		// --- Ruby signal via env var (no ruby:* base) ---
+		{
+			Name: "RAILS_ENV signals a Ruby stage even on debian base",
+			Content: `FROM debian:12-slim
+ENV RAILS_ENV=production
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
+		// --- Ruby signal via runtime command ---
+		{
+			Name: "puma CMD signals a Ruby stage on debian base",
+			Content: `FROM debian:12-slim
+RUN apt-get install -y libjemalloc2
+CMD ["puma", "-C", "config/puma.rb"]
+`,
+			WantViolations: 1,
+		},
+		// --- Ruby derivative image ---
+		{
+			Name: "phusion passenger-ruby base counts as Ruby",
+			Content: `FROM phusion/passenger-ruby33:latest
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
 	})
 }
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -642,6 +642,34 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 			want: true,
 		},
 		{
+			// Regression: a directory NAMED libjemalloc-backups must NOT
+			// fool the matcher when the basename of the source is some
+			// unrelated `.so`. Substring matching the full path used to
+			// accept this.
+			name: "libjemalloc in dirname but unrelated .so basename does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && cp /opt/libjemalloc-backups/libfoo.so /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// `libjemalloc.so.2-backup` is a lookalike, not jemalloc.
+			name: "lookalike libjemalloc.so.2-backup basename does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && cp /tmp/libjemalloc.so.2-backup /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Non-canonical paths to genuine jemalloc shared objects still
+			// count via basename matching.
+			name: "ln from non-standard path with jemalloc basename counts",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /opt/jemalloc/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n",
+			want: true,
+		},
+		{
 			// Regression: target is canonical but the source is some
 			// unrelated .so. Counting this would have LD_PRELOAD load a
 			// non-jemalloc library.

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -240,6 +240,26 @@ RUN apt-get install -y libjemalloc2
 `,
 			WantViolations: 1,
 		},
+		// Regression: an ARG-promoted RAILS_ENV is build-time only and must
+		// NOT classify a non-Ruby stage as Ruby — the rule should stay out
+		// of scope rather than warn on a debian image that just happens to
+		// declare a Rails-flavored ARG.
+		{
+			Name: "ARG-only RAILS_ENV does not classify debian as Ruby",
+			Content: `FROM debian:12-slim
+ARG RAILS_ENV=production
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ARG-only BUNDLE_PATH does not classify alpine as Ruby",
+			Content: `FROM alpine:3.20
+ARG BUNDLE_PATH=/vendor/bundle
+RUN apk add --no-cache jemalloc
+`,
+			WantViolations: 0,
+		},
 		// --- Ruby signal via runtime command ---
 		{
 			Name: "puma CMD signals a Ruby stage on debian base",

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -236,6 +236,34 @@ RUN apt-get install -y libjemalloc2
 `,
 			WantViolations: 1,
 		},
+		// --- ARG-templated FROM: must expand against meta ARGs ---
+		{
+			Name: "ARG-templated ruby image with default value resolves",
+			Content: `ARG RUBY_IMAGE=ruby:3.3-slim
+FROM ${RUBY_IMAGE}
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ARG-templated rails image resolves to non-default",
+			Content: `ARG BASE_IMAGE=ruby:3.3-slim
+FROM $BASE_IMAGE
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
+		{
+			// Without expansion the rule used to skip this stage entirely;
+			// classification must still fire on the templated-but-non-Ruby
+			// case only when the resolved name is Ruby.
+			Name: "ARG-templated non-Ruby base does not fire",
+			Content: `ARG BASE_IMAGE=python:3.12-slim
+FROM ${BASE_IMAGE}
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 0,
+		},
 	})
 }
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -772,15 +772,47 @@ func TestMallocConfHasJemallocKnob(t *testing.T) {
 	}
 }
 
-func TestJemallocViolationDetail_AptVsOther(t *testing.T) {
+func TestJemallocViolationDetail_AptLibjemalloc2(t *testing.T) {
 	t.Parallel()
 
-	apt := jemallocViolationDetail("apt-get")
-	if !strings.Contains(apt, "ln -sf /usr/lib/$(uname -m)") {
-		t.Errorf("apt detail missing canonical ln -sf command: %q", apt)
+	ic := shell.InstallCommand{
+		Manager:  "apt-get",
+		Packages: []shell.PackageArg{{Normalized: "libjemalloc2"}},
 	}
-	apk := jemallocViolationDetail("apk")
-	if strings.Contains(apk, "ln -sf /usr/lib/$(uname -m)") {
-		t.Errorf("non-apt detail should not suggest a debian-multiarch ln -sf command: %q", apk)
+	got := jemallocViolationDetail(ic)
+	if !strings.Contains(got, "ln -sf /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so") {
+		t.Errorf("apt+libjemalloc2 detail missing canonical ln -sf: %q", got)
+	}
+}
+
+// Regression: libjemalloc1 ships libjemalloc.so.1, not .so.2. The detail
+// must NOT propose the hardcoded .so.2 symlink — that would steer users
+// toward a dangling link.
+func TestJemallocViolationDetail_AptLibjemalloc1AvoidsSo2Suggestion(t *testing.T) {
+	t.Parallel()
+
+	ic := shell.InstallCommand{
+		Manager:  "apt-get",
+		Packages: []shell.PackageArg{{Normalized: "libjemalloc1"}},
+	}
+	got := jemallocViolationDetail(ic)
+	if strings.Contains(got, "libjemalloc.so.2") {
+		t.Errorf("libjemalloc1 detail must not mention .so.2 — that would propose a dangling symlink: %q", got)
+	}
+	if !strings.Contains(got, "migrate to libjemalloc2") {
+		t.Errorf("libjemalloc1 detail should recommend migrating to libjemalloc2: %q", got)
+	}
+}
+
+func TestJemallocViolationDetail_NonAptManager(t *testing.T) {
+	t.Parallel()
+
+	ic := shell.InstallCommand{
+		Manager:  "apk",
+		Packages: []shell.PackageArg{{Normalized: "jemalloc"}},
+	}
+	got := jemallocViolationDetail(ic)
+	if strings.Contains(got, "ln -sf /usr/lib/$(uname -m)") {
+		t.Errorf("non-apt detail should not suggest a debian-multiarch ln -sf command: %q", got)
 	}
 }

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -676,6 +676,55 @@ func TestJemallocInstalledButNotPreloadedRule_FixInsertsAfterLaterEnvClobber(t *
 	}
 }
 
+// Regression: a later `RUN rm /usr/local/lib/libjemalloc.so` would delete
+// the symlink we just inserted. The fix anchor must move past that
+// removal so the recreated `ln -sf` survives.
+func TestJemallocInstalledButNotPreloadedRule_FixInsertsAfterLaterSymlinkRemoval(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\n" + // L1
+		"RUN apt-get install -y libjemalloc2\n" + // L2
+		"RUN rm /usr/local/lib/libjemalloc.so\n" + // L3 — would delete our symlink
+		"CMD [\"bin/rails\", \"server\"]\n" // L4
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if got := fix.Edits[0].Location.Start.Line; got != 4 {
+		t.Errorf("insert anchor line = %d, want 4 (after the rm at L3)", got)
+	}
+	// Sanity: this branch must emit the symlink-creation step.
+	if !strings.Contains(fix.Edits[0].NewText, "ln -sf") {
+		t.Errorf("expected ln -sf in fix text, got %q", fix.Edits[0].NewText)
+	}
+}
+
+func TestJemallocInstalledButNotPreloadedRule_FixInsertsAfterLaterMvAway(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\n" + // L1
+		"RUN apt-get install -y libjemalloc2\n" + // L2
+		"RUN mv /usr/local/lib/libjemalloc.so /tmp/old.so\n" + // L3 — undoes our symlink
+		"CMD [\"bin/rails\", \"server\"]\n" // L4
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if got := fix.Edits[0].Location.Start.Line; got != 4 {
+		t.Errorf("insert anchor line = %d, want 4 (after the mv at L3)", got)
+	}
+}
+
 func TestJemallocInstalledButNotPreloadedRule_FixSkipsClobberPushWhenEnvIsBeforeInstall(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -659,6 +659,44 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 			want: true,
 		},
 		{
+			// Regression: a common cleanup `rm -f /usr/local/lib/libjemalloc*`
+			// uses a glob that matches the canonical file.
+			name: "rm -f with glob matching canonical undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm -f /usr/local/lib/libjemalloc*\n",
+			want: false,
+		},
+		{
+			// Suffix-only glob that still matches: libjemalloc.so*.
+			name: "rm with libjemalloc.so* glob undoes",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm -f /usr/local/lib/libjemalloc.so*\n",
+			want: false,
+		},
+		{
+			// Non-matching glob: rm -f /usr/local/lib/libfoo* doesn't
+			// match the canonical file.
+			name: "rm with glob not matching canonical does not undo",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm -f /usr/local/lib/libfoo*\n",
+			want: true,
+		},
+		{
+			// rm -rf with a glob that matches an ancestor directory.
+			name: "rm -rf with ancestor glob undoes",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm -rf /usr/local/li*\n",
+			want: false,
+		},
+		{
 			// Order matters: a `rm` followed by a re-creation leaves the
 			// file present at the end of the stage.
 			name: "rm followed by recreate is present",

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -609,6 +609,39 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 			want: true,
 		},
 		{
+			// Regression: a later `cp /tmp/libfoo.so` to the canonical
+			// target overwrites the earlier valid symlink with an
+			// unrelated .so. The runtime LD_PRELOAD would load the wrong
+			// library, so present must be cleared.
+			name: "later cp of unrelated .so to canonical overwrites valid symlink",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Same idea with mv: `mv /tmp/libfoo.so /usr/local/lib/libjemalloc.so`
+			// has the canonical path as DESTINATION (not source), so it's
+			// an overwrite, not a removal — but the source is non-jemalloc.
+			name: "later mv of unrelated .so to canonical overwrites valid symlink",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN mv /tmp/libfoo.so /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Sanity: an overwrite with a jemalloc source still keeps
+			// present=true (it's effectively a re-create).
+			name: "later cp of jemalloc.so.2 to canonical keeps present",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN cp /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n",
+			want: true,
+		},
+		{
 			// Regression: target is canonical but the source is some
 			// unrelated .so. Counting this would have LD_PRELOAD load a
 			// non-jemalloc library.

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -801,6 +801,79 @@ func TestJemallocInstalledButNotPreloadedRule_AptFixAfterMultiLineRun(t *testing
 	}
 }
 
+// Regression: when the stage already has a non-jemalloc LD_PRELOAD set via
+// ENV, the fix must preserve that value by prepending the jemalloc path —
+// not overwrite it. Otherwise --fix-unsafe silently drops a deliberate
+// preload chain (instrumentation, sanitizers, etc.).
+func TestJemallocInstalledButNotPreloadedRule_FixPreservesExistingLDPreload(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\n" + // L1
+		"RUN apt-get install -y libjemalloc2\n" + // L2
+		"ENV LD_PRELOAD=/opt/instrumentation/libtrace.so\n" + // L3 — non-jemalloc
+		"CMD [\"bin/rails\", \"server\"]\n" // L4
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	got := fix.Edits[0].NewText
+	want := `ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so /opt/instrumentation/libtrace.so"`
+	if !strings.Contains(got, want) {
+		t.Errorf("fix must preserve existing LD_PRELOAD by prepending jemalloc: got %q, want substring %q", got, want)
+	}
+}
+
+func TestJemallocInstalledButNotPreloadedRule_FixIgnoresUnquotableLDPreload(t *testing.T) {
+	t.Parallel()
+
+	// Awkward existing value (embedded `"`) — fall back to the canonical
+	// path alone so we don't emit a malformed ENV literal.
+	content := "FROM ruby:3.3-slim\n" +
+		"RUN apt-get install -y libjemalloc2\n" +
+		"ENV LD_PRELOAD=/opt/with\"quote.so\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	got := fix.Edits[0].NewText
+	if !strings.Contains(got, `ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"`) {
+		t.Errorf("fallback should emit canonical-only ENV: %q", got)
+	}
+	if strings.Contains(got, "with\"quote") {
+		t.Errorf("fix must not splice an awkward-to-quote value into the ENV literal: %q", got)
+	}
+}
+
+// Sanity: no existing LD_PRELOAD ENV — emit just the canonical path.
+func TestJemallocInstalledButNotPreloadedRule_FixNoExistingLDPreloadEmitsCanonical(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN apt-get install -y libjemalloc2\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	got := violations[0].SuggestedFix.Edits[0].NewText
+	want := `ENV LD_PRELOAD="/usr/local/lib/libjemalloc.so"`
+	if !strings.Contains(got, want) {
+		t.Errorf("expected canonical-only ENV: got %q want substring %q", got, want)
+	}
+	if strings.Contains(got, "/usr/local/lib/libjemalloc.so /") {
+		t.Errorf("no existing LD_PRELOAD should not produce a multi-path value: %q", got)
+	}
+}
+
 func TestJemallocInstalledButNotPreloadedRule_NoFixForApk(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -300,6 +300,45 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 				"    && cp /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n",
 			want: true,
 		},
+		{
+			// Regression: cp where libjemalloc.so is the SOURCE, not the
+			// target. The canonical file is not created here; the fix must
+			// keep emitting the ln -sf step.
+			name: "cp with libjemalloc.so as source not target",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && cp /opt/libjemalloc.so /tmp/backup.so\n",
+			want: false,
+		},
+		{
+			// Regression: mv from the canonical target REMOVES the file
+			// rather than creating it. Counting this would leave LD_PRELOAD
+			// pointing at a missing file.
+			name: "mv from canonical target removes the file",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && mv /usr/local/lib/libjemalloc.so /tmp/old.so\n",
+			want: false,
+		},
+		{
+			// Symlink TARGET written with redundant `..` segments still
+			// resolves to the canonical path under path.Clean.
+			name: "ln target with .. segments resolves to canonical",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/../lib/libjemalloc.so\n",
+			want: true,
+		},
+		{
+			// `ln -s SRC` form (no explicit target) creates the symlink in
+			// the current directory with the basename of SRC. Without a
+			// canonical target, we conservatively don't suppress the fix.
+			name: "ln without explicit target does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2\n",
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -128,6 +128,27 @@ ENV MALLOC_CONF="thp:never"
 `,
 			WantViolations: 0,
 		},
+		// Regression: ENV chaining (LD_PRELOAD=$JEMALLOC_PATH) must resolve
+		// through EffectiveEnv.Values, not the literal binding.Value, so
+		// the load signal is recognized.
+		{
+			Name: "chained ENV LD_PRELOAD via $JEMALLOC_PATH suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc2
+ENV JEMALLOC_PATH=/usr/local/lib/libjemalloc.so
+ENV LD_PRELOAD=$JEMALLOC_PATH
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "chained ENV MALLOC_CONF via $MALLOC_TUNING suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get install -y libjemalloc2
+ENV MALLOC_TUNING=narenas:2,background_thread:true,thp:never
+ENV MALLOC_CONF=$MALLOC_TUNING
+`,
+			WantViolations: 0,
+		},
 		// Regression: ARG values are build-time only and absent from the
 		// final image runtime, so an ARG-only LD_PRELOAD must NOT suppress
 		// the violation — the running process still uses glibc malloc.

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -257,6 +257,26 @@ RUN apt-get install -y libjemalloc2
 `,
 			WantViolations: 1,
 		},
+		// --- Multi-stage FROM <prev-stage>: must walk ancestry to find Ruby base ---
+		{
+			Name: "final stage FROM builder where builder is ruby:* fires",
+			Content: `FROM ruby:3.3-slim AS builder
+RUN echo build steps
+
+FROM builder
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "multi-hop FROM ancestry still resolves to ruby base",
+			Content: `FROM ruby:3.3-slim AS base
+FROM base AS deps
+FROM deps
+RUN apt-get install -y libjemalloc2
+`,
+			WantViolations: 1,
+		},
 		// --- ARG-templated FROM: must expand against meta ARGs ---
 		{
 			Name: "ARG-templated ruby image with default value resolves",

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -513,6 +513,34 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 			want: false,
 		},
 		{
+			// Regression: GNU `mv -t DIR SRC...` reverses arg order.
+			// SRC is /usr/local/lib/libjemalloc.so → still removed.
+			name: "later mv -t away from canonical path undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN mv -t /tmp /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Same as above but using long form `--target-directory`.
+			name: "mv --target-directory removes canonical source",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN mv --target-directory /tmp /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Combined `-t=DIR` form keeps the value in the same token.
+			name: "mv -t=DIR removes canonical source",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN mv -t=/tmp /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
 			// Regression: unlink also removes.
 			name: "unlink of canonical path undoes earlier ln",
 			content: "FROM ruby:3.3-slim\n" +

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -78,6 +78,13 @@ RUN dnf install -y jemalloc
 			WantViolations: 1,
 		},
 		{
+			Name: "dnf install jemalloc-devel on UBI triggers",
+			Content: `FROM registry.access.redhat.com/ubi9/ruby-33
+RUN dnf install -y jemalloc-devel
+`,
+			WantViolations: 1,
+		},
+		{
 			Name: "multi-stage final stage violates only once",
 			Content: `FROM ruby:3.3-slim AS builder
 RUN apt-get install -y libjemalloc2 build-essential
@@ -486,6 +493,7 @@ func TestIsJemallocPackage(t *testing.T) {
 		{name: "libjemalloc-dev", want: true},
 		{name: "jemalloc", want: true},
 		{name: "jemalloc-dev", want: true},
+		{name: "jemalloc-devel", want: true},
 		{name: "libjemalloc2=5.3.0-1", want: true},
 		{name: "libjemalloc2:amd64", want: true},
 		{name: "LIBJEMALLOC2", want: true},

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -339,6 +339,34 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2\n",
 			want: false,
 		},
+		{
+			// Regression: `install -d /path` creates a directory at /path,
+			// not the shared object. LD_PRELOAD pointing at a directory
+			// does not load jemalloc.
+			name: "install -d at canonical path does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && install -d /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Long-form --directory must also disqualify the install
+			// command from counting as "symlink already created".
+			name: "install --directory at canonical path does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && install --directory /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// `install` without -d copies the source file to the target,
+			// so it does materialize the canonical libjemalloc.so file.
+			name: "install copy mode at canonical target counts",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && install -m 644 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n",
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -541,6 +541,15 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 			want: false,
 		},
 		{
+			// GNU short flag with directly-attached value: `mv -tDIR SRC`.
+			name: "mv -tDIR (attached value) removes canonical source",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN mv -t/tmp /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
 			// Regression: unlink also removes.
 			name: "unlink of canonical path undoes earlier ln",
 			content: "FROM ruby:3.3-slim\n" +

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -599,6 +599,66 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 			want: false,
 		},
 		{
+			// Regression: `rm -rf /usr/local/lib` deletes the parent
+			// directory and therefore the canonical symlink. The walk
+			// must see this as a removal even though the path doesn't
+			// exactly match the canonical symlink path.
+			name: "rm -rf parent directory undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm -rf /usr/local/lib\n",
+			want: false,
+		},
+		{
+			// Same for higher ancestors: `rm -rf /usr/local` removes the
+			// canonical symlink transitively.
+			name: "rm -rf grand-ancestor undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm -rf /usr/local\n",
+			want: false,
+		},
+		{
+			// `rm /usr/local/lib` (no -r) on a directory fails — must NOT
+			// be counted as a removal.
+			name: "rm without -r on parent directory does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm /usr/local/lib\n",
+			want: true,
+		},
+		{
+			// Combined short flags `rm -Rf` count as recursive too.
+			name: "rm -Rf parent undoes via combined short flag",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm -Rf /usr/local/lib\n",
+			want: false,
+		},
+		{
+			// `mv` of an ancestor directory also deletes the canonical
+			// symlink (the source subtree is gone).
+			name: "mv parent directory away undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN mv /usr/local/lib /tmp/old-lib\n",
+			want: false,
+		},
+		{
+			// rm of an unrelated dir must not affect the symlink.
+			name: "rm -rf of unrelated path does not undo",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm -rf /var/cache/apt\n",
+			want: true,
+		},
+		{
 			// Order matters: a `rm` followed by a re-creation leaves the
 			// file present at the end of the stage.
 			name: "rm followed by recreate is present",

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -1228,6 +1228,17 @@ func TestEnvContainsJemallocLDPreload(t *testing.T) {
 		{name: "uppercase path", value: "/USR/LIB/libJemalloc.so", want: true},
 		{name: "non-jemalloc preload", value: "/usr/lib/libfoo.so", want: false},
 		{name: "empty", value: "", want: false},
+		// Regression: directory name contains "libjemalloc" but the actual
+		// preloaded basename is unrelated. The substring matcher used to
+		// false-suppress here.
+		{name: "libjemalloc in dirname only", value: "/opt/libjemalloc-backups/libfoo.so", want: false},
+		// Lookalike basename: must not match.
+		{name: "libjemalloc.so.2-backup lookalike", value: "/tmp/libjemalloc.so.2-backup", want: false},
+		// Multi-entry preload chains: jemalloc anywhere in the chain counts.
+		{name: "space-separated chain with jemalloc first", value: "/usr/local/lib/libjemalloc.so /opt/x/libtrace.so", want: true},
+		{name: "space-separated chain with jemalloc last", value: "/opt/x/libtrace.so /usr/local/lib/libjemalloc.so", want: true},
+		{name: "colon-separated chain with jemalloc", value: "/opt/x/libtrace.so:/usr/local/lib/libjemalloc.so.2", want: true},
+		{name: "chain of unrelated entries", value: "/opt/x/libtrace.so /opt/y/libfoo.so", want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -625,6 +625,60 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 	})
 }
 
+// Regression: a later `ENV LD_PRELOAD=""` (or any non-jemalloc value) after
+// the install RUN would clobber a fix inserted on the install line. The
+// inserted fix must land *after* the latest ENV write to LD_PRELOAD or
+// MALLOC_CONF so the runtime env actually carries our value.
+func TestJemallocInstalledButNotPreloadedRule_FixInsertsAfterLaterEnvClobber(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\n" + // L1
+		"RUN apt-get install -y libjemalloc2\n" + // L2
+		"ENV SOMETHING_ELSE=ok\n" + // L3
+		"ENV LD_PRELOAD=\"\"\n" + // L4 — this would clobber a fix inserted at L3
+		"CMD [\"bin/rails\", \"server\"]\n" // L5
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if len(fix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	}
+	// Insert anchor must be line 5 (after the clobbering ENV at L4),
+	// NOT line 3 (which would land before the clobber).
+	if got := fix.Edits[0].Location.Start.Line; got != 5 {
+		t.Errorf("insert anchor line = %d, want 5 (after the later ENV LD_PRELOAD clobber)", got)
+	}
+}
+
+func TestJemallocInstalledButNotPreloadedRule_FixSkipsClobberPushWhenEnvIsBeforeInstall(t *testing.T) {
+	t.Parallel()
+
+	// `ENV LD_PRELOAD=""` BEFORE the install — no need to push past it,
+	// the fix's own ENV (placed after install) will be the last writer.
+	content := "FROM ruby:3.3-slim\n" + // L1
+		"ENV LD_PRELOAD=\"\"\n" + // L2 — pre-install, irrelevant
+		"RUN apt-get install -y libjemalloc2\n" + // L3
+		"CMD [\"bin/rails\", \"server\"]\n" // L4
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewJemallocInstalledButNotPreloadedRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if got := fix.Edits[0].Location.Start.Line; got != 4 {
+		t.Errorf("insert anchor line = %d, want 4 (right after install RUN; pre-install ENV is irrelevant)", got)
+	}
+}
+
 func TestJemallocInstalledButNotPreloadedRule_AptFixAfterMultiLineRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -415,6 +415,24 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 				"    && install -m 644 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n",
 			want: true,
 		},
+		{
+			// Regression: target is canonical but the source is some
+			// unrelated .so. Counting this would have LD_PRELOAD load a
+			// non-jemalloc library.
+			name: "cp of unrelated .so to canonical path does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && cp /tmp/libfoo.so /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Regression: ln -s pointing at an unrelated source. Same risk.
+			name: "ln -s of unrelated .so to canonical path does not count",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /tmp/libfoo.so /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
+++ b/internal/rules/tally/ruby/jemalloc_installed_but_not_preloaded_test.go
@@ -484,6 +484,54 @@ func TestStageReferencesJemallocSymlink(t *testing.T) {
 			want: true,
 		},
 		{
+			// Regression: a later `rm` removes the canonical file. The
+			// symlink is not present at the end of the stage, so the
+			// fix must still emit the ln -sf step.
+			name: "later rm of canonical path undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN rm /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Regression: rm -f same path also undoes the symlink.
+			name: "later rm -f of canonical path undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so \\\n" +
+				"    && rm -f /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Regression: mv away from canonical path is also a removal.
+			name: "later mv away from canonical path undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n" +
+				"RUN mv /usr/local/lib/libjemalloc.so /tmp/old.so\n",
+			want: false,
+		},
+		{
+			// Regression: unlink also removes.
+			name: "unlink of canonical path undoes earlier ln",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so \\\n" +
+				"    && unlink /usr/local/lib/libjemalloc.so\n",
+			want: false,
+		},
+		{
+			// Order matters: a `rm` followed by a re-creation leaves the
+			// file present at the end of the stage.
+			name: "rm followed by recreate is present",
+			content: "FROM ruby:3.3-slim\n" +
+				"RUN apt-get install -y libjemalloc2 \\\n" +
+				"    && rm -f /usr/local/lib/libjemalloc.so \\\n" +
+				"    && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so\n",
+			want: true,
+		},
+		{
 			// Regression: target is canonical but the source is some
 			// unrelated .so. Counting this would have LD_PRELOAD load a
 			// non-jemalloc library.

--- a/internal/semantic/builder.go
+++ b/internal/semantic/builder.go
@@ -90,6 +90,15 @@ func (b *Builder) Build() *Model {
 		info.BaseImage = b.processBaseImage(stage, i, graph)
 		effectiveBaseName := resolveFromEvalWord(stage.BaseName, fromEval)
 		effectivePlatform := resolveFromEvalWord(stage.Platform, fromEval)
+		// Expose the resolved external base name on the BaseImageRef so
+		// rules that classify images can match against build-arg-aware
+		// values without re-implementing FROM expansion. Stage refs and
+		// scratch keep Effective == Raw.
+		if info.BaseImage != nil && !info.BaseImage.IsStageRef {
+			info.BaseImage.Effective = effectiveBaseName
+		} else if info.BaseImage != nil {
+			info.BaseImage.Effective = info.BaseImage.Raw
+		}
 
 		// Detect base image OS from name and platform heuristics.
 		info.BaseImageOS = detectBaseImageOS(effectiveBaseName, effectivePlatform)
@@ -474,9 +483,10 @@ func (b *Builder) processStageNaming(stage *instructions.Stage, index int) {
 // processBaseImage analyzes the FROM instruction's base image.
 func (b *Builder) processBaseImage(stage *instructions.Stage, stageIndex int, graph *StageGraph) *BaseImageRef {
 	ref := &BaseImageRef{
-		Raw:      stage.BaseName,
-		Platform: stage.Platform,
-		Location: stage.Location,
+		Raw:       stage.BaseName,
+		Effective: stage.BaseName, // overwritten with the ARG-resolved form below when applicable
+		Platform:  stage.Platform,
+		Location:  stage.Location,
 	}
 
 	// Check if base name references another stage

--- a/internal/semantic/semantic.go
+++ b/internal/semantic/semantic.go
@@ -95,6 +95,37 @@ func (m *Model) StageInfo(index int) *StageInfo {
 	return m.stageInfo[index]
 }
 
+// ExternalBase walks the FROM-ancestry of the stage at stageIdx through any
+// number of `FROM <stage>` stage references and returns the BaseImageRef of
+// the first non-stage-ref base — i.e. the original external image (or
+// `scratch`) that ultimately backs the stage. Returns nil when the stage
+// index is unknown, the chain is broken, or the depth bound is exceeded
+// (which should not happen on valid Dockerfiles but is cheap to guard).
+//
+// Rules that need to classify a final stage by its underlying base image
+// (e.g. detecting a Ruby/Rails runtime in a multi-stage `FROM builder`
+// pattern) should prefer this over reading `BaseImage.Raw` directly.
+func (m *Model) ExternalBase(stageIdx int) *BaseImageRef {
+	if m == nil {
+		return nil
+	}
+	const maxHops = 64
+	for range maxHops {
+		info := m.StageInfo(stageIdx)
+		if info == nil || info.BaseImage == nil {
+			return nil
+		}
+		if !info.BaseImage.IsStageRef {
+			return info.BaseImage
+		}
+		if info.BaseImage.StageIndex < 0 {
+			return nil
+		}
+		stageIdx = info.BaseImage.StageIndex
+	}
+	return nil
+}
+
 // OnbuildInstructions returns parsed ONBUILD commands for the given stage.
 // Returns nil if the index is out of bounds or the stage has no ONBUILD instructions.
 func (m *Model) OnbuildInstructions(stageIdx int) []OnbuildInstruction {

--- a/internal/semantic/semantic_test.go
+++ b/internal/semantic/semantic_test.go
@@ -215,6 +215,41 @@ func TestExternalBase(t *testing.T) {
 	}
 }
 
+// Regression: a templated FROM resolved through CLI --build-arg overrides
+// (not just in-file ARG defaults) must produce a populated Effective on
+// the BaseImageRef, so rules can classify the image accurately.
+func TestExternalBase_BuildArgOverrideExposedAsEffective(t *testing.T) {
+	t.Parallel()
+
+	content := "ARG RUBY_IMAGE=alpine:3.20\n" + // in-file default is non-Ruby
+		"FROM ${RUBY_IMAGE}\n"
+	pr := parseDockerfile(t, content)
+
+	// Without overrides: Effective resolves to the in-file default.
+	plain := NewModel(pr, nil, "Dockerfile")
+	got := plain.ExternalBase(0)
+	if got == nil {
+		t.Fatal("plain ExternalBase = nil")
+	}
+	if got.Effective != "alpine:3.20" {
+		t.Errorf("plain Effective = %q, want %q", got.Effective, "alpine:3.20")
+	}
+
+	// With a CLI --build-arg style override: Effective picks up the override.
+	overridden := NewModel(pr, map[string]string{"RUBY_IMAGE": "ruby:3.3-slim"}, "Dockerfile")
+	got = overridden.ExternalBase(0)
+	if got == nil {
+		t.Fatal("overridden ExternalBase = nil")
+	}
+	if got.Effective != "ruby:3.3-slim" {
+		t.Errorf("overridden Effective = %q, want %q", got.Effective, "ruby:3.3-slim")
+	}
+	// Raw stays as the unexpanded source token.
+	if got.Raw != "${RUBY_IMAGE}" {
+		t.Errorf("Raw = %q, want %q (unexpanded)", got.Raw, "${RUBY_IMAGE}")
+	}
+}
+
 func TestExternalBase_NilModel(t *testing.T) {
 	t.Parallel()
 	var m *Model

--- a/internal/semantic/semantic_test.go
+++ b/internal/semantic/semantic_test.go
@@ -145,6 +145,84 @@ COPY --from=builder /app /app
 	}
 }
 
+func TestExternalBase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		stageIdx int
+		wantRaw  string
+		wantNil  bool
+	}{
+		{
+			name:     "single external base resolves directly",
+			content:  "FROM ruby:3.3-slim\n",
+			stageIdx: 0,
+			wantRaw:  "ruby:3.3-slim",
+		},
+		{
+			name: "stage ref resolves to parent's external base",
+			content: "FROM ruby:3.3-slim AS builder\n" +
+				"FROM builder\n",
+			stageIdx: 1,
+			wantRaw:  "ruby:3.3-slim",
+		},
+		{
+			name: "multi-hop stage refs resolve to terminal external base",
+			content: "FROM ruby:3.3-slim AS base\n" +
+				"FROM base AS deps\n" +
+				"FROM deps\n",
+			stageIdx: 2,
+			wantRaw:  "ruby:3.3-slim",
+		},
+		{
+			name:     "scratch base is returned as the external base",
+			content:  "FROM scratch\n",
+			stageIdx: 0,
+			wantRaw:  "scratch",
+		},
+		{
+			name:     "out-of-range stage returns nil",
+			content:  "FROM ruby:3.3-slim\n",
+			stageIdx: 5,
+			wantNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pr := parseDockerfile(t, tt.content)
+			model := NewModel(pr, nil, "Dockerfile")
+			got := model.ExternalBase(tt.stageIdx)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("ExternalBase(%d) = %+v, want nil", tt.stageIdx, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("ExternalBase(%d) = nil, want %q", tt.stageIdx, tt.wantRaw)
+			}
+			if got.Raw != tt.wantRaw {
+				t.Errorf("ExternalBase(%d).Raw = %q, want %q", tt.stageIdx, got.Raw, tt.wantRaw)
+			}
+			if got.IsStageRef {
+				t.Errorf("ExternalBase(%d).IsStageRef = true, want false", tt.stageIdx)
+			}
+		})
+	}
+}
+
+func TestExternalBase_NilModel(t *testing.T) {
+	t.Parallel()
+	var m *Model
+	if got := m.ExternalBase(0); got != nil {
+		t.Errorf("nil model ExternalBase = %+v, want nil", got)
+	}
+}
+
 func TestNamedAndUnnamedStages(t *testing.T) {
 	t.Parallel()
 	content := `FROM alpine:3.18 AS first

--- a/internal/semantic/stage_info.go
+++ b/internal/semantic/stage_info.go
@@ -282,7 +282,7 @@ func (s *StageInfo) IsScratch() bool {
 func parseImageRef(raw string) (string, string, string) {
 	named, err := reference.ParseNormalizedNamed(raw)
 	if err != nil {
-		// Fallback for unparseable refs (e.g. stage names, empty strings).
+		// Fallback for unparsable refs (e.g. stage names, empty strings).
 		// Simple split: everything before first ":" or "@" is the name.
 		name := raw
 		var tag string
@@ -590,6 +590,14 @@ func (s *StageInfo) PackageManagers() []shell.PackageManager {
 type BaseImageRef struct {
 	// Raw is the original base image string (e.g., "ubuntu:22.04", "builder").
 	Raw string
+
+	// Effective is Raw with `${VAR}`/`$VAR` references expanded against the
+	// scope visible to FROM (meta-ARG defaults plus any --build-arg
+	// overrides supplied via the invocation). When expansion fails or the
+	// reference is to another stage (IsStageRef), Effective is set to Raw.
+	// Use this for image-classification heuristics that need the actual
+	// resolved image name; use Raw when you need the unexpanded source.
+	Effective string
 
 	// IsStageRef is true if this references another stage in the Dockerfile.
 	IsStageRef bool

--- a/internal/stagename/stagename.go
+++ b/internal/stagename/stagename.go
@@ -1,0 +1,48 @@
+// Package stagename contains small helpers for classifying Dockerfile stage
+// names. Multiple rules need to know whether a stage looks like a development,
+// test, debug, or CI stage so they can skip production-only checks; that
+// classification has no rule-specific knowledge and lives here so each rule
+// does not re-derive it.
+package stagename
+
+import (
+	"slices"
+	"strings"
+)
+
+// nonProductionTokens are the substring tokens that mark a stage as
+// development-, test-, debug-, or CI-only when found as a delimited part of
+// the stage name. Matching is case-insensitive and operates on tokens split
+// by '-', '_', '.', '/' or ':' so that "device" or "developer-tooling" do not
+// collide with "dev".
+var nonProductionTokens = []string{"dev", "development", "test", "testing", "ci", "debug"}
+
+// LooksLikeDev reports whether a stage name is a development, test, debug, or
+// CI stage. Production-only rules use this to skip such stages.
+//
+// The match is token-based: the name is split by '-', '_', '.', '/' or ':'
+// and each part is compared case-insensitively against the known tokens.
+// Substrings inside a single token (e.g. "device", "production-deploy") do
+// not count.
+func LooksLikeDev(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		return false
+	}
+
+	parts := strings.FieldsFunc(normalized, func(r rune) bool {
+		switch r {
+		case '-', '_', '.', '/', ':':
+			return true
+		default:
+			return false
+		}
+	})
+	if len(parts) == 0 {
+		parts = []string{normalized}
+	}
+
+	return slices.ContainsFunc(parts, func(part string) bool {
+		return slices.Contains(nonProductionTokens, part)
+	})
+}

--- a/internal/stagename/stagename_test.go
+++ b/internal/stagename/stagename_test.go
@@ -1,0 +1,35 @@
+package stagename
+
+import "testing"
+
+func TestLooksLikeDev(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		stage string
+		want  bool
+	}{
+		{name: "plain dev", stage: "dev", want: true},
+		{name: "hyphenated token", stage: "builder-dev", want: true},
+		{name: "underscored token", stage: "php_test", want: true},
+		{name: "dotted debug token", stage: "runtime.debug", want: true},
+		{name: "slashed ci token", stage: "build/ci", want: true},
+		{name: "colon-separated testing token", stage: "stage:testing", want: true},
+		{name: "uppercase Development", stage: "Development", want: true},
+		{name: "leading whitespace", stage: "   dev  ", want: true},
+		{name: "non-dev word", stage: "device", want: false},
+		{name: "production-deploy", stage: "production-deploy", want: false},
+		{name: "empty", stage: "", want: false},
+		{name: "delimiters only", stage: "---", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := LooksLikeDev(tt.stage); got != tt.want {
+				t.Errorf("LooksLikeDev(%q) = %v, want %v", tt.stage, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- First rule in a new `tally/ruby/*` namespace; rule #1 of Batch 1 in `design-docs/43-ruby-on-docker.md`.
- Flags final stages that install a jemalloc package (apt: `libjemalloc{1,2,-dev}`; apk/dnf/yum/zypper: `jemalloc{,-dev}`) without `LD_PRELOAD` containing `jemalloc` or `MALLOC_CONF` carrying jemalloc-only knobs (`narenas:`, `background_thread:`, `dirty_decay_ms:`, `muzzy_decay_ms:`, `thp:`).
- `FixSuggestion` for apt-family installs: inserts the canonical Rails-generator `RUN ln -s … && ENV LD_PRELOAD=…` pair as a single zero-width insertion on the line after the install RUN — disjoint from content edits other rules (e.g. `tally/sort-packages`) apply to the install RUN itself.
- Extracts `LooksLikeDev` into a new `internal/stagename` package; PHP rules now consume the shared helper instead of re-implementing it locally.

## Test plan
- [x] `go test ./internal/rules/tally/ruby/... ./internal/stagename/...` — combined coverage 90.2% (rule 88.9%, helper 100%).
- [x] `go test ./internal/rules/tally/php/...` — unchanged after extraction.
- [x] `go test ./internal/integration/...` — new `TestLint/ruby-jemalloc-installed-but-not-preloaded`, `TestFix/ruby-jemalloc-installed-but-not-preloaded-apt-fix`, and `TestFix/ruby-jemalloc-with-sort-packages` (combined-rule scenario) all pass.
- [x] `go test ./...` clean.
- [x] `make lint` clean.
- [x] `make cpd` clean.
- [x] Edit-overlap sanity check on combined `tally/sort-packages` + jemalloc fix run: sort-packages edits are on L2; jemalloc edit is zero-width on L3 — no overlap, both apply in one `--fix` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Ruby lint rule: warns when jemalloc is installed but not preloaded (default Warning); targets final Ruby/Rails stages and skips dev/non-final/Windows stages.

* **Documentation**
  * Docs added with scope, examples, exclusions, and apt-family auto-fix guidance; navigation updated to include a Ruby group.

* **Tests & Integration**
  * Added unit/integration tests and updated snapshots covering detection, fixes, multi-stage scenarios, and fix composition; rule count increased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->