### PR TITLE
[codex] Sort markdown output by source location

### DIFF
--- a/_docs/guides/output-formats.mdx
+++ b/_docs/guides/output-formats.mdx
@@ -222,14 +222,14 @@ See [Build invocations](/guides/build-invocations) for CLI examples and supporte
 
     | Line | Issue                                       |
     | ---- | ------------------------------------------- |
-    | 10   | ❌ Use absolute WORKDIR                     |
     | 2    | ⚠️ Stage name 'Builder' should be lowercase |
+    | 10   | ❌ Use absolute WORKDIR                     |
     ```
 
     Features:
 
     - Summary line with total issue count upfront.
-    - Violations sorted by severity (errors first).
+    - Violations sorted by invocation, file, line, column, and rule code.
     - Emoji severity indicators: ❌ error, ⚠️ warning, ℹ️ info, 💅 style.
     - No rule codes or doc URLs — optimized for token efficiency.
     - Adds a `File` column automatically when linting multiple files.

--- a/internal/integration/fixtures/fix/benchmark-real-world-fix/report_1.snap.md
+++ b/internal/integration/fixtures/fix/benchmark-real-world-fix/report_1.snap.md
@@ -9,37 +9,12 @@ note: skipped fix hadolint/DL4001 (<stdin>): resolver not registered: ai-autofix
 | Line | Issue |
 |------|-------|
 | 5 | ⚠️ remove stale wget install and config after switching to curl |
-| 117 | ⚠️ do not use apt as it is meant to be an end-user tool, use apt-get or apt-cache instead |
-| 130 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
-| 148 | ⚠️ Quote this to prevent word splitting. |
-| 150 | ⚠️ use WORKDIR to switch to a directory |
-| 152 | ⚠️ use WORKDIR to switch to a directory |
-| 152 | ⚠️ both wget and curl are installed; keep curl and remove wget |
-| 152 | ⚠️ Quote this to prevent word splitting. |
-| 232 | ⚠️ use WORKDIR to switch to a directory |
-| 232 | ⚠️ prefer ADD <git source> over git clone in RUN for more hermetic, supply-chain-friendly builds |
-| 238 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
-| 238 | ⚠️ final stage runs as root (no USER instruction (defaults to root)) and signals persistent state via RUN mkdir /var/run/sshd |
-| 252 | ⚠️ use WORKDIR to switch to a directory |
-| 269 | ⚠️ use WORKDIR to switch to a directory |
-| 269 | ⚠️ both wget and curl are installed; keep curl and remove wget |
-| 278 | ⚠️ both wget and curl are installed; keep curl and remove wget |
-| 12 | ℹ️ echo may not expand escape sequences. Use printf. |
-| 15 | ℹ️ echo may not expand escape sequences. Use printf. |
-| 45 | ℹ️ Ranges can only match single chars (mentioned due to duplicates). |
-| 64 | ℹ️ use cache mounts for package manager cache directories |
-| 130 | ℹ️ use cache mounts for package manager cache directories |
-| 150 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
-| 173 | ℹ️ echo may not expand escape sequences. Use printf. |
-| 176 | ℹ️ echo may not expand escape sequences. Use printf. |
-| 252 | ℹ️ wget without progress bar will bloat build logs; use `wget --progress=dot:giga`, `-q`, or `-nv` |
-| 252 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
-| 264 | ℹ️ use cache mounts for package manager cache directories |
-| 269 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
 | 5 | 💅 split chained commands onto separate lines |
 | 8 | 💅 expected blank line between ARG and RUN |
 | 11 | 💅 expected blank line between ARG and RUN |
 | 11 | 💅 split chained commands onto separate lines |
+| 12 | ℹ️ echo may not expand escape sequences. Use printf. |
+| 15 | ℹ️ echo may not expand escape sequences. Use printf. |
 | 29 | 💅 split chained commands onto separate lines |
 | 29 | 💅 multiple consecutive spaces (1 extra) |
 | 35 | 💅 expected blank line between ARG and RUN |
@@ -50,9 +25,11 @@ note: skipped fix hadolint/DL4001 (<stdin>): resolver not registered: ai-autofix
 | 39 | 💅 RUN instruction with chained commands can use heredoc syntax |
 | 39 | 💅 multiple consecutive spaces (1 extra) |
 | 44 | 💅 expected blank line between ARG and RUN |
+| 45 | ℹ️ Ranges can only match single chars (mentioned due to duplicates). |
 | 58 | 💅 expected blank line between COPY and RUN |
 | 61 | 💅 expected blank line between ARG and RUN |
 | 64 | 💅 expected blank line between ARG and RUN |
+| 64 | ℹ️ use cache mounts for package manager cache directories |
 | 70 | 💅 unexpected blank line between ARG and ARG |
 | 72 | 💅 unexpected blank line between ARG and ARG |
 | 75 | 💅 expected blank line between ENV and ARG |
@@ -64,8 +41,11 @@ note: skipped fix hadolint/DL4001 (<stdin>): resolver not registered: ai-autofix
 | 93 | 💅 unexpected blank line between ENV and ENV |
 | 95 | 💅 unexpected blank line between ENV and ENV |
 | 103 | 💅 unexpected blank line between ENV and ENV |
+| 117 | ⚠️ do not use apt as it is meant to be an end-user tool, use apt-get or apt-cache instead |
+| 130 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
 | 130 | 💅 expected blank line between ENV and RUN |
 | 130 | 💅 split chained commands onto separate lines |
+| 130 | ℹ️ use cache mounts for package manager cache directories |
 | 130 | 💅 packages in apt-get install are not sorted alphabetically |
 | 130 | 💅 multiple consecutive spaces (20 extra) |
 | 134 | 💅 expected blank line between ENV and RUN |
@@ -79,10 +59,16 @@ note: skipped fix hadolint/DL4001 (<stdin>): resolver not registered: ai-autofix
 | 145 | 💅 multiple consecutive spaces (172 extra) |
 | 148 | 💅 unexpected blank line between RUN and RUN |
 | 148 | 💅 multiple consecutive spaces (4 extra) |
+| 148 | ⚠️ Quote this to prevent word splitting. |
+| 150 | ⚠️ use WORKDIR to switch to a directory |
 | 150 | 💅 unexpected blank line between RUN and RUN |
 | 150 | 💅 split chained commands onto separate lines |
+| 150 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
 | 150 | 💅 multiple consecutive spaces (11 extra) |
+| 152 | ⚠️ use WORKDIR to switch to a directory |
+| 152 | ⚠️ both wget and curl are installed; keep curl and remove wget |
 | 152 | 💅 unexpected blank line between RUN and RUN |
+| 152 | ⚠️ Quote this to prevent word splitting. |
 | 157 | 💅 multiple consecutive spaces (5 extra) |
 | 161 | 💅 split chained commands onto separate lines |
 | 161 | 💅 multiple consecutive spaces (108 extra) |
@@ -91,6 +77,8 @@ note: skipped fix hadolint/DL4001 (<stdin>): resolver not registered: ai-autofix
 | 172 | 💅 expected blank line between ARG and RUN |
 | 172 | 💅 split chained commands onto separate lines |
 | 172 | 💅 RUN instruction with chained commands can use heredoc syntax |
+| 173 | ℹ️ echo may not expand escape sequences. Use printf. |
+| 176 | ℹ️ echo may not expand escape sequences. Use printf. |
 | 188 | 💅 unexpected blank line between RUN and RUN |
 | 188 | 💅 multiple consecutive spaces (49 extra) |
 | 191 | 💅 unexpected blank line between RUN and RUN |
@@ -102,27 +90,39 @@ note: skipped fix hadolint/DL4001 (<stdin>): resolver not registered: ai-autofix
 | 215 | 💅 expected blank line between COPY and RUN |
 | 223 | 💅 expected blank line between ARG and RUN |
 | 230 | 💅 unexpected blank line between RUN and RUN |
+| 232 | ⚠️ use WORKDIR to switch to a directory |
+| 232 | ⚠️ prefer ADD <git source> over git clone in RUN for more hermetic, supply-chain-friendly builds |
 | 234 | 💅 unexpected blank line between RUN and RUN |
 | 236 | 💅 unexpected blank line between RUN and RUN |
 | 236 | 💅 multiple consecutive spaces (16 extra) |
+| 238 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
 | 238 | 💅 unexpected blank line between RUN and RUN |
 | 238 | 💅 split chained commands onto separate lines |
+| 238 | ⚠️ final stage runs as root (no USER instruction (defaults to root)) and signals persistent state via RUN mkdir /var/run/sshd |
 | 238 | 💅 multiple consecutive spaces (9 extra) |
 | 240 | 💅 unexpected blank line between RUN and RUN |
 | 244 | 💅 expected blank line between ARG and RUN |
 | 246 | 💅 unexpected blank line between RUN and RUN |
 | 248 | 💅 unexpected blank line between RUN and RUN |
 | 248 | 💅 multiple consecutive spaces (8 extra) |
+| 252 | ⚠️ use WORKDIR to switch to a directory |
+| 252 | ℹ️ wget without progress bar will bloat build logs; use `wget --progress=dot:giga`, `-q`, or `-nv` |
+| 252 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
 | 252 | 💅 RUN instruction with chained commands can use heredoc syntax |
 | 263 | 💅 expected 1 blank line between WORKDIR and ARG, found 2 |
 | 264 | 💅 expected blank line between ARG and RUN |
+| 264 | ℹ️ use cache mounts for package manager cache directories |
 | 264 | 💅 multiple consecutive spaces (8 extra) |
 | 266 | 💅 unexpected blank line between RUN and RUN |
 | 266 | 💅 multiple consecutive spaces (14 extra) |
+| 269 | ⚠️ use WORKDIR to switch to a directory |
+| 269 | ⚠️ both wget and curl are installed; keep curl and remove wget |
 | 269 | 💅 expected blank line between ARG and RUN |
+| 269 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
 | 272 | 💅 expected 1 blank line between RUN and ENV, found 2 |
 | 274 | 💅 split chained commands onto separate lines |
 | 274 | 💅 multiple consecutive spaces (7 extra) |
+| 278 | ⚠️ both wget and curl are installed; keep curl and remove wget |
 | 278 | 💅 RUN instruction with chained commands can use heredoc syntax |
 | 284 | 💅 unexpected blank line between RUN and RUN |
 | 291 | 💅 expected 1 blank line between CMD and RUN, found 2 |

--- a/internal/integration/fixtures/fix/consistent-indentation/report_1.snap.md
+++ b/internal/integration/fixtures/fix/consistent-indentation/report_1.snap.md
@@ -4,17 +4,17 @@ Skipped 3 fixes
 
 | Line | Issue |
 |------|-------|
-| 11 | ⚠️ Usage of undefined variable '$LAMBDA_TASK_ROOT' |
 | - | ℹ️ `HEALTHCHECK` instruction missing |
-| 5 | ℹ️ use cache mounts for package manager cache directories |
-| 7 | ℹ️ use cache mounts for package manager cache directories |
-| 10 | ℹ️ use cache mounts for package manager cache directories |
 | 3 | 💅 expected blank line between FROM and WORKDIR |
 | 4 | 💅 expected blank line between WORKDIR and COPY |
 | 5 | 💅 expected blank line between COPY and RUN |
+| 5 | ℹ️ use cache mounts for package manager cache directories |
 | 6 | 💅 expected blank line between RUN and COPY |
 | 7 | 💅 expected blank line between COPY and RUN |
+| 7 | ℹ️ use cache mounts for package manager cache directories |
 | 10 | 💅 expected blank line between FROM and RUN |
+| 10 | ℹ️ use cache mounts for package manager cache directories |
+| 11 | ⚠️ Usage of undefined variable '$LAMBDA_TASK_ROOT' |
 | 18 | 💅 expected blank line between RUN and USER |
 | 21 | 💅 expected blank line between FROM and COPY |
 | 22 | 💅 expected blank line between COPY and EXPOSE |

--- a/internal/integration/fixtures/fix/dl3047-cross-rules/report_1.snap.md
+++ b/internal/integration/fixtures/fix/dl3047-cross-rules/report_1.snap.md
@@ -6,7 +6,7 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 
 | Line | Issue |
 |------|-------|
-| 4 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 2 | ℹ️ wget without progress bar will bloat build logs; use `wget --progress=dot:giga`, `-q`, or `-nv` |
 | 2 | 💅 consecutive RUN instructions can be combined using heredoc syntax |
+| 4 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |

--- a/internal/integration/fixtures/fix/real-world-aria/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-aria/report_1.snap.md
@@ -4,24 +4,24 @@ Skipped 4 fixes
 
 | Line | Issue |
 |------|-------|
-| 51 | ❌ file has 257 lines, maximum allowed is 50 |
-| 81 | ❌ Parsing stopped here. Mismatched keywords or invalid parentheses? |
-| 81 | ❌ Unexpected start of line. If breaking lines, \|/\|\|/&& should be at the end of the previous one. |
-| 27 | ⚠️ Quote this to prevent word splitting. |
-| 39 | ⚠️ Do not use ARG or ENV instructions for sensitive data (HF_TOKEN) |
-| 40 | ⚠️ Do not use ARG or ENV instructions for sensitive data (ARIA2_SECRET) |
-| 52 | ⚠️ Do not use ARG or ENV instructions for sensitive data (HF_TOKEN) |
-| 53 | ⚠️ Do not use ARG or ENV instructions for sensitive data (ARIA2_SECRET) |
-| 62 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
-| 283 | ⚠️ Quote this to prevent word splitting. |
-| 284 | ⚠️ Quote this to prevent word splitting. |
-| 62 | ℹ️ use cache mounts for package manager cache directories |
 | 2 | 💅 packages in apt-get install are not sorted alphabetically |
 | 8 | 💅 unexpected blank line between RUN and RUN |
 | 9 | 💅 expected blank line between RUN and WORKDIR |
 | 10 | 💅 expected blank line between WORKDIR and RUN |
+| 27 | ⚠️ Quote this to prevent word splitting. |
+| 39 | ⚠️ Do not use ARG or ENV instructions for sensitive data (HF_TOKEN) |
+| 40 | ⚠️ Do not use ARG or ENV instructions for sensitive data (ARIA2_SECRET) |
+| 51 | ❌ file has 257 lines, maximum allowed is 50 |
+| 52 | ⚠️ Do not use ARG or ENV instructions for sensitive data (HF_TOKEN) |
+| 53 | ⚠️ Do not use ARG or ENV instructions for sensitive data (ARIA2_SECRET) |
+| 62 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
 | 62 | 💅 split chained commands onto separate lines |
+| 62 | ℹ️ use cache mounts for package manager cache directories |
 | 62 | 💅 packages in apt-get install are not sorted alphabetically |
+| 81 | ❌ Parsing stopped here. Mismatched keywords or invalid parentheses? |
+| 81 | ❌ Unexpected start of line. If breaking lines, \|/\|\|/&& should be at the end of the previous one. |
 | 91 | 💅 expected blank line between ARG and ADD |
 | 93 | 💅 expected blank line between ADD and RUN |
 | 93 | 💅 consecutive RUN instructions can be combined using heredoc syntax |
+| 283 | ⚠️ Quote this to prevent word splitting. |
+| 284 | ⚠️ Quote this to prevent word splitting. |

--- a/internal/integration/fixtures/fix/real-world-boost-msvc/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-boost-msvc/report_1.snap.md
@@ -7,11 +7,11 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 
 | Line | Issue |
 |------|-------|
-| 28 | ❌ Script definition uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings should be used instead. |
-| 7 | ⚠️ Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead. |
-| 13 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
-| 24 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
 | - | ℹ️ `HEALTHCHECK` instruction missing |
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
+| 7 | ⚠️ Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead. |
 | 13 | 💅 expected blank line between COPY and RUN |
+| 13 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
+| 24 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
 | 24 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
+| 28 | ❌ Script definition uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings should be used instead. |

--- a/internal/integration/fixtures/fix/real-world-jaraco-windows/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-jaraco-windows/report_1.snap.md
@@ -6,14 +6,14 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 
 | Line | Issue |
 |------|-------|
+| - | ℹ️ `HEALTHCHECK` instruction missing |
+| - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 12 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
+| 12 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
+| 12 | 💅 consecutive RUN instructions can be combined using heredoc syntax |
 | 12 | ⚠️ 'iwr' is an alias of 'Invoke-WebRequest'. Alias can introduce possible problems and make scripts hard to maintain. Please consider changing alias to its full content. |
 | 12 | ⚠️ 'iex' is an alias of 'Invoke-Expression'. Alias can introduce possible problems and make scripts hard to maintain. Please consider changing alias to its full content. |
 | 12 | ⚠️ Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead. |
-| - | ℹ️ `HEALTHCHECK` instruction missing |
-| - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
-| 12 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
-| 12 | 💅 consecutive RUN instructions can be combined using heredoc syntax |
 | 17 | 💅 multiple consecutive spaces (1 extra) |
 | 19 | 💅 unexpected blank line between RUN and RUN |
 | 21 | 💅 unexpected blank line between RUN and RUN |

--- a/internal/integration/fixtures/fix/real-world-metalama/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-metalama/report_1.snap.md
@@ -6,18 +6,13 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 
 | Line | Issue |
 |------|-------|
-| 91 | ❌ The string is missing the terminator: ". |
-| 40 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
-| 49 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
-| 78 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
-| 83 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
-| 85 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
-| 105 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 26 | 💅 RUN instruction with chained commands can use heredoc syntax |
+| 40 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
 | 40 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
 | 40 | 💅 RUN instruction with chained commands can use heredoc syntax |
 | 49 | 💅 expected 1 blank line between ENV and RUN, found 2 |
+| 49 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
 | 49 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
 | 49 | 💅 RUN instruction with chained commands can use heredoc syntax |
 | 58 | 💅 expected 1 blank line between ENV and RUN, found 2 |
@@ -25,8 +20,13 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 | 65 | 💅 expected 1 blank line between ENV and RUN, found 2 |
 | 77 | 💅 expected 1 blank line between RUN and COPY, found 2 |
 | 78 | 💅 expected blank line between COPY and RUN |
+| 78 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
 | 78 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
 | 78 | 💅 RUN instruction with chained commands can use heredoc syntax |
+| 83 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
+| 85 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
 | 90 | 💅 expected blank line between RUN and ENV |
+| 91 | ❌ The string is missing the terminator: ". |
 | 101 | 💅 expected blank line between ARG and RUN |
+| 105 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
 | 114 | 💅 expected blank line between COPY and RUN |

--- a/internal/integration/fixtures/fix/real-world-nolus/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-nolus/report_1.snap.md
@@ -3,26 +3,6 @@ Fixed 6 issues
 
 | Line | Issue |
 |------|-------|
-| 51 | ❌ file has 261 lines, maximum allowed is 50 |
-| 64 | ⚠️ stage "rust" (index 1) is not reachable from the final stage and does not contribute to the final image |
-| 86 | ⚠️ stage "binaryen" (index 3) is not reachable from the final stage and does not contribute to the final image |
-| 115 | ⚠️ stage "cargo-audit" (index 4) is not reachable from the final stage and does not contribute to the final image |
-| 124 | ⚠️ stage "cargo-each" (index 5) is not reachable from the final stage and does not contribute to the final image |
-| 131 | ⚠️ stage "cargo-udeps" (index 6) is not reachable from the final stage and does not contribute to the final image |
-| 141 | ⚠️ stage "cosmwasm-check" (index 7) is not reachable from the final stage and does not contribute to the final image |
-| 159 | ⚠️ stage "rust-ci" (index 9) is not reachable from the final stage and does not contribute to the final image |
-| 168 | ⚠️ stage "rust-ci-multi-workspace" (index 10) is not reachable from the final stage and does not contribute to the final image |
-| 176 | ⚠️ stage "audit-dependencies" (index 11) is not reachable from the final stage and does not contribute to the final image |
-| 186 | ⚠️ stage "check-formatting" (index 12) is not reachable from the final stage and does not contribute to the final image |
-| 192 | ⚠️ stage "check-lockfiles" (index 13) is not reachable from the final stage and does not contribute to the final image |
-| 202 | ⚠️ stage "check-unused-dependencies" (index 14) is not reachable from the final stage and does not contribute to the final image |
-| 230 | ⚠️ stage "lint" (index 15) is not reachable from the final stage and does not contribute to the final image |
-| 248 | ⚠️ stage "test" (index 16) is not reachable from the final stage and does not contribute to the final image |
-| 264 | ⚠️ stage "build" (index 17) is not reachable from the final stage and does not contribute to the final image |
-| 345 | ⚠️ stage "build-platform" (index 18) is not reachable from the final stage and does not contribute to the final image |
-| 357 | ⚠️ stage "build-protocol" (index 19) is not reachable from the final stage and does not contribute to the final image |
-| 379 | ⚠️ stage "compress" (index 20) is not reachable from the final stage and does not contribute to the final image |
-| 391 | ⚠️ final stage runs as root (no USER instruction (defaults to root)) and signals persistent state via volume /bind |
 | - | ℹ️ `HEALTHCHECK` instruction missing |
 | 17 | 💅 unexpected blank line between ARG and ARG |
 | 19 | 💅 unexpected blank line between ARG and ARG |
@@ -36,16 +16,32 @@ Fixed 6 issues
 | 38 | 💅 unexpected blank line between ARG and ARG |
 | 46 | 💅 unexpected blank line between ARG and ARG |
 | 48 | 💅 unexpected blank line between ARG and ARG |
+| 51 | ❌ file has 261 lines, maximum allowed is 50 |
+| 64 | ⚠️ stage "rust" (index 1) is not reachable from the final stage and does not contribute to the final image |
+| 86 | ⚠️ stage "binaryen" (index 3) is not reachable from the final stage and does not contribute to the final image |
 | 90 | 💅 unexpected blank line between ARG and ARG |
+| 115 | ⚠️ stage "cargo-audit" (index 4) is not reachable from the final stage and does not contribute to the final image |
+| 124 | ⚠️ stage "cargo-each" (index 5) is not reachable from the final stage and does not contribute to the final image |
+| 131 | ⚠️ stage "cargo-udeps" (index 6) is not reachable from the final stage and does not contribute to the final image |
+| 141 | ⚠️ stage "cosmwasm-check" (index 7) is not reachable from the final stage and does not contribute to the final image |
+| 159 | ⚠️ stage "rust-ci" (index 9) is not reachable from the final stage and does not contribute to the final image |
+| 168 | ⚠️ stage "rust-ci-multi-workspace" (index 10) is not reachable from the final stage and does not contribute to the final image |
+| 176 | ⚠️ stage "audit-dependencies" (index 11) is not reachable from the final stage and does not contribute to the final image |
+| 186 | ⚠️ stage "check-formatting" (index 12) is not reachable from the final stage and does not contribute to the final image |
 | 188 | 💅 epilogue instructions should appear at the end of the stage in order: STOPSIGNAL, HEALTHCHECK, ENTRYPOINT, CMD |
+| 192 | ⚠️ stage "check-lockfiles" (index 13) is not reachable from the final stage and does not contribute to the final image |
 | 194 | 💅 epilogue instructions should appear at the end of the stage in order: STOPSIGNAL, HEALTHCHECK, ENTRYPOINT, CMD |
+| 202 | ⚠️ stage "check-unused-dependencies" (index 14) is not reachable from the final stage and does not contribute to the final image |
 | 210 | 💅 epilogue instructions should appear at the end of the stage in order: STOPSIGNAL, HEALTHCHECK, ENTRYPOINT, CMD |
 | 218 | 💅 unexpected blank line between COPY and COPY |
 | 224 | 💅 unexpected blank line between COPY and COPY |
+| 230 | ⚠️ stage "lint" (index 15) is not reachable from the final stage and does not contribute to the final image |
 | 234 | 💅 epilogue instructions should appear at the end of the stage in order: STOPSIGNAL, HEALTHCHECK, ENTRYPOINT, CMD |
 | 242 | 💅 unexpected blank line between COPY and COPY |
+| 248 | ⚠️ stage "test" (index 16) is not reachable from the final stage and does not contribute to the final image |
 | 250 | 💅 epilogue instructions should appear at the end of the stage in order: STOPSIGNAL, HEALTHCHECK, ENTRYPOINT, CMD |
 | 258 | 💅 unexpected blank line between COPY and COPY |
+| 264 | ⚠️ stage "build" (index 17) is not reachable from the final stage and does not contribute to the final image |
 | 276 | 💅 unexpected blank line between ONBUILD and ONBUILD |
 | 286 | 💅 unexpected blank line between ARG and ARG |
 | 288 | 💅 unexpected blank line between ARG and ARG |
@@ -59,6 +55,10 @@ Fixed 6 issues
 | 327 | 💅 unexpected blank line between COPY and COPY |
 | 333 | 💅 unexpected blank line between COPY and COPY |
 | 339 | 💅 unexpected blank line between COPY and COPY |
+| 345 | ⚠️ stage "build-platform" (index 18) is not reachable from the final stage and does not contribute to the final image |
+| 357 | ⚠️ stage "build-protocol" (index 19) is not reachable from the final stage and does not contribute to the final image |
+| 379 | ⚠️ stage "compress" (index 20) is not reachable from the final stage and does not contribute to the final image |
 | 381 | 💅 epilogue instructions should appear at the end of the stage in order: STOPSIGNAL, HEALTHCHECK, ENTRYPOINT, CMD |
+| 391 | ⚠️ final stage runs as root (no USER instruction (defaults to root)) and signals persistent state via volume /bind |
 | 393 | 💅 epilogue instructions should appear at the end of the stage in order: STOPSIGNAL, HEALTHCHECK, ENTRYPOINT, CMD |
 | 403 | 💅 unexpected blank line between COPY and COPY |

--- a/internal/integration/fixtures/fix/real-world-php-fpm-56/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-php-fpm-56/report_1.snap.md
@@ -3,13 +3,13 @@ Fixed 12 issues
 
 | Line | Issue |
 |------|-------|
-| 51 | ❌ file has 200 lines, maximum allowed is 50 |
+| - | ℹ️ `HEALTHCHECK` instruction missing |
 | 3 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
+| 3 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
+| 51 | ❌ file has 200 lines, maximum allowed is 50 |
+| 92 | ℹ️ echo may not expand escape sequences. Use printf. |
 | 122 | ⚠️ use WORKDIR to switch to a directory |
 | 122 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
 | 164 | ⚠️ set the SHELL option -o pipefail before RUN with a pipe in it |
-| - | ℹ️ `HEALTHCHECK` instruction missing |
-| 3 | ℹ️ use `ADD --unpack <url> <dest>` instead of downloading and extracting in `RUN` |
-| 92 | ℹ️ echo may not expand escape sequences. Use printf. |
 | 164 | 💅 RUN instruction with chained commands can use heredoc syntax |
 | 210 | 💅 expected blank line between EXPOSE and CMD |

--- a/internal/integration/fixtures/fix/real-world-powershell-alpine/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-powershell-alpine/report_1.snap.md
@@ -6,7 +6,7 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 
 | Line | Issue |
 |------|-------|
-| 16 | ⚠️ both wget and curl are used; standardize on wget |
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 8 | 💅 RUN instruction with chained commands can use heredoc syntax |
+| 16 | ⚠️ both wget and curl are used; standardize on wget |
 | 16 | 💅 unexpected blank line between RUN and RUN |

--- a/internal/integration/fixtures/fix/real-world-teamcity-nanoserver/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-teamcity-nanoserver/report_1.snap.md
@@ -3,15 +3,15 @@ Fixed 11 issues
 
 | Line | Issue |
 |------|-------|
-| 23 | ❌ Default value for ARG ${powershellImage} results in empty or invalid base image name |
-| 54 | ❌ Default value for ARG ${nanoserverImage} results in empty or invalid base image name |
-| 44 | ⚠️ Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead. |
-| 56 | ⚠️ Usage of undefined variable '$ProgramFiles' |
-| 76 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
-| 81 | ⚠️ COPY without --chown creates root-owned files despite USER ContainerUser |
 | - | ℹ️ `HEALTHCHECK` instruction missing |
+| 23 | ❌ Default value for ARG ${powershellImage} results in empty or invalid base image name |
 | 40 | 💅 RUN instruction with chained commands can use heredoc syntax |
+| 44 | ⚠️ Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead. |
+| 54 | ❌ Default value for ARG ${nanoserverImage} results in empty or invalid base image name |
+| 56 | ⚠️ Usage of undefined variable '$ProgramFiles' |
 | 67 | 💅 expected blank line between USER and RUN |
 | 68 | 💅 expected blank line between RUN and USER |
+| 76 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
+| 81 | ⚠️ COPY without --chown creates root-owned files despite USER ContainerUser |
 | 90 | 💅 expected blank line between USER and RUN |
 | 92 | 💅 expected blank line between RUN and USER |

--- a/internal/integration/fixtures/fix/real-world-ticketdesk/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-ticketdesk/report_1.snap.md
@@ -6,9 +6,9 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 
 | Line | Issue |
 |------|-------|
-| 4 | ⚠️ Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead. |
 | - | ℹ️ `HEALTHCHECK` instruction missing |
 | - | ℹ️ This Dockerfile appears to build artifacts in a single stage; consider a multi-stage build to reduce final image size. |
 | 4 | 💅 consecutive RUN instructions can be combined using heredoc syntax |
+| 4 | ⚠️ Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead. |
 | 17 | 💅 expected blank line between WORKDIR and COPY |
 | 22 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |

--- a/internal/reporter/markdown.go
+++ b/internal/reporter/markdown.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -29,7 +28,7 @@ func (r *MarkdownReporter) Report(violations []rules.Violation, _ map[string][]b
 		return err
 	}
 
-	sorted := SortViolationsBySeverity(violations)
+	sorted := SortViolations(violations)
 
 	// Normalize file paths for consistent output
 	for i := range sorted {
@@ -152,60 +151,6 @@ func formatLineNumber(v rules.Violation) string {
 		return strconv.Itoa(line)
 	}
 	return "-"
-}
-
-// SortViolationsBySeverity sorts violations by severity (errors first), then by file and line.
-// Uses stable sort to preserve original order for equal-priority items.
-func SortViolationsBySeverity(violations []rules.Violation) []rules.Violation {
-	sorted := make([]rules.Violation, len(violations))
-	copy(sorted, violations)
-
-	sort.SliceStable(sorted, func(i, j int) bool {
-		// shouldSwap returns true if i should come AFTER j,
-		// so we invert arguments to get "less than" semantics
-		return shouldSwap(sorted[j], sorted[i])
-	})
-
-	return sorted
-}
-
-// shouldSwap returns true if a should come after b in the sorted output.
-func shouldSwap(a, b rules.Violation) bool {
-	// Sort by severity first (error < warning < info < style)
-	aPriority := severityPriority(a.Severity)
-	bPriority := severityPriority(b.Severity)
-	if aPriority != bPriority {
-		return aPriority > bPriority
-	}
-
-	// Then by file
-	if InvocationLabel(a) != InvocationLabel(b) {
-		return InvocationLabel(a) > InvocationLabel(b)
-	}
-	if a.Location.File != b.Location.File {
-		return a.Location.File > b.Location.File
-	}
-
-	// Then by line
-	return a.Location.Start.Line > b.Location.Start.Line
-}
-
-// severityPriority returns a numeric priority for sorting (lower = more severe).
-func severityPriority(s rules.Severity) int {
-	switch s {
-	case rules.SeverityError:
-		return 0
-	case rules.SeverityWarning:
-		return 1
-	case rules.SeverityInfo:
-		return 2
-	case rules.SeverityStyle:
-		return 3
-	case rules.SeverityOff:
-		return 5 // Should never reach here
-	default:
-		return 4
-	}
 }
 
 // severityEmoji returns an emoji indicator for the severity level.

--- a/internal/reporter/markdown_test.go
+++ b/internal/reporter/markdown_test.go
@@ -51,7 +51,7 @@ func TestMarkdownReporterSingleFile(t *testing.T) {
 		t.Errorf("Expected table header, got: %s", output)
 	}
 
-	// Check error comes first (severity sorting)
+	// Check earlier line comes first even when a later issue is more severe.
 	lines := strings.Split(output, "\n")
 	errorLine := -1
 	warningLine := -1
@@ -70,8 +70,8 @@ func TestMarkdownReporterSingleFile(t *testing.T) {
 			warningLine,
 		)
 	}
-	if errorLine >= warningLine {
-		t.Error("Expected error to come before warning in output")
+	if warningLine >= errorLine {
+		t.Error("Expected lower line number to come before later error in output")
 	}
 
 	// Check emoji indicators
@@ -232,45 +232,41 @@ func TestMarkdownReporterFileLevelViolation(t *testing.T) {
 	}
 }
 
-func TestSortViolationsBySeverity(t *testing.T) {
+func TestMarkdownReporterSortsByLocation(t *testing.T) {
 	t.Parallel()
 	violations := []rules.Violation{
 		{
-			Location: rules.Location{File: "a.txt", Start: rules.Position{Line: 1}},
-			Severity: rules.SeverityStyle,
-		},
-		{
-			Location: rules.Location{File: "a.txt", Start: rules.Position{Line: 2}},
+			Location: rules.Location{File: "Dockerfile", Start: rules.Position{Line: 20}},
+			Message:  "later error",
 			Severity: rules.SeverityError,
 		},
 		{
-			Location: rules.Location{File: "a.txt", Start: rules.Position{Line: 3}},
+			Location: rules.Location{File: "Dockerfile", Start: rules.Position{Line: 5}},
+			Message:  "earlier warning",
 			Severity: rules.SeverityWarning,
 		},
 		{
-			Location: rules.Location{File: "a.txt", Start: rules.Position{Line: 4}},
+			Location: rules.Location{File: "Dockerfile", Start: rules.Position{Line: 12}},
+			Message:  "middle info",
 			Severity: rules.SeverityInfo,
 		},
 	}
 
-	sorted := SortViolationsBySeverity(violations)
-
-	// Should be: error, warning, info, style
-	expectedOrder := []rules.Severity{
-		rules.SeverityError,
-		rules.SeverityWarning,
-		rules.SeverityInfo,
-		rules.SeverityStyle,
+	var buf bytes.Buffer
+	reporter := NewMarkdownReporter(&buf)
+	if err := reporter.Report(violations, nil, ReportMetadata{}); err != nil {
+		t.Fatalf("Report() error = %v", err)
 	}
 
-	if len(sorted) != len(expectedOrder) {
-		t.Fatalf("expected %d violations, got %d", len(expectedOrder), len(sorted))
+	output := buf.String()
+	earlier := strings.Index(output, "earlier warning")
+	middle := strings.Index(output, "middle info")
+	later := strings.Index(output, "later error")
+	if earlier == -1 || middle == -1 || later == -1 {
+		t.Fatalf("expected all messages in output, got: %s", output)
 	}
-
-	for i, expected := range expectedOrder {
-		if sorted[i].Severity != expected {
-			t.Errorf("Position %d: expected %v, got %v", i, expected, sorted[i].Severity)
-		}
+	if earlier >= middle || middle >= later {
+		t.Fatalf("expected markdown output sorted by line number, got: %s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- change markdown reporting to use the shared invocation/file/line/column/rule ordering instead of severity-first ordering
- update markdown reporter tests to lock line-number ordering across severities
- update output-format docs and regenerated markdown report snapshots

## Validation

- GOEXPERIMENT=jsonv2 go test ./internal/reporter
- GOEXPERIMENT=jsonv2 UPDATE_SNAPS=true go test ./internal/integration/...
- git diff --check
- pre-push: make build, make deadcode, make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown violation reports now prioritize sorting by location (invocation, file, line, column, and rule code) instead of severity, ensuring consistent and predictable output ordering for better readability.

* **Documentation**
  * Updated markdown output format documentation to reflect the new location-based violation sorting behavior and expected report ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wharflab/tally/pull/660)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->