### PR TITLE
[codex] handle Dockerfile comments in continued RUN

### DIFF
--- a/internal/dockerfile/parser.go
+++ b/internal/dockerfile/parser.go
@@ -533,7 +533,7 @@ func bridgeRunSourceDockerfileCommentContinuations(
 func runHeredocHeaderEndLine(lines []string, files []instructions.ShellInlineFile) int {
 	headerEndIdx := -1
 	for _, file := range files {
-		openerIdx := firstRunHeredocOpenerLine(lines, file.Name)
+		openerIdx := HeredocOpenerLine(lines, file.Name)
 		if openerIdx > headerEndIdx {
 			headerEndIdx = openerIdx
 		}
@@ -541,7 +541,9 @@ func runHeredocHeaderEndLine(lines []string, files []instructions.ShellInlineFil
 	return headerEndIdx
 }
 
-func firstRunHeredocOpenerLine(lines []string, delimiter string) int {
+// HeredocOpenerLine returns the first physical line containing an opener for
+// delimiter, or -1 if the opener is not present.
+func HeredocOpenerLine(lines []string, delimiter string) int {
 	if delimiter == "" {
 		return -1
 	}

--- a/internal/dockerfile/parser.go
+++ b/internal/dockerfile/parser.go
@@ -505,9 +505,77 @@ func RunSourceScript(run *instructions.RunCommand, sm *sourcemap.SourceMap, esca
 	// that appear between "RUN " and the shell script. These are Dockerfile-level
 	// options, not shell arguments, and would confuse the shell parser.
 	lines[0] = blankRunFlags(lines[0])
-	lines = shell.BridgeDockerfileCommentContinuations(lines, escapeToken, escapeToken)
+	lines = bridgeRunSourceDockerfileCommentContinuations(run, lines, escapeToken)
 
 	return strings.Join(lines, "\n"), startLine
+}
+
+func bridgeRunSourceDockerfileCommentContinuations(
+	run *instructions.RunCommand,
+	lines []string,
+	escapeToken rune,
+) []string {
+	if len(run.Files) == 0 {
+		return shell.BridgeDockerfileCommentContinuations(lines, escapeToken, escapeToken)
+	}
+
+	openerIdx := firstRunHeredocOpenerLine(lines, run.Files[0].Name)
+	if openerIdx < 0 {
+		return lines
+	}
+
+	header := shell.BridgeDockerfileCommentContinuations(lines[:openerIdx+1], escapeToken, escapeToken)
+	out := append([]string(nil), lines...)
+	copy(out[:openerIdx+1], header)
+	return out
+}
+
+func firstRunHeredocOpenerLine(lines []string, delimiter string) int {
+	if delimiter == "" {
+		return -1
+	}
+	for i, line := range lines {
+		if hasRunHeredocOpener(line, delimiter) {
+			return i
+		}
+	}
+	return -1
+}
+
+func hasRunHeredocOpener(line, delimiter string) bool {
+	for {
+		idx := strings.Index(line, "<<")
+		if idx < 0 {
+			return false
+		}
+		rest := line[idx+len("<<"):]
+		rest = strings.TrimPrefix(rest, "-")
+		rest = strings.TrimLeft(rest, " \t")
+		token := heredocDelimiterToken(rest)
+		if token == delimiter {
+			return true
+		}
+		line = rest
+	}
+}
+
+func heredocDelimiterToken(text string) string {
+	if text == "" {
+		return ""
+	}
+	if text[0] == '\'' || text[0] == '"' {
+		quote := text[0]
+		end := strings.IndexByte(text[1:], quote)
+		if end < 0 {
+			return ""
+		}
+		return text[1 : 1+end]
+	}
+	end := 0
+	for end < len(text) && text[end] != ' ' && text[end] != '\t' {
+		end++
+	}
+	return text[:end]
 }
 
 func defaultDockerfileEscapeToken(escapeToken rune) rune {

--- a/internal/dockerfile/parser.go
+++ b/internal/dockerfile/parser.go
@@ -47,6 +47,15 @@ type ParseResult struct {
 	Warnings []LintWarning
 }
 
+// ASTEscapeToken returns the Dockerfile escape token from a BuildKit AST,
+// defaulting to backslash when the AST is absent or does not specify one.
+func ASTEscapeToken(ast *parser.Result) rune {
+	if ast != nil && ast.EscapeToken != 0 {
+		return ast.EscapeToken
+	}
+	return '\\'
+}
+
 // openDockerfile opens a Dockerfile path for reading.
 // If path is "-", returns os.Stdin and a no-op closer.
 // Otherwise, opens the file and returns it with its Close method.
@@ -441,7 +450,8 @@ func ResolveRunSource(run *instructions.RunCommand, sm *sourcemap.SourceMap) (Ru
 //
 // Returns the script and the 1-based start line number, or ("", 0) if the
 // instruction has no location or no source lines.
-func RunSourceScript(run *instructions.RunCommand, sm *sourcemap.SourceMap) (string, int) {
+func RunSourceScript(run *instructions.RunCommand, sm *sourcemap.SourceMap, escapeToken rune) (string, int) {
+	escapeToken = defaultDockerfileEscapeToken(escapeToken)
 	runLoc := run.Location()
 	if len(runLoc) == 0 {
 		return "", 0
@@ -495,9 +505,16 @@ func RunSourceScript(run *instructions.RunCommand, sm *sourcemap.SourceMap) (str
 	// that appear between "RUN " and the shell script. These are Dockerfile-level
 	// options, not shell arguments, and would confuse the shell parser.
 	lines[0] = blankRunFlags(lines[0])
-	lines = shell.BridgeDockerfileCommentContinuations(lines, '\\', '\\')
+	lines = shell.BridgeDockerfileCommentContinuations(lines, escapeToken, escapeToken)
 
 	return strings.Join(lines, "\n"), startLine
+}
+
+func defaultDockerfileEscapeToken(escapeToken rune) rune {
+	if escapeToken == 0 {
+		return '\\'
+	}
+	return escapeToken
 }
 
 // blankRunFlags replaces BuildKit RUN flags (--mount, --network, --security)

--- a/internal/dockerfile/parser.go
+++ b/internal/dockerfile/parser.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/wharflab/tally/internal/config"
+	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/sourcemap"
 )
 
@@ -494,6 +495,7 @@ func RunSourceScript(run *instructions.RunCommand, sm *sourcemap.SourceMap) (str
 	// that appear between "RUN " and the shell script. These are Dockerfile-level
 	// options, not shell arguments, and would confuse the shell parser.
 	lines[0] = blankRunFlags(lines[0])
+	lines = shell.BridgeDockerfileCommentContinuations(lines, '\\', '\\')
 
 	return strings.Join(lines, "\n"), startLine
 }

--- a/internal/dockerfile/parser.go
+++ b/internal/dockerfile/parser.go
@@ -519,15 +519,26 @@ func bridgeRunSourceDockerfileCommentContinuations(
 		return shell.BridgeDockerfileCommentContinuations(lines, escapeToken, escapeToken)
 	}
 
-	openerIdx := firstRunHeredocOpenerLine(lines, run.Files[0].Name)
-	if openerIdx < 0 {
+	headerEndIdx := runHeredocHeaderEndLine(lines, run.Files)
+	if headerEndIdx < 0 {
 		return lines
 	}
 
-	header := shell.BridgeDockerfileCommentContinuations(lines[:openerIdx+1], escapeToken, escapeToken)
+	header := shell.BridgeDockerfileCommentContinuations(lines[:headerEndIdx+1], escapeToken, escapeToken)
 	out := append([]string(nil), lines...)
-	copy(out[:openerIdx+1], header)
+	copy(out[:headerEndIdx+1], header)
 	return out
+}
+
+func runHeredocHeaderEndLine(lines []string, files []instructions.ShellInlineFile) int {
+	headerEndIdx := -1
+	for _, file := range files {
+		openerIdx := firstRunHeredocOpenerLine(lines, file.Name)
+		if openerIdx > headerEndIdx {
+			headerEndIdx = openerIdx
+		}
+	}
+	return headerEndIdx
 }
 
 func firstRunHeredocOpenerLine(lines []string, delimiter string) int {

--- a/internal/dockerfile/parser_helpers_test.go
+++ b/internal/dockerfile/parser_helpers_test.go
@@ -315,3 +315,40 @@ EOF
 		t.Fatalf("start line = %d, want 2", startLine)
 	}
 }
+
+func TestRunSourceScript_BridgesCommentsBetweenHeredocOpeners(t *testing.T) {
+	t.Parallel()
+
+	dockerfile := `FROM alpine
+RUN <<FILE1 cat > /tmp/one && \
+    # Dockerfile header comment
+    <<FILE2 cat > /tmp/two
+one \
+# shell body comment
+FILE1
+two
+FILE2
+`
+
+	result, err := Parse(strings.NewReader(dockerfile), nil)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sm := sourcemap.New(result.Source)
+
+	run, ok := result.Stages[0].Commands[0].(*instructions.RunCommand)
+	if !ok {
+		t.Fatal("expected RUN command")
+	}
+
+	got, startLine := RunSourceScript(run, sm, result.AST.EscapeToken)
+	if strings.Contains(got, "Dockerfile header comment") {
+		t.Fatalf("expected Dockerfile header comment between heredoc openers to be elided, got %q", got)
+	}
+	if !strings.Contains(got, "# shell body comment") {
+		t.Fatalf("expected heredoc body comment to be preserved, got %q", got)
+	}
+	if startLine != 2 {
+		t.Fatalf("start line = %d, want 2", startLine)
+	}
+}

--- a/internal/dockerfile/parser_helpers_test.go
+++ b/internal/dockerfile/parser_helpers_test.go
@@ -240,12 +240,42 @@ RUN echo one \
 		t.Fatal("expected RUN command")
 	}
 
-	got, startLine := RunSourceScript(run, sm)
+	got, startLine := RunSourceScript(run, sm, result.AST.EscapeToken)
 	want := "    echo one \\\n    \\\n    && echo two"
 	if got != want {
 		t.Fatalf("RunSourceScript() = %q, want %q", got, want)
 	}
 	if startLine != 2 {
 		t.Fatalf("start line = %d, want 2", startLine)
+	}
+}
+
+func TestRunSourceScript_BridgesDockerfileCommentsWithBacktickEscape(t *testing.T) {
+	t.Parallel()
+
+	dockerfile := "# escape=`\n" +
+		"FROM mcr.microsoft.com/powershell:7.4-ubuntu-22.04\n" +
+		"RUN Write-Host 'one' `\n" +
+		"    # Dockerfile comment\n" +
+		"    && Write-Host 'two'\n"
+
+	result, err := Parse(strings.NewReader(dockerfile), nil)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sm := sourcemap.New(result.Source)
+
+	run, ok := result.Stages[0].Commands[0].(*instructions.RunCommand)
+	if !ok {
+		t.Fatal("expected RUN command")
+	}
+
+	got, startLine := RunSourceScript(run, sm, result.AST.EscapeToken)
+	want := "    Write-Host 'one' `\n    `\n    && Write-Host 'two'"
+	if got != want {
+		t.Fatalf("RunSourceScript() = %q, want %q", got, want)
+	}
+	if startLine != 3 {
+		t.Fatalf("start line = %d, want 3", startLine)
 	}
 }

--- a/internal/dockerfile/parser_helpers_test.go
+++ b/internal/dockerfile/parser_helpers_test.go
@@ -219,3 +219,33 @@ EOF
 		})
 	}
 }
+
+func TestRunSourceScript_BridgesDockerfileCommentsInContinuedRun(t *testing.T) {
+	t.Parallel()
+
+	dockerfile := `FROM alpine
+RUN echo one \
+    # Dockerfile comment
+    && echo two
+`
+
+	result, err := Parse(strings.NewReader(dockerfile), nil)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sm := sourcemap.New(result.Source)
+
+	run, ok := result.Stages[0].Commands[0].(*instructions.RunCommand)
+	if !ok {
+		t.Fatal("expected RUN command")
+	}
+
+	got, startLine := RunSourceScript(run, sm)
+	want := "    echo one \\\n    \\\n    && echo two"
+	if got != want {
+		t.Fatalf("RunSourceScript() = %q, want %q", got, want)
+	}
+	if startLine != 2 {
+		t.Fatalf("start line = %d, want 2", startLine)
+	}
+}

--- a/internal/dockerfile/parser_helpers_test.go
+++ b/internal/dockerfile/parser_helpers_test.go
@@ -279,3 +279,39 @@ func TestRunSourceScript_BridgesDockerfileCommentsWithBacktickEscape(t *testing.
 		t.Fatalf("start line = %d, want 3", startLine)
 	}
 }
+
+func TestRunSourceScript_BridgesHeaderCommentsWithoutChangingHeredocBody(t *testing.T) {
+	t.Parallel()
+
+	dockerfile := `FROM alpine
+RUN --mount=type=cache,target=/root/.cache \
+    # Dockerfile header comment
+    <<EOF
+echo one \
+# shell body comment
+echo two
+EOF
+`
+
+	result, err := Parse(strings.NewReader(dockerfile), nil)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	sm := sourcemap.New(result.Source)
+
+	run, ok := result.Stages[0].Commands[0].(*instructions.RunCommand)
+	if !ok {
+		t.Fatal("expected RUN command")
+	}
+
+	got, startLine := RunSourceScript(run, sm, result.AST.EscapeToken)
+	if strings.Contains(got, "Dockerfile header comment") {
+		t.Fatalf("expected Dockerfile header comment to be elided from shell script, got %q", got)
+	}
+	if !strings.Contains(got, "# shell body comment") {
+		t.Fatalf("expected heredoc body comment to be preserved, got %q", got)
+	}
+	if startLine != 2 {
+		t.Fatalf("start line = %d, want 2", startLine)
+	}
+}

--- a/internal/facts/command_operations.go
+++ b/internal/facts/command_operations.go
@@ -124,12 +124,13 @@ func buildCommandOperationFacts(
 	run *instructions.RunCommand,
 	sm *sourcemap.SourceMap,
 	shellFacts ShellFacts,
+	escapeToken rune,
 ) []CommandOperationFact {
 	if run == nil {
 		return nil
 	}
 
-	script, startLine, hasMappedSource := commandOperationScript(run, sm)
+	script, startLine, hasMappedSource := commandOperationScript(run, sm, escapeToken)
 	if script == "" {
 		return nil
 	}
@@ -169,12 +170,12 @@ func buildCommandOperationFacts(
 	return facts
 }
 
-func commandOperationScript(run *instructions.RunCommand, sm *sourcemap.SourceMap) (string, int, bool) {
+func commandOperationScript(run *instructions.RunCommand, sm *sourcemap.SourceMap, escapeToken rune) (string, int, bool) {
 	if run == nil {
 		return "", 0, false
 	}
 	if run.PrependShell && len(run.Files) == 0 && sm != nil {
-		if script, startLine := dockerfile.RunSourceScript(run, sm); script != "" && startLine > 0 {
+		if script, startLine := dockerfile.RunSourceScript(run, sm, escapeToken); script != "" && startLine > 0 {
 			return script, startLine, true
 		}
 	}

--- a/internal/facts/facts.go
+++ b/internal/facts/facts.go
@@ -347,10 +347,7 @@ func (f *FileFacts) build() {
 
 func factsBuildContext(parseResult *dockerfile.ParseResult) (*sourcemap.SourceMap, rune) {
 	sm := sourcemap.New(parseResult.Source)
-	escapeToken := rune('\\')
-	if parseResult.AST != nil {
-		escapeToken = parseResult.AST.EscapeToken
-	}
+	escapeToken := dockerfile.ASTEscapeToken(parseResult.AST)
 	return sm, escapeToken
 }
 

--- a/internal/facts/facts.go
+++ b/internal/facts/facts.go
@@ -45,7 +45,7 @@ type StageFacts struct {
 	// base image tag. Only populated for nvidia/cuda:* base images with a
 	// parseable version tag (e.g., nvidia/cuda:12.2.0-devel-ubuntu22.04 →
 	// CUDAMajor=12, CUDAMinor=2). Zero values mean the version is unknown
-	// (non-CUDA image, ARG-based tag, digest reference, or unparseable tag).
+	// (non-CUDA image, ARG-based tag, digest reference, or unparsable tag).
 	CUDAMajor int
 	CUDAMinor int
 
@@ -112,6 +112,7 @@ type RunFacts struct {
 	CommandIndex int
 	Run          *instructions.RunCommand
 	UsesShell    bool
+	EscapeToken  rune
 
 	Workdir       string
 	CommandScript string
@@ -435,7 +436,7 @@ const nvidiaCUDAFamiliarName = "nvidia/cuda"
 // parseCUDAVersionFromBaseImage extracts CUDA major.minor version from an
 // nvidia/cuda:* base image tag using the distribution/reference library for
 // proper OCI image reference parsing. Returns (0, 0) for non-CUDA images,
-// stage references, digest-only references, or unparseable tags.
+// stage references, digest-only references, or unparsable tags.
 func parseCUDAVersionFromBaseImage(info *semantic.StageInfo) (major, minor int) {
 	if info == nil || info.BaseImage == nil || info.BaseImage.IsStageRef {
 		return 0, 0
@@ -1216,13 +1217,14 @@ func buildRunFacts(params runFactBuildParams) *RunFacts {
 		CommandIndex:          params.commandIdx,
 		Run:                   params.run,
 		UsesShell:             params.run != nil && params.run.PrependShell,
+		EscapeToken:           params.escape,
 		Workdir:               params.workdir,
 		CommandScript:         commandScript,
 		SourceScript:          sourceScript,
 		Shell:                 params.shell,
 		Env:                   envFacts,
 		CommandInfos:          commandInfos,
-		CommandOperationFacts: buildCommandOperationFacts(params.run, params.sm, params.shell),
+		CommandOperationFacts: buildCommandOperationFacts(params.run, params.sm, params.shell, params.escape),
 		InstallCommands:       shell.FindInstallPackages(sourceScript, installVariant),
 		CachePathOverrides:    deriveCachePathOverrides(envFacts.Values, params.workdir),
 		CacheDisablingEnv:     append([]EnvBinding(nil), params.cacheDisablingEnv...),

--- a/internal/highlight/extract/script.go
+++ b/internal/highlight/extract/script.go
@@ -160,7 +160,9 @@ func extractRunLikeScript(
 
 	lines := linesForSpan(sm, start, end)
 	lines = blankLeadingFlags(lines, escapeToken)
-	if !hasHeredoc {
+	if hasHeredoc {
+		lines = bridgeDockerfileCommentContinuationsBeforeHeredocBody(lines, escapeToken)
+	} else {
 		lines = shell.BridgeDockerfileCommentContinuations(lines, escapeToken, escapeToken)
 	}
 
@@ -187,6 +189,7 @@ func heredocBodyScriptMode(
 	}
 
 	blanked := blankLeadingFlags(lines, escapeToken)
+	blanked = bridgeDockerfileCommentContinuationsBeforeHeredocBody(blanked, escapeToken)
 	headerIdx, header := firstHeaderLine(blanked, escapeToken)
 	if header == "" {
 		return "", 0, false
@@ -205,6 +208,27 @@ func heredocBodyScriptMode(
 		return "", 0, false
 	}
 	return shellName, headerIdx, true
+}
+
+func bridgeDockerfileCommentContinuationsBeforeHeredocBody(lines []string, escapeToken rune) []string {
+	openerIdx := heredocOpenerLine(lines)
+	if openerIdx < 0 {
+		return lines
+	}
+
+	header := shell.BridgeDockerfileCommentContinuations(lines[:openerIdx+1], escapeToken, escapeToken)
+	out := append([]string(nil), lines...)
+	copy(out[:openerIdx+1], header)
+	return out
+}
+
+func heredocOpenerLine(lines []string) int {
+	for i, line := range lines {
+		if _, ok := heredocCommandRemainder(line); ok {
+			return i
+		}
+	}
+	return -1
 }
 
 // firstHeaderLine returns the index and content of the first line that carries

--- a/internal/highlight/extract/script.go
+++ b/internal/highlight/extract/script.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	dfparser "github.com/moby/buildkit/frontend/dockerfile/parser"
 
+	"github.com/wharflab/tally/internal/dockerfile"
 	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/sourcemap"
 )
@@ -141,6 +142,7 @@ func extractRunLikeScript(
 			linesForSpan(sm, start, end),
 			escapeToken,
 			blankLeadingFlags,
+			node.Heredocs,
 		); bodyOnly {
 			bodyStart := start + openerOffset + 1
 			bodyEnd := end - 1
@@ -161,7 +163,7 @@ func extractRunLikeScript(
 	lines := linesForSpan(sm, start, end)
 	lines = blankLeadingFlags(lines, escapeToken)
 	if hasHeredoc {
-		lines = bridgeDockerfileCommentContinuationsBeforeHeredocBody(lines, escapeToken)
+		lines = bridgeDockerfileCommentContinuationsBeforeHeredocBody(lines, escapeToken, node.Heredocs)
 	} else {
 		lines = shell.BridgeDockerfileCommentContinuations(lines, escapeToken, escapeToken)
 	}
@@ -183,13 +185,14 @@ func heredocBodyScriptMode(
 	lines []string,
 	escapeToken rune,
 	blankLeadingFlags func(lines []string, escapeToken rune) []string,
+	heredocs []dfparser.Heredoc,
 ) (string, int, bool) {
 	if len(lines) == 0 {
 		return "", 0, false
 	}
 
 	blanked := blankLeadingFlags(lines, escapeToken)
-	blanked = bridgeDockerfileCommentContinuationsBeforeHeredocBody(blanked, escapeToken)
+	blanked = bridgeDockerfileCommentContinuationsBeforeHeredocBody(blanked, escapeToken, heredocs)
 	headerIdx, header := firstHeaderLine(blanked, escapeToken)
 	if header == "" {
 		return "", 0, false
@@ -210,19 +213,38 @@ func heredocBodyScriptMode(
 	return shellName, headerIdx, true
 }
 
-func bridgeDockerfileCommentContinuationsBeforeHeredocBody(lines []string, escapeToken rune) []string {
-	openerIdx := heredocOpenerLine(lines)
-	if openerIdx < 0 {
+func bridgeDockerfileCommentContinuationsBeforeHeredocBody(
+	lines []string,
+	escapeToken rune,
+	heredocs []dfparser.Heredoc,
+) []string {
+	headerEndIdx := heredocHeaderEndLine(lines, heredocs)
+	if headerEndIdx < 0 {
 		return lines
 	}
 
-	header := shell.BridgeDockerfileCommentContinuations(lines[:openerIdx+1], escapeToken, escapeToken)
+	header := shell.BridgeDockerfileCommentContinuations(lines[:headerEndIdx+1], escapeToken, escapeToken)
 	out := append([]string(nil), lines...)
-	copy(out[:openerIdx+1], header)
+	copy(out[:headerEndIdx+1], header)
 	return out
 }
 
-func heredocOpenerLine(lines []string) int {
+func heredocHeaderEndLine(lines []string, heredocs []dfparser.Heredoc) int {
+	if len(heredocs) == 0 {
+		return firstHeredocOpenerLine(lines)
+	}
+
+	headerEndIdx := -1
+	for _, heredoc := range heredocs {
+		openerIdx := dockerfile.HeredocOpenerLine(lines, heredoc.Name)
+		if openerIdx > headerEndIdx {
+			headerEndIdx = openerIdx
+		}
+	}
+	return headerEndIdx
+}
+
+func firstHeredocOpenerLine(lines []string) int {
 	for i, line := range lines {
 		if _, ok := heredocCommandRemainder(line); ok {
 			return i

--- a/internal/highlight/extract/script.go
+++ b/internal/highlight/extract/script.go
@@ -57,6 +57,7 @@ func ExtractShellFormScript(
 
 	lines := linesForSpan(sm, start, end)
 	lines = blankLeadingKeywordOnly(lines, keyword, escapeToken)
+	lines = shell.BridgeDockerfileCommentContinuations(lines, escapeToken, escapeToken)
 
 	return Mapping{
 		Script:          strings.Join(lines, "\n"),
@@ -83,6 +84,7 @@ func ExtractHealthcheckCmdShellScript(
 	if !ok {
 		return Mapping{}, false
 	}
+	out = shell.BridgeDockerfileCommentContinuations(out, escapeToken, escapeToken)
 	return Mapping{
 		Script:          strings.Join(out, "\n"),
 		OriginStartLine: start,
@@ -133,7 +135,8 @@ func extractRunLikeScript(
 	end := sm.ResolveEndLineWithEscape(node.EndLine, escapeToken)
 	end = max(end, start)
 
-	if len(node.Heredocs) > 0 {
+	hasHeredoc := len(node.Heredocs) > 0
+	if hasHeredoc {
 		if overrideShell, openerOffset, bodyOnly := heredocBodyScriptMode(
 			linesForSpan(sm, start, end),
 			escapeToken,
@@ -157,6 +160,9 @@ func extractRunLikeScript(
 
 	lines := linesForSpan(sm, start, end)
 	lines = blankLeadingFlags(lines, escapeToken)
+	if !hasHeredoc {
+		lines = shell.BridgeDockerfileCommentContinuations(lines, escapeToken, escapeToken)
+	}
 
 	return Mapping{
 		Script:          strings.Join(lines, "\n"),

--- a/internal/highlight/extract/script_test.go
+++ b/internal/highlight/extract/script_test.go
@@ -91,6 +91,57 @@ EOF
 	}
 }
 
+func TestExtractRunScript_BridgesDockerfileCommentsInHeredocHeader(t *testing.T) {
+	t.Parallel()
+
+	mapping := extractRunScriptForTest(t, `FROM alpine
+RUN --mount=type=cache,target=/root/.cache \
+    # Dockerfile comment
+    <<EOF
+echo one
+# shell comment
+echo two
+EOF
+`)
+
+	if !mapping.IsHeredoc {
+		t.Fatalf("expected header comment to preserve heredoc body mapping, got Script=%q", mapping.Script)
+	}
+	want := "echo one\n# shell comment\necho two"
+	if mapping.Script != want {
+		t.Fatalf("expected body-only script, got %q", mapping.Script)
+	}
+	if mapping.OriginStartLine != 5 {
+		t.Fatalf("expected body origin line 5, got %d", mapping.OriginStartLine)
+	}
+}
+
+func TestExtractRunScript_BridgesHeaderCommentsForHeredocPayload(t *testing.T) {
+	t.Parallel()
+
+	mapping := extractRunScriptForTest(t, `FROM alpine
+RUN --mount=type=cache,target=/root/.cache \
+    # Dockerfile comment
+    <<EOF cat > /etc/app.conf
+# payload comment
+enable-rpc=true
+EOF
+`)
+
+	if mapping.IsHeredoc {
+		t.Fatalf("expected file payload heredoc to remain part of full shell command, got Script=%q", mapping.Script)
+	}
+	if strings.Contains(mapping.Script, "Dockerfile comment") {
+		t.Fatalf("expected Dockerfile header comment to be elided from shell script, got %q", mapping.Script)
+	}
+	if !strings.Contains(mapping.Script, "\n    \\\n") {
+		t.Fatalf("expected header comment line to be bridged as a continuation line, got %q", mapping.Script)
+	}
+	if !strings.Contains(mapping.Script, "# payload comment") {
+		t.Fatalf("expected heredoc payload comment to be preserved, got %q", mapping.Script)
+	}
+}
+
 func TestExtractRunScript_ExplicitShellUsesBodyWithOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/highlight/extract/script_test.go
+++ b/internal/highlight/extract/script_test.go
@@ -54,6 +54,43 @@ EOF
 	}
 }
 
+func TestExtractRunScript_BridgesDockerfileCommentsInContinuedRun(t *testing.T) {
+	t.Parallel()
+
+	mapping := extractRunScriptForTest(t, `FROM alpine
+RUN echo one \
+    # Dockerfile comment
+    && echo two
+`)
+
+	want := "    echo one \\\n    \\\n    && echo two"
+	if mapping.Script != want {
+		t.Fatalf("script = %q, want %q", mapping.Script, want)
+	}
+	if strings.Contains(mapping.Script, "Dockerfile comment") {
+		t.Fatalf("expected Dockerfile comment to be elided from shell script, got %q", mapping.Script)
+	}
+	if mapping.OriginStartLine != 2 {
+		t.Fatalf("expected origin line 2, got %d", mapping.OriginStartLine)
+	}
+}
+
+func TestExtractRunScript_KeepsHeredocBodyComments(t *testing.T) {
+	t.Parallel()
+
+	mapping := extractRunScriptForTest(t, `FROM alpine
+RUN <<EOF
+echo one
+# shell comment
+echo two
+EOF
+`)
+
+	if mapping.Script != "echo one\n# shell comment\necho two" {
+		t.Fatalf("expected heredoc body comments to be preserved, got %q", mapping.Script)
+	}
+}
+
 func TestExtractRunScript_ExplicitShellUsesBodyWithOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/highlight/extract/script_test.go
+++ b/internal/highlight/extract/script_test.go
@@ -142,6 +142,31 @@ EOF
 	}
 }
 
+func TestExtractRunScript_BridgesCommentsBetweenHeredocPayloadOpeners(t *testing.T) {
+	t.Parallel()
+
+	mapping := extractRunScriptForTest(t, `FROM alpine
+RUN <<FILE1 cat > /tmp/one && \
+    # Dockerfile header comment
+    <<FILE2 cat > /tmp/two
+one \
+# payload comment
+FILE1
+two
+FILE2
+`)
+
+	if mapping.IsHeredoc {
+		t.Fatalf("expected file-payload heredocs to remain part of full shell command, got Script=%q", mapping.Script)
+	}
+	if strings.Contains(mapping.Script, "Dockerfile header comment") {
+		t.Fatalf("expected Dockerfile header comment between heredoc openers to be elided, got %q", mapping.Script)
+	}
+	if !strings.Contains(mapping.Script, "# payload comment") {
+		t.Fatalf("expected heredoc payload comment to be preserved, got %q", mapping.Script)
+	}
+}
+
 func TestExtractRunScript_ExplicitShellUsesBodyWithOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/fixtures/fix/real-world-aria/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-aria/report_1.snap.md
@@ -1,6 +1,6 @@
 Fixed 17 issues
 Skipped 4 fixes
-**21 issues** in `<stdin>`
+**19 issues** in `<stdin>`
 
 | Line | Issue |
 |------|-------|
@@ -18,8 +18,6 @@ Skipped 4 fixes
 | 62 | 💅 split chained commands onto separate lines |
 | 62 | ℹ️ use cache mounts for package manager cache directories |
 | 62 | 💅 packages in apt-get install are not sorted alphabetically |
-| 81 | ❌ Parsing stopped here. Mismatched keywords or invalid parentheses? |
-| 81 | ❌ Unexpected start of line. If breaking lines, \|/\|\|/&& should be at the end of the previous one. |
 | 91 | 💅 expected blank line between ARG and ADD |
 | 93 | 💅 expected blank line between ADD and RUN |
 | 93 | 💅 consecutive RUN instructions can be combined using heredoc syntax |

--- a/internal/integration/fixtures/lint/powershell-backtick-comment-continuation/.tally.toml
+++ b/internal/integration/fixtures/lint/powershell-backtick-comment-continuation/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "on"
+
+[rules]
+include = ["powershell/UnexpectedToken"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/powershell-backtick-comment-continuation/Dockerfile
+++ b/internal/integration/fixtures/lint/powershell-backtick-comment-continuation/Dockerfile
@@ -1,0 +1,8 @@
+# escape=`
+FROM mcr.microsoft.com/powershell:7.4-ubuntu-22.04
+
+SHELL ["pwsh", "-NoLogo", "-NoProfile", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+RUN Set-Content -Path /tmp/comment-proof.txt -Value 'before' `
+    # Dockerfile comment: Docker removes this before invoking PowerShell
+    && Add-Content -Path /tmp/comment-proof.txt -Value 'after'

--- a/internal/integration/fixtures/lint/powershell-backtick-comment-continuation/result_1.snap.json
+++ b/internal/integration/fixtures/lint/powershell-backtick-comment-continuation/result_1.snap.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 0,
+    "info": 0,
+    "style": 0,
+    "total": 0,
+    "warnings": 0
+  }
+}

--- a/internal/rules/hadolint/dl3027.go
+++ b/internal/rules/hadolint/dl3027.go
@@ -61,6 +61,7 @@ var aptCommandMapping = map[string]struct {
 func (r *DL3027Rule) Check(input rules.LintInput) []rules.Violation {
 	meta := r.Metadata()
 	sm := input.SourceMap()
+	escapeToken := dockerfile.ASTEscapeToken(input.AST)
 
 	return ScanRunCommandsWithPOSIXShell(
 		input,
@@ -73,7 +74,7 @@ func (r *DL3027Rule) Check(input rules.LintInput) []rules.Violation {
 			if run.PrependShell {
 				// Shell form: parse original source with "RUN " replaced by spaces
 				// This preserves column positions for accurate edits on multi-line commands
-				script, startLine := dockerfile.RunSourceScript(run, sm)
+				script, startLine := dockerfile.RunSourceScript(run, sm, escapeToken)
 				if script == "" {
 					return nil
 				}

--- a/internal/rules/hadolint/dl3046.go
+++ b/internal/rules/hadolint/dl3046.go
@@ -117,7 +117,7 @@ func (r *DL3046Rule) createAutoFix(
 	}
 
 	sm := input.SourceMap()
-	sourceScript, scriptStartLine := dockerfile.RunSourceScript(run, sm)
+	sourceScript, scriptStartLine := dockerfile.RunSourceScript(run, sm, dockerfile.ASTEscapeToken(input.AST))
 	if sourceScript == "" {
 		return nil
 	}

--- a/internal/rules/hadolint/dl3047.go
+++ b/internal/rules/hadolint/dl3047.go
@@ -81,6 +81,7 @@ func wgetHasProgressSuppression(cmd *shell.CommandInfo) bool {
 func (r *DL3047Rule) Check(input rules.LintInput) []rules.Violation {
 	meta := r.Metadata()
 	sm := input.SourceMap()
+	escapeToken := dockerfile.ASTEscapeToken(input.AST)
 
 	return ScanRunCommandsWithPOSIXShell(
 		input,
@@ -90,7 +91,7 @@ func (r *DL3047Rule) Check(input rules.LintInput) []rules.Violation {
 
 			if run.PrependShell {
 				// Shell form: parse original source preserving column positions.
-				script, startLine := dockerfile.RunSourceScript(run, sm)
+				script, startLine := dockerfile.RunSourceScript(run, sm, escapeToken)
 				if script == "" {
 					return nil
 				}

--- a/internal/rules/hadolint/dl4001_fix.go
+++ b/internal/rules/hadolint/dl4001_fix.go
@@ -589,7 +589,7 @@ func runSourceScript(parsed *dockerfile.ParseResult, run *instructions.RunComman
 	if parsed == nil {
 		return strings.Join(run.CmdLine, " ")
 	}
-	if script, _ := dockerfile.RunSourceScript(run, sourcemap.New(parsed.Source)); script != "" {
+	if script, _ := dockerfile.RunSourceScript(run, sourcemap.New(parsed.Source), dockerfile.ASTEscapeToken(parsed.AST)); script != "" {
 		return script
 	}
 	return strings.Join(run.CmdLine, " ")

--- a/internal/rules/runcheck/runcheck.go
+++ b/internal/rules/runcheck/runcheck.go
@@ -85,6 +85,7 @@ func FindCommands(
 	run *instructions.RunCommand,
 	shellVariant shell.Variant,
 	sm *sourcemap.SourceMap,
+	escapeToken rune,
 	names ...string,
 ) ([]shell.CommandInfo, int) {
 	if run == nil {
@@ -92,7 +93,7 @@ func FindCommands(
 	}
 
 	if run.PrependShell && sm != nil {
-		script, startLine := dockerfile.RunSourceScript(run, sm)
+		script, startLine := dockerfile.RunSourceScript(run, sm, escapeToken)
 		if script == "" {
 			return nil, 0
 		}
@@ -155,11 +156,12 @@ func BuildInsertAfterSubcommandFix(
 // a command name and subcommand.
 func CheckCommandFlag(input rules.LintInput, meta rules.RuleMetadata, config CommandFlagRuleConfig) []rules.Violation {
 	sm := input.SourceMap()
+	escapeToken := dockerfile.ASTEscapeToken(input.AST)
 
 	return ScanRunCommandsWithPOSIXShell(
 		input,
 		func(run *instructions.RunCommand, shellVariant shell.Variant, file string) []rules.Violation {
-			cmds, runStartLine := FindCommands(run, shellVariant, sm, config.CommandNames...)
+			cmds, runStartLine := FindCommands(run, shellVariant, sm, escapeToken, config.CommandNames...)
 			if len(cmds) == 0 {
 				return nil
 			}

--- a/internal/rules/shellcheck/shellcheck_test.go
+++ b/internal/rules/shellcheck/shellcheck_test.go
@@ -231,6 +231,7 @@ enable-rpc=true
 rpc-listen-all=true
 EOF
 `)
+	input.EnabledRules = []string{ShellCheckRuleCode}
 
 	violations := NewRule().Check(input)
 	if len(violations) != 0 {
@@ -238,10 +239,35 @@ EOF
 	}
 }
 
+func TestRule_BridgesDockerfileCommentsInContinuedRun(t *testing.T) {
+	t.Parallel()
+
+	input := makeShellcheckLintInput(t, `FROM alpine
+RUN echo one \
+    # Dockerfile comment
+    && echo $(date)
+`)
+
+	violations := NewRule().Check(input)
+	for _, v := range violations {
+		switch v.RuleCode {
+		case "shellcheck/SC1070", "shellcheck/SC1133":
+			t.Fatalf("unexpected parse violation after Dockerfile comment bridge: %+v", v)
+		}
+	}
+
+	for _, v := range violations {
+		if v.RuleCode == "shellcheck/SC2046" && v.Location.Start.Line == 4 {
+			return
+		}
+	}
+	t.Fatalf("expected mapped SC2046 on line 4, got %+v", violations)
+}
+
 func TestRule_DoesNotLintCmdStageAsPOSIXAfterSeparatePowerShellStage(t *testing.T) {
 	t.Parallel()
 
-	input := makeShellcheckLintInput(t, "Dockerfile", `FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022 AS base
+	input := makeShellcheckLintInput(t, `FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022 AS base
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN Write-Host hi
 
@@ -261,7 +287,7 @@ RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 func TestRule_DoesNotLintExplicitPwshWrapperInCmdStage(t *testing.T) {
 	t.Parallel()
 
-	input := makeShellcheckLintInput(t, "Dockerfile", `FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+	input := makeShellcheckLintInput(t, `FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 RUN pwsh -NoLogo -NoProfile -Command " \
     $stopTime = (get-date).AddMinutes(15); \
     $ErrorActionPreference = 'Stop' ; \
@@ -282,7 +308,7 @@ RUN pwsh -NoLogo -NoProfile -Command " \
 func TestRule_DoesNotLintExplicitWrappersWhenBaseImageOSIsUnknown(t *testing.T) {
 	t.Parallel()
 
-	input := makeShellcheckLintInput(t, "Dockerfile", `ARG base
+	input := makeShellcheckLintInput(t, `ARG base
 FROM ${base}
 RUN pwsh -NoLogo -NoProfile -Command "Write-Host hi"
 RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
@@ -294,8 +320,10 @@ RUN cmd /c icacls.exe C:\\BuildAgent\\* /grant:r Users:(OI)(CI)F
 	}
 }
 
-func makeShellcheckLintInput(tb testing.TB, file, content string) rules.LintInput {
+func makeShellcheckLintInput(tb testing.TB, content string) rules.LintInput {
 	tb.Helper()
+
+	const file = "Dockerfile"
 
 	result, err := dockerfile.Parse(strings.NewReader(content), nil)
 	if err != nil {
@@ -309,12 +337,13 @@ func makeShellcheckLintInput(tb testing.TB, file, content string) rules.LintInpu
 		Build()
 
 	return rules.LintInput{
-		File:     file,
-		AST:      result.AST,
-		Stages:   result.Stages,
-		MetaArgs: result.MetaArgs,
-		Source:   result.Source,
-		Semantic: sem,
+		File:         file,
+		AST:          result.AST,
+		Stages:       result.Stages,
+		MetaArgs:     result.MetaArgs,
+		Source:       result.Source,
+		Semantic:     sem,
+		EnabledRules: []string{ShellCheckRuleCode},
 	}
 }
 

--- a/internal/rules/tally/curl_should_follow_redirects.go
+++ b/internal/rules/tally/curl_should_follow_redirects.go
@@ -46,6 +46,7 @@ func (r *CurlShouldFollowRedirectsRule) Metadata() rules.RuleMetadata {
 func (r *CurlShouldFollowRedirectsRule) Check(input rules.LintInput) []rules.Violation {
 	meta := r.Metadata()
 	sm := input.SourceMap()
+	escapeToken := dockerfile.ASTEscapeToken(input.AST)
 
 	return hadolint.ScanRunCommandsWithPOSIXShell(
 		input,
@@ -57,7 +58,7 @@ func (r *CurlShouldFollowRedirectsRule) Check(input rules.LintInput) []rules.Vio
 			var runStartLine int
 
 			if run.PrependShell && sm != nil {
-				script, startLine := dockerfile.RunSourceScript(run, sm)
+				script, startLine := dockerfile.RunSourceScript(run, sm, escapeToken)
 				if script == "" {
 					return nil
 				}

--- a/internal/rules/tally/js/node_gyp_cache_mounts.go
+++ b/internal/rules/tally/js/node_gyp_cache_mounts.go
@@ -1007,7 +1007,7 @@ func buildNodeGypCacheFix(
 	edits := []rules.TextEdit{mountEdit}
 
 	if addDevDirEnv {
-		if envEdits, ok := buildNodeGypDevDirEnvEdits(file, runFacts.Run, runFacts.Shell.Variant, sm, devdir); ok {
+		if envEdits, ok := buildNodeGypDevDirEnvEdits(file, runFacts.Run, runFacts.Shell.Variant, sm, runFacts.EscapeToken, devdir); ok {
 			for _, edit := range envEdits {
 				if edit.Location == mountEdit.Location {
 					edits[0].NewText += edit.NewText
@@ -1031,6 +1031,7 @@ func buildNodeGypDevDirEnvEdits(
 	run *instructions.RunCommand,
 	shellVariant shell.Variant,
 	sm *sourcemap.SourceMap,
+	escapeToken rune,
 	devdir string,
 ) ([]rules.TextEdit, bool) {
 	if run == nil || sm == nil || !run.PrependShell || len(run.Files) > 0 {
@@ -1048,7 +1049,7 @@ func buildNodeGypDevDirEnvEdits(
 		return nil, false
 	}
 
-	cmds, runStartLine := runcheck.FindCommands(run, shellVariant, sm, npmManager, pnpmManager, yarnManager)
+	cmds, runStartLine := runcheck.FindCommands(run, shellVariant, sm, escapeToken, npmManager, pnpmManager, yarnManager)
 	if runStartLine == 0 {
 		return nil, false
 	}

--- a/internal/rules/tally/php/composer_no_dev_in_production.go
+++ b/internal/rules/tally/php/composer_no_dev_in_production.go
@@ -73,7 +73,7 @@ func (r *ComposerNoDevInProductionRule) checkStageWithFacts(
 			continue
 		}
 
-		violations = append(violations, r.checkRun(runFacts.Run, shellVariant, file, meta, sm)...)
+		violations = append(violations, r.checkRun(runFacts.Run, shellVariant, file, meta, sm, runFacts.EscapeToken)...)
 	}
 
 	return violations
@@ -98,8 +98,9 @@ func (r *ComposerNoDevInProductionRule) checkRun(
 	file string,
 	meta rules.RuleMetadata,
 	sm *sourcemap.SourceMap,
+	escapeToken rune,
 ) []rules.Violation {
-	cmds, runStartLine := findComposerCommands(run, shellVariant, sm, "install")
+	cmds, runStartLine := findComposerCommands(run, shellVariant, sm, escapeToken, "install")
 	if len(cmds) == 0 {
 		return nil
 	}

--- a/internal/rules/tally/php/helpers.go
+++ b/internal/rules/tally/php/helpers.go
@@ -67,9 +67,10 @@ func findComposerCommands(
 	run *instructions.RunCommand,
 	shellVariant shell.Variant,
 	sm *sourcemap.SourceMap,
+	escapeToken rune,
 	subcommands ...string,
 ) ([]shell.CommandInfo, int) {
-	cmds, runStartLine := runcheck.FindCommands(run, shellVariant, sm, "composer")
+	cmds, runStartLine := runcheck.FindCommands(run, shellVariant, sm, escapeToken, "composer")
 	if len(subcommands) == 0 {
 		return cmds, runStartLine
 	}
@@ -115,7 +116,7 @@ func findXdebugCommands(
 	names = append(names, phpExtensionCommandNames...)
 	names = append(names, osPackageManagersForPHPSorted...)
 
-	cmds, runStartLine := runcheck.FindCommands(runFacts.Run, shellVariant, sm, names...)
+	cmds, runStartLine := runcheck.FindCommands(runFacts.Run, shellVariant, sm, runFacts.EscapeToken, names...)
 	if len(cmds) == 0 {
 		return nil, 0
 	}

--- a/internal/rules/tally/powershell/prefer_shell_instruction.go
+++ b/internal/rules/tally/powershell/prefer_shell_instruction.go
@@ -583,7 +583,7 @@ func adaptImpactedRunForPowerShell(
 			return rules.TextEdit{}, false, false
 		}
 
-		edit, ok := buildRunBodyRewriteEdit(file, sm, run, newScript)
+		edit, ok := buildRunBodyRewriteEdit(file, sm, run, newScript, escapeToken)
 		if !ok {
 			return rules.TextEdit{}, false, false
 		}
@@ -601,7 +601,7 @@ func adaptImpactedRunForPowerShell(
 		return rules.TextEdit{}, false, true
 	}
 
-	edit, ok := buildRunBodyRewriteEdit(file, sm, run, newScript)
+	edit, ok := buildRunBodyRewriteEdit(file, sm, run, newScript, escapeToken)
 	if !ok {
 		return rules.TextEdit{}, false, false
 	}
@@ -962,7 +962,7 @@ func buildPowerShellWrapperRewriteEdit(
 	if !ok || strings.TrimSpace(newScript) == "" {
 		return rules.TextEdit{}, false
 	}
-	return buildRunBodyRewriteEdit(file, sm, item.run, newScript)
+	return buildRunBodyRewriteEdit(file, sm, item.run, newScript, escapeToken)
 }
 
 func buildRunBodyRewriteEdit(
@@ -970,6 +970,7 @@ func buildRunBodyRewriteEdit(
 	sm *sourcemap.SourceMap,
 	run *instructions.RunCommand,
 	newScript string,
+	escapeToken rune,
 ) (rules.TextEdit, bool) {
 	resolved, ok := dockerfile.ResolveRunSource(run, sm)
 	if ok {
@@ -987,7 +988,7 @@ func buildRunBodyRewriteEdit(
 		return *edit, true
 	}
 
-	source, startLine, scriptIndex, ok := resolveRunInstructionScriptRange(run, sm)
+	source, startLine, scriptIndex, ok := resolveRunInstructionScriptRange(run, sm, escapeToken)
 	if !ok {
 		return rules.TextEdit{}, false
 	}
@@ -1022,12 +1023,13 @@ func buildShellDependantCommandRewriteEdit(
 func resolveRunInstructionScriptRange(
 	run *instructions.RunCommand,
 	sm *sourcemap.SourceMap,
+	escapeToken rune,
 ) (string, int, int, bool) {
 	if run == nil || sm == nil {
 		return "", 0, 0, false
 	}
 
-	source, startLine := dockerfile.RunSourceScript(run, sm)
+	source, startLine := dockerfile.RunSourceScript(run, sm, escapeToken)
 	if source == "" || startLine == 0 {
 		return "", 0, 0, false
 	}

--- a/internal/rules/tally/world_writable_state_path_workaround.go
+++ b/internal/rules/tally/world_writable_state_path_workaround.go
@@ -94,7 +94,7 @@ func (r *WorldWritableStatePathWorkaroundRule) checkRun(
 	var sourceScript string
 	var runStartLine int
 	if sm := input.SourceMap(); sm != nil && runFacts.Run.PrependShell {
-		sourceScript, runStartLine = dockerfile.RunSourceScript(runFacts.Run, sm)
+		sourceScript, runStartLine = dockerfile.RunSourceScript(runFacts.Run, sm, runFacts.EscapeToken)
 	}
 
 	// Pre-parse sourceScript chmods for column-accurate fix positions.

--- a/internal/shell/chain_format.go
+++ b/internal/shell/chain_format.go
@@ -249,6 +249,8 @@ func reconstructSourceTextWithTarget(
 	escapeToken rune,
 	target rune,
 ) string {
+	lines = BridgeDockerfileCommentContinuations(lines, escapeToken, target)
+
 	var sb strings.Builder
 	escByte := byte(escapeToken)
 	needsRewrite := escapeToken != target && escapeToken != 0

--- a/internal/shell/chain_format_test.go
+++ b/internal/shell/chain_format_test.go
@@ -281,6 +281,13 @@ func TestReconstructSourceText(t *testing.T) {
 			want:        "echo hello \\\n    && echo world",
 		},
 		{
+			name:        "dockerfile comment inside continued instruction",
+			lines:       []string{`RUN echo hello \`, `    # Dockerfile comment`, `    && echo world`},
+			cmdStartCol: 4,
+			escapeToken: '\\',
+			want:        "echo hello \\\n    \\\n    && echo world",
+		},
+		{
 			name:        "with mount prefix",
 			lines:       []string{"RUN --mount=type=cache,target=/var apt-get update"},
 			cmdStartCol: 35,

--- a/internal/shell/dockerfile_source.go
+++ b/internal/shell/dockerfile_source.go
@@ -58,3 +58,54 @@ func SkipDockerfileFlagValue(line string, offset int, stopAtLineContinuation boo
 	}
 	return offset
 }
+
+// BridgeDockerfileCommentContinuations replaces Dockerfile comment-only lines
+// inside a continued shell-form instruction with a synthetic continuation line.
+// Dockerfile comments are removed before the shell sees the instruction; keeping
+// them as shell comments can make a valid Dockerfile look like an invalid shell
+// script when the preceding line ends with a continuation marker.
+func BridgeDockerfileCommentContinuations(lines []string, escapeToken, target rune) []string {
+	if len(lines) == 0 || escapeToken == 0 {
+		return lines
+	}
+	if target == 0 {
+		target = '\\'
+	}
+
+	var out []string
+	continued := false
+	for i, line := range lines {
+		if isDockerfileCommentLine(line) {
+			if continued {
+				if out == nil {
+					out = append([]string(nil), lines...)
+				}
+				out[i] = dockerfileContinuationBridgeLine(line, target)
+			}
+			continue
+		}
+		continued = dockerfileLineContinues(line, escapeToken)
+	}
+	if out == nil {
+		return lines
+	}
+	return out
+}
+
+func isDockerfileCommentLine(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	return strings.HasPrefix(trimmed, "#")
+}
+
+func dockerfileLineContinues(line string, escapeToken rune) bool {
+	trimmed := strings.TrimRight(line, " \t")
+	return trimmed != "" && strings.HasSuffix(trimmed, string(escapeToken))
+}
+
+func dockerfileContinuationBridgeLine(line string, target rune) string {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	return line[:i] + string(target)
+}

--- a/internal/shell/dockerfile_source_test.go
+++ b/internal/shell/dockerfile_source_test.go
@@ -79,3 +79,91 @@ func TestSkipDockerfileFlagValue(t *testing.T) {
 		})
 	}
 }
+
+func TestBridgeDockerfileCommentContinuations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		lines       []string
+		escapeToken rune
+		target      rune
+		want        []string
+	}{
+		{
+			name: "comment between continued shell lines",
+			lines: []string{
+				`RUN echo one \`,
+				`    # Dockerfile comment`,
+				`    && echo two`,
+			},
+			escapeToken: '\\',
+			target:      '\\',
+			want: []string{
+				`RUN echo one \`,
+				`    \`,
+				`    && echo two`,
+			},
+		},
+		{
+			name: "consecutive comments stay in continued span",
+			lines: []string{
+				`RUN echo one \`,
+				`    # first`,
+				`    # second`,
+				`    && echo two`,
+			},
+			escapeToken: '\\',
+			target:      '\\',
+			want: []string{
+				`RUN echo one \`,
+				`    \`,
+				`    \`,
+				`    && echo two`,
+			},
+		},
+		{
+			name: "comment outside continuation is unchanged",
+			lines: []string{
+				`RUN echo one`,
+				`# normal Dockerfile comment`,
+			},
+			escapeToken: '\\',
+			target:      '\\',
+			want: []string{
+				`RUN echo one`,
+				`# normal Dockerfile comment`,
+			},
+		},
+		{
+			name: "rewrites to requested target continuation",
+			lines: []string{
+				"RUN Write-Host one `",
+				"    # Dockerfile comment",
+				"    ; Write-Host two",
+			},
+			escapeToken: '`',
+			target:      '`',
+			want: []string{
+				"RUN Write-Host one `",
+				"    `",
+				"    ; Write-Host two",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := BridgeDockerfileCommentContinuations(tt.lines, tt.escapeToken, tt.target)
+			if len(got) != len(tt.want) {
+				t.Fatalf("line count = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("line %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- bridge Dockerfile comment-only lines inside continued shell-form instructions before shell parsing
- apply the behavior to ShellCheck/highlight extraction and RunSourceScript consumers
- add regression coverage, including a PowerShell backtick escape lint fixture for powershell/UnexpectedToken

## Why
Docker strips Dockerfile comments before invoking the configured shell. tally was feeding those comment lines to shell analyzers, which made valid continued RUN commands look syntactically invalid when the following physical line began with &&.

## Validation
- Built and ran a temporary Ubuntu PowerShell image with # escape=` and a comment inside a multiline PowerShell RUN; Docker omitted the comment and the container printed both expected values.
- GOEXPERIMENT=jsonv2 go test ./...
- pre-push: make build, make deadcode, make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of Dockerfile comments inside continued RUN lines and heredoc headers, reducing false-positive parsing issues.

* **Improvements**
  * Extraction and mapping of RUN scripts now respect Dockerfile escape tokens, improving accuracy (including PowerShell backtick mode).

* **Tests**
  * Added extensive tests and fixtures covering comment continuations, heredocs, and escape-token scenarios; snapshot reports show fewer reported issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wharflab/tally/pull/663)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->