### PR TITLE
feat(powershell): curate default-disabled PSSA rule set for Dockerfile RUN

### DIFF
--- a/_docs/rules/powershell/PSAvoidDefaultValueForMandatoryParameter.mdx
+++ b/_docs/rules/powershell/PSAvoidDefaultValueForMandatoryParameter.mdx
@@ -11,7 +11,15 @@ Dockerfiles.
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSAvoidDefaultValueForMandatoryParameter"]` or by setting
+  `rules.powershell.PSAvoidDefaultValueForMandatoryParameter.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidDefaultValueSwitchParameter.mdx
+++ b/_docs/rules/powershell/PSAvoidDefaultValueSwitchParameter.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSAvoidDefaultValueSwitchParameter"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSAvoidDefaultValueSwitchParameter"]` or by setting
+  `rules.powershell.PSAvoidDefaultValueSwitchParameter.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidGlobalAliases.mdx
+++ b/_docs/rules/powershell/PSAvoidGlobalAliases.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSAvoidGlobalAliases"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSAvoidGlobalAliases"]` or by setting
+  `rules.powershell.PSAvoidGlobalAliases.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidGlobalFunctions.mdx
+++ b/_docs/rules/powershell/PSAvoidGlobalFunctions.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSAvoidGlobalFunctions"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSAvoidGlobalFunctions"]` or by setting
+  `rules.powershell.PSAvoidGlobalFunctions.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidGlobalVars.mdx
+++ b/_docs/rules/powershell/PSAvoidGlobalVars.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSAvoidGlobalVars"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSAvoidGlobalVars"]` or by setting
+  `rules.powershell.PSAvoidGlobalVars.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidNullOrEmptyHelpMessageAttribute.mdx
+++ b/_docs/rules/powershell/PSAvoidNullOrEmptyHelpMessageAttribute.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSAvoidNullOrEmptyHelpMessageAttribute"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSAvoidNullOrEmptyHelpMessageAttribute"]` or by setting
+  `rules.powershell.PSAvoidNullOrEmptyHelpMessageAttribute.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidShouldContinueWithoutForce.mdx
+++ b/_docs/rules/powershell/PSAvoidShouldContinueWithoutForce.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSAvoidShouldContinueWithoutForce"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSAvoidShouldContinueWithoutForce"]` or by setting
+  `rules.powershell.PSAvoidShouldContinueWithoutForce.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidUsingDeprecatedManifestFields.mdx
+++ b/_docs/rules/powershell/PSAvoidUsingDeprecatedManifestFields.mdx
@@ -10,7 +10,16 @@ sidebarTitle: "PSAvoidUsingDeprecatedManifestFields"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Dockerfiles do not ship PowerShell module
+  manifests (`.psd1` files) — this rule targets module-authoring artifacts that are out of
+  scope for container builds. Re-enable it with
+  `include = ["powershell/PSAvoidUsingDeprecatedManifestFields"]` or by setting
+  `rules.powershell.PSAvoidUsingDeprecatedManifestFields.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidUsingPositionalParameters.mdx
+++ b/_docs/rules/powershell/PSAvoidUsingPositionalParameters.mdx
@@ -10,7 +10,16 @@ sidebarTitle: "PSAvoidUsingPositionalParameters"
 |----------|-------|
 | Severity | Information |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because there is no
+  downstream pipeline or caller in a one-shot container build, so the script-reusability
+  concerns this rule targets do not apply. Re-enable it with
+  `include = ["powershell/PSAvoidUsingPositionalParameters"]` or by setting
+  `rules.powershell.PSAvoidUsingPositionalParameters.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSAvoidUsingWriteHost.mdx
+++ b/_docs/rules/powershell/PSAvoidUsingWriteHost.mdx
@@ -10,7 +10,16 @@ sidebarTitle: "PSAvoidUsingWriteHost"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because there is no downstream
+  pipeline or interactive host inside a one-shot container build — the script-reusability concerns
+  this rule targets do not apply. Re-enable it with
+  `include = ["powershell/PSAvoidUsingWriteHost"]` or by setting
+  `rules.powershell.PSAvoidUsingWriteHost.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSDSCDscExamplesPresent.mdx
+++ b/_docs/rules/powershell/PSDSCDscExamplesPresent.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSDSCDscExamplesPresent"
 |----------|-------|
 | Severity | Information |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Desired State Configuration resources are out
+  of scope for Dockerfile `RUN` analysis. Re-enable it with
+  `include = ["powershell/PSDSCDscExamplesPresent"]` or by setting
+  `rules.powershell.PSDSCDscExamplesPresent.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSDSCDscTestsPresent.mdx
+++ b/_docs/rules/powershell/PSDSCDscTestsPresent.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSDSCDscTestsPresent"
 |----------|-------|
 | Severity | Information |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Desired State Configuration resources are out
+  of scope for Dockerfile `RUN` analysis. Re-enable it with
+  `include = ["powershell/PSDSCDscTestsPresent"]` or by setting
+  `rules.powershell.PSDSCDscTestsPresent.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSDSCReturnCorrectTypesForDSCFunctions.mdx
+++ b/_docs/rules/powershell/PSDSCReturnCorrectTypesForDSCFunctions.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSDSCReturnCorrectTypesForDSCFunctions"
 |----------|-------|
 | Severity | Information |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Desired State Configuration resources are out
+  of scope for Dockerfile `RUN` analysis. Re-enable it with
+  `include = ["powershell/PSDSCReturnCorrectTypesForDSCFunctions"]` or by setting
+  `rules.powershell.PSDSCReturnCorrectTypesForDSCFunctions.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSDSCStandardDSCFunctionsInResource.mdx
+++ b/_docs/rules/powershell/PSDSCStandardDSCFunctionsInResource.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSDSCStandardDSCFunctionsInResource"
 |----------|-------|
 | Severity | Error |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Desired State Configuration resources are out
+  of scope for Dockerfile `RUN` analysis. Re-enable it with
+  `include = ["powershell/PSDSCStandardDSCFunctionsInResource"]` or by setting
+  `rules.powershell.PSDSCStandardDSCFunctionsInResource.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSDSCUseIdenticalMandatoryParametersForDSC.mdx
+++ b/_docs/rules/powershell/PSDSCUseIdenticalMandatoryParametersForDSC.mdx
@@ -11,7 +11,15 @@ Dockerfiles.
 |----------|-------|
 | Severity | Error |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Desired State Configuration resources are out
+  of scope for Dockerfile `RUN` analysis. Re-enable it with
+  `include = ["powershell/PSDSCUseIdenticalMandatoryParametersForDSC"]` or by setting
+  `rules.powershell.PSDSCUseIdenticalMandatoryParametersForDSC.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSDSCUseIdenticalParametersForDSC.mdx
+++ b/_docs/rules/powershell/PSDSCUseIdenticalParametersForDSC.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSDSCUseIdenticalParametersForDSC"
 |----------|-------|
 | Severity | Error |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Desired State Configuration resources are out
+  of scope for Dockerfile `RUN` analysis. Re-enable it with
+  `include = ["powershell/PSDSCUseIdenticalParametersForDSC"]` or by setting
+  `rules.powershell.PSDSCUseIdenticalParametersForDSC.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSDSCUseVerboseMessageInDSCResource.mdx
+++ b/_docs/rules/powershell/PSDSCUseVerboseMessageInDSCResource.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSDSCUseVerboseMessageInDSCResource"
 |----------|-------|
 | Severity | Information |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Desired State Configuration resources are out
+  of scope for Dockerfile `RUN` analysis. Re-enable it with
+  `include = ["powershell/PSDSCUseVerboseMessageInDSCResource"]` or by setting
+  `rules.powershell.PSDSCUseVerboseMessageInDSCResource.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSMissingModuleManifestField.mdx
+++ b/_docs/rules/powershell/PSMissingModuleManifestField.mdx
@@ -10,7 +10,16 @@ sidebarTitle: "PSMissingModuleManifestField"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Dockerfiles do not ship PowerShell module
+  manifests (`.psd1` files) — this rule targets module-authoring artifacts that are out of
+  scope for container builds. Re-enable it with
+  `include = ["powershell/PSMissingModuleManifestField"]` or by setting
+  `rules.powershell.PSMissingModuleManifestField.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSProvideCommentHelp.mdx
+++ b/_docs/rules/powershell/PSProvideCommentHelp.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSProvideCommentHelp"
 |----------|-------|
 | Severity | Info |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSProvideCommentHelp"]` or by setting
+  `rules.powershell.PSProvideCommentHelp.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSReservedCmdletChar.mdx
+++ b/_docs/rules/powershell/PSReservedCmdletChar.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSReservedCmdletChar"
 |----------|-------|
 | Severity | Error |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSReservedCmdletChar"]` or by setting
+  `rules.powershell.PSReservedCmdletChar.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSReservedParams.mdx
+++ b/_docs/rules/powershell/PSReservedParams.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSReservedParams"
 |----------|-------|
 | Severity | Error |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSReservedParams"]` or by setting
+  `rules.powershell.PSReservedParams.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSReviewUnusedParameter.mdx
+++ b/_docs/rules/powershell/PSReviewUnusedParameter.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSReviewUnusedParameter"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSReviewUnusedParameter"]` or by setting
+  `rules.powershell.PSReviewUnusedParameter.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSShouldProcess.mdx
+++ b/_docs/rules/powershell/PSShouldProcess.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSShouldProcess"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSShouldProcess"]` or by setting
+  `rules.powershell.PSShouldProcess.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseApprovedVerbs.mdx
+++ b/_docs/rules/powershell/PSUseApprovedVerbs.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSUseApprovedVerbs"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSUseApprovedVerbs"]` or by setting
+  `rules.powershell.PSUseApprovedVerbs.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseBOMForUnicodeEncodedFile.mdx
+++ b/_docs/rules/powershell/PSUseBOMForUnicodeEncodedFile.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSUseBOMForUnicodeEncodedFile"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Dockerfile `RUN` bodies are inline strings, not
+  files on disk with encoding metadata. Re-enable it with
+  `include = ["powershell/PSUseBOMForUnicodeEncodedFile"]` or by setting
+  `rules.powershell.PSUseBOMForUnicodeEncodedFile.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseOutputTypeCorrectly.mdx
+++ b/_docs/rules/powershell/PSUseOutputTypeCorrectly.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSUseOutputTypeCorrectly"
 |----------|-------|
 | Severity | Information |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSUseOutputTypeCorrectly"]` or by setting
+  `rules.powershell.PSUseOutputTypeCorrectly.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseProcessBlockForPipelineCommand.mdx
+++ b/_docs/rules/powershell/PSUseProcessBlockForPipelineCommand.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSUseProcessBlockForPipelineCommand"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSUseProcessBlockForPipelineCommand"]` or by setting
+  `rules.powershell.PSUseProcessBlockForPipelineCommand.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseShouldProcessForStateChangingFunctions.mdx
+++ b/_docs/rules/powershell/PSUseShouldProcessForStateChangingFunctions.mdx
@@ -11,7 +11,15 @@ Dockerfiles.
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSUseShouldProcessForStateChangingFunctions"]` or by setting
+  `rules.powershell.PSUseShouldProcessForStateChangingFunctions.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseSingularNouns.mdx
+++ b/_docs/rules/powershell/PSUseSingularNouns.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSUseSingularNouns"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSUseSingularNouns"]` or by setting
+  `rules.powershell.PSUseSingularNouns.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseSupportsShouldProcess.mdx
+++ b/_docs/rules/powershell/PSUseSupportsShouldProcess.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSUseSupportsShouldProcess"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default for Dockerfile `RUN` snippets because a `RUN` executes
+  statements inline rather than defining cmdlets, parameters, or modules with external callers. Re-enable it with
+  `include = ["powershell/PSUseSupportsShouldProcess"]` or by setting
+  `rules.powershell.PSUseSupportsShouldProcess.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseToExportFieldsInManifest.mdx
+++ b/_docs/rules/powershell/PSUseToExportFieldsInManifest.mdx
@@ -10,7 +10,16 @@ sidebarTitle: "PSUseToExportFieldsInManifest"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Dockerfiles do not ship PowerShell module
+  manifests (`.psd1` files) — this rule targets module-authoring artifacts that are out of
+  scope for container builds. Re-enable it with
+  `include = ["powershell/PSUseToExportFieldsInManifest"]` or by setting
+  `rules.powershell.PSUseToExportFieldsInManifest.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PSUseUTF8EncodingForHelpFile.mdx
+++ b/_docs/rules/powershell/PSUseUTF8EncodingForHelpFile.mdx
@@ -10,7 +10,15 @@ sidebarTitle: "PSUseUTF8EncodingForHelpFile"
 |----------|-------|
 | Severity | Warning |
 | Category | PSScriptAnalyzer |
+| Default  | Disabled in tally |
 | Auto-fix | No |
+
+<Note>
+  tally disables this rule by default because Dockerfile `RUN` bodies are inline strings, not
+  files on disk with encoding metadata. Re-enable it with
+  `include = ["powershell/PSUseUTF8EncodingForHelpFile"]` or by setting
+  `rules.powershell.PSUseUTF8EncodingForHelpFile.severity = "warning"` in `.tally.toml`.
+</Note>
 
 ## Description
 

--- a/_docs/rules/powershell/PowerShell.mdx
+++ b/_docs/rules/powershell/PowerShell.mdx
@@ -34,6 +34,28 @@ options such as `Enable`, `TargetProfiles`, and compatibility profile settings d
 When an upstream PSScriptAnalyzer diagnostic includes suggested corrections, tally exposes them as normal fix suggestions. These fixes are only
 attached when the PowerShell snippet can be mapped back to precise Dockerfile source ranges.
 
+## Default-disabled PSScriptAnalyzer rules
+
+A subset of PSScriptAnalyzer rules is targeted at long-lived script reusability, function or module authoring, manifest authoring, or Desired State
+Configuration — concerns that do not apply to a one-shot Dockerfile `RUN`. tally ships with these rules disabled by default so the diagnostics you see
+are correctness, security, and compatibility findings. Each affected rule's documentation page has a `Default: Disabled in tally` row and a note
+explaining why.
+
+To re-enable a default-disabled rule for your project, opt in explicitly:
+
+```toml
+# .tally.toml
+[rules]
+include = ["powershell/PSAvoidUsingWriteHost"]
+
+# Or per-rule:
+[rules.powershell.PSAvoidUsingWriteHost]
+severity = "warning"
+```
+
+To re-enable the entire default-disabled set, use the namespace wildcard: `include = ["powershell/*"]`. The engine selector
+`include = ["powershell/PowerShell"]` only toggles the analyzer engine and does **not** override per-rule defaults.
+
 ## Requirements
 
 - PowerShell 7 (`pwsh`) must be available on `PATH`.

--- a/internal/integration/fixtures/fix/real-world-metalama/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-metalama/report_1.snap.md
@@ -2,7 +2,7 @@ Fixed 16 issues
 Skipped 1 fixes
 note: 1 AI fix(es) failed (see details below)
 note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registered: ai-autofix
-**24 issues** in `<stdin>`
+**21 issues** in `<stdin>`
 
 | Line | Issue |
 |------|-------|
@@ -23,10 +23,7 @@ note: skipped fix tally/prefer-multi-stage-build (<stdin>): resolver not registe
 | 78 | ⚠️ PowerShell RUN is missing $ErrorActionPreference = 'Stop' and $PSNativeCommandUseErrorActionPreference = $true |
 | 78 | 💅 PowerShell Invoke-WebRequest without $ProgressPreference = 'SilentlyContinue' |
 | 78 | 💅 RUN instruction with chained commands can use heredoc syntax |
-| 83 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
-| 85 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
 | 90 | 💅 expected blank line between RUN and ENV |
 | 91 | ❌ The string is missing the terminator: ". |
 | 101 | 💅 expected blank line between ARG and RUN |
-| 105 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
 | 114 | 💅 expected blank line between COPY and RUN |

--- a/internal/integration/fixtures/fix/real-world-teamcity-nanoserver/report_1.snap.md
+++ b/internal/integration/fixtures/fix/real-world-teamcity-nanoserver/report_1.snap.md
@@ -1,5 +1,5 @@
 Fixed 11 issues
-**12 issues** in `<stdin>`
+**11 issues** in `<stdin>`
 
 | Line | Issue |
 |------|-------|
@@ -11,7 +11,6 @@ Fixed 11 issues
 | 56 | ⚠️ Usage of undefined variable '$ProgramFiles' |
 | 67 | 💅 expected blank line between USER and RUN |
 | 68 | 💅 expected blank line between RUN and USER |
-| 76 | ⚠️ Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information. |
 | 81 | ⚠️ COPY without --chown creates root-owned files despite USER ContainerUser |
 | 90 | 💅 expected blank line between USER and RUN |
 | 92 | 💅 expected blank line between RUN and USER |

--- a/internal/rules/powershell/powershell_test.go
+++ b/internal/rules/powershell/powershell_test.go
@@ -320,8 +320,10 @@ RUN [System.Management.Automation.SemanticVersion]'1.18.0-rc1'
 	if len(settings.IncludeRules) != 0 {
 		t.Fatalf("IncludeRules = %#v, want none so tally include semantics do not restrict PSScriptAnalyzer", settings.IncludeRules)
 	}
-	if !slices.Equal(settings.ExcludeRules, []string{"PSAvoidExclaimOperator", "PSAvoidUsingWriteHost"}) {
-		t.Fatalf("ExcludeRules = %#v", settings.ExcludeRules)
+	for _, name := range []string{"PSAvoidExclaimOperator", "PSAvoidUsingWriteHost"} {
+		if !slices.Contains(settings.ExcludeRules, name) {
+			t.Fatalf("ExcludeRules = %#v, want to contain %q", settings.ExcludeRules, name)
+		}
 	}
 	ruleSettings := settings.Rules["PSUseCompatibleTypes"]
 	if len(ruleSettings) != 2 {
@@ -372,8 +374,148 @@ RUN Write-Host hi
 	if len(settings.IncludeRules) != 0 {
 		t.Fatalf("IncludeRules = %#v, want none so tally include semantics do not restrict PSScriptAnalyzer", settings.IncludeRules)
 	}
-	if len(settings.ExcludeRules) != 0 {
-		t.Fatalf("ExcludeRules = %#v, want none because include takes precedence over exclude", settings.ExcludeRules)
+	if slices.Contains(settings.ExcludeRules, "PSAvoidUsingWriteHost") {
+		t.Fatalf(
+			"ExcludeRules = %#v, want PSAvoidUsingWriteHost absent (include beats user+default exclude)",
+			settings.ExcludeRules,
+		)
+	}
+}
+
+func TestAnalyzerSettingsAppliesDefaultExcludes(t *testing.T) {
+	t.Parallel()
+
+	settings := analyzerSettings(&config.RulesConfig{})
+
+	if len(settings.IncludeRules) != 0 {
+		t.Fatalf("IncludeRules = %#v, want none", settings.IncludeRules)
+	}
+	for name := range defaultExcludedAnalyzerRules {
+		if !slices.Contains(settings.ExcludeRules, name) {
+			t.Fatalf("ExcludeRules missing default-disabled rule %q: got %#v", name, settings.ExcludeRules)
+		}
+	}
+}
+
+func TestAnalyzerSettingsDefaultExcludesWhenConfigNil(t *testing.T) {
+	t.Parallel()
+
+	settings := analyzerSettings(nil)
+
+	for name := range defaultExcludedAnalyzerRules {
+		if !slices.Contains(settings.ExcludeRules, name) {
+			t.Fatalf("ExcludeRules missing default-disabled rule %q when config is nil: got %#v", name, settings.ExcludeRules)
+		}
+	}
+}
+
+func TestAnalyzerSettingsIncludeReenablesDefaultExcludedRule(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.RulesConfig{
+		Include: []string{"powershell/PSAvoidUsingWriteHost"},
+	}
+	settings := analyzerSettings(cfg)
+
+	if slices.Contains(settings.ExcludeRules, "PSAvoidUsingWriteHost") {
+		t.Fatalf("ExcludeRules = %#v, want PSAvoidUsingWriteHost absent after explicit include", settings.ExcludeRules)
+	}
+	for _, name := range []string{"PSAvoidUsingPositionalParameters", "PSProvideCommentHelp"} {
+		if !slices.Contains(settings.ExcludeRules, name) {
+			t.Fatalf("ExcludeRules = %#v, want untouched default %q to remain excluded", settings.ExcludeRules, name)
+		}
+	}
+}
+
+func TestAnalyzerSettingsNamespaceWildcardIncludeReenablesAllDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.RulesConfig{
+		Include: []string{"powershell/*"},
+	}
+	settings := analyzerSettings(cfg)
+
+	for name := range defaultExcludedAnalyzerRules {
+		if slices.Contains(settings.ExcludeRules, name) {
+			t.Fatalf("ExcludeRules = %#v, want %q absent after powershell/* include", settings.ExcludeRules, name)
+		}
+	}
+}
+
+func TestAnalyzerSettingsEngineIncludeDoesNotReenableDefaultExcludes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.RulesConfig{
+		Include: []string{"powershell/PowerShell"},
+	}
+	settings := analyzerSettings(cfg)
+
+	if !slices.Contains(settings.ExcludeRules, "PSAvoidUsingWriteHost") {
+		t.Fatalf(
+			"ExcludeRules = %#v, want PSAvoidUsingWriteHost still excluded; engine selector is not a per-rule opt-in",
+			settings.ExcludeRules,
+		)
+	}
+}
+
+func TestAnalyzerSettingsPerRuleSeverityReenablesDefaultExcludedRule(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.RulesConfig{
+		Powershell: map[string]config.RuleConfig{
+			"PSAvoidUsingWriteHost": {Severity: "warning"},
+		},
+	}
+	settings := analyzerSettings(cfg)
+
+	if slices.Contains(settings.ExcludeRules, "PSAvoidUsingWriteHost") {
+		t.Fatalf("ExcludeRules = %#v, want PSAvoidUsingWriteHost absent after explicit per-rule severity", settings.ExcludeRules)
+	}
+}
+
+func TestAnalyzerSettingsPerRuleOptionsReenableDefaultExcludedRule(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.RulesConfig{
+		Powershell: map[string]config.RuleConfig{
+			"PSAvoidUsingWriteHost": {Options: map[string]any{"Enable": true}},
+		},
+	}
+	settings := analyzerSettings(cfg)
+
+	if slices.Contains(settings.ExcludeRules, "PSAvoidUsingWriteHost") {
+		t.Fatalf("ExcludeRules = %#v, want PSAvoidUsingWriteHost absent after per-rule options entry", settings.ExcludeRules)
+	}
+}
+
+func TestAnalyzerSettingsPerRuleSeverityOffKeepsDefaultExcluded(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.RulesConfig{
+		Powershell: map[string]config.RuleConfig{
+			"PSAvoidUsingWriteHost": {Severity: config.SeverityOffValue},
+		},
+	}
+	settings := analyzerSettings(cfg)
+
+	if !slices.Contains(settings.ExcludeRules, "PSAvoidUsingWriteHost") {
+		t.Fatalf("ExcludeRules = %#v, want PSAvoidUsingWriteHost excluded when user severity = off", settings.ExcludeRules)
+	}
+}
+
+func TestAnalyzerSettingsUserExcludeAddsToDefaultExcludes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.RulesConfig{
+		Exclude: []string{"powershell/PSMisleadingBacktick"},
+	}
+	settings := analyzerSettings(cfg)
+
+	if !slices.Contains(settings.ExcludeRules, "PSMisleadingBacktick") {
+		t.Fatalf("ExcludeRules = %#v, want PSMisleadingBacktick excluded by user config", settings.ExcludeRules)
+	}
+	if !slices.Contains(settings.ExcludeRules, "PSAvoidUsingWriteHost") {
+		t.Fatalf("ExcludeRules = %#v, want default PSAvoidUsingWriteHost still present", settings.ExcludeRules)
 	}
 }
 

--- a/internal/rules/powershell/settings.go
+++ b/internal/rules/powershell/settings.go
@@ -67,7 +67,7 @@ var defaultExcludedAnalyzerRules = map[string]struct{}{
 func analyzerSettings(cfg any) psanalyzer.Settings {
 	rulesCfg, ok := cfg.(*config.RulesConfig)
 	if !ok || rulesCfg == nil {
-		return defaultAnalyzerSettings(nil)
+		return defaultAnalyzerSettings()
 	}
 
 	var settings psanalyzer.Settings
@@ -106,7 +106,7 @@ func analyzerSettings(cfg any) psanalyzer.Settings {
 // defaultAnalyzerSettings returns the analyzer settings to use when no rules
 // config is available. It still applies the default-exclude list so the
 // curated set of off-by-default PSSA rules stays consistent.
-func defaultAnalyzerSettings(_ *config.RulesConfig) psanalyzer.Settings {
+func defaultAnalyzerSettings() psanalyzer.Settings {
 	excludeSet := make(map[string]struct{}, len(defaultExcludedAnalyzerRules))
 	for name := range defaultExcludedAnalyzerRules {
 		excludeSet[name] = struct{}{}

--- a/internal/rules/powershell/settings.go
+++ b/internal/rules/powershell/settings.go
@@ -10,10 +10,64 @@ import (
 	"github.com/wharflab/tally/internal/rules"
 )
 
+// defaultExcludedAnalyzerRules lists PSScriptAnalyzer rule names that tally
+// disables by default for Dockerfile RUN snippets. The exclusion can be
+// overridden by including the rule explicitly (`include = ["powershell/<Name>"]`)
+// or by setting a non-off severity / options entry under
+// `rules.powershell.<Name>` in `.tally.toml`.
+//
+// Rules land here when they target script reusability, function/module
+// authoring, manifest authoring, DSC resources, or pure style — concerns
+// that don't apply to a one-shot RUN. Rules that catch real correctness,
+// security, or compatibility issues are left enabled.
+var defaultExcludedAnalyzerRules = map[string]struct{}{
+	// Reusability concerns — RUN has no downstream pipeline.
+	"PSAvoidUsingWriteHost":            {},
+	"PSAvoidUsingPositionalParameters": {},
+
+	// Function / cmdlet authoring — a RUN executes statements, not exported APIs.
+	"PSProvideCommentHelp":                        {},
+	"PSUseShouldProcessForStateChangingFunctions": {},
+	"PSUseSupportsShouldProcess":                  {},
+	"PSShouldProcess":                             {},
+	"PSAvoidShouldContinueWithoutForce":           {},
+	"PSUseSingularNouns":                          {},
+	"PSUseApprovedVerbs":                          {},
+	"PSReservedCmdletChar":                        {},
+	"PSReservedParams":                            {},
+	"PSAvoidNullOrEmptyHelpMessageAttribute":      {},
+	"PSAvoidDefaultValueForMandatoryParameter":    {},
+	"PSAvoidDefaultValueSwitchParameter":          {},
+	"PSAvoidGlobalAliases":                        {},
+	"PSAvoidGlobalFunctions":                      {},
+	"PSAvoidGlobalVars":                           {},
+	"PSReviewUnusedParameter":                     {},
+	"PSUseOutputTypeCorrectly":                    {},
+	"PSUseProcessBlockForPipelineCommand":         {},
+
+	// Module manifest rules — Dockerfiles don't ship `.psd1` files.
+	"PSMissingModuleManifestField":         {},
+	"PSUseToExportFieldsInManifest":        {},
+	"PSAvoidUsingDeprecatedManifestFields": {},
+
+	// Desired State Configuration — out of scope for container builds.
+	"PSDSCDscExamplesPresent":                    {},
+	"PSDSCDscTestsPresent":                       {},
+	"PSDSCReturnCorrectTypesForDSCFunctions":     {},
+	"PSDSCStandardDSCFunctionsInResource":        {},
+	"PSDSCUseIdenticalMandatoryParametersForDSC": {},
+	"PSDSCUseIdenticalParametersForDSC":          {},
+	"PSDSCUseVerboseMessageInDSCResource":        {},
+
+	// File-encoding rules — RUN bodies aren't files on disk.
+	"PSUseBOMForUnicodeEncodedFile": {},
+	"PSUseUTF8EncodingForHelpFile":  {},
+}
+
 func analyzerSettings(cfg any) psanalyzer.Settings {
 	rulesCfg, ok := cfg.(*config.RulesConfig)
 	if !ok || rulesCfg == nil {
-		return psanalyzer.Settings{}
+		return defaultAnalyzerSettings(nil)
 	}
 
 	var settings psanalyzer.Settings
@@ -43,8 +97,63 @@ func analyzerSettings(cfg any) psanalyzer.Settings {
 		settings.Rules[name] = options
 	}
 
+	addDefaultExcludedRules(excludeSet, rulesCfg)
+
 	settings.ExcludeRules = sortedRuleNames(excludeSet)
 	return settings
+}
+
+// defaultAnalyzerSettings returns the analyzer settings to use when no rules
+// config is available. It still applies the default-exclude list so the
+// curated set of off-by-default PSSA rules stays consistent.
+func defaultAnalyzerSettings(_ *config.RulesConfig) psanalyzer.Settings {
+	excludeSet := make(map[string]struct{}, len(defaultExcludedAnalyzerRules))
+	for name := range defaultExcludedAnalyzerRules {
+		excludeSet[name] = struct{}{}
+	}
+	return psanalyzer.Settings{ExcludeRules: sortedRuleNames(excludeSet)}
+}
+
+// addDefaultExcludedRules merges tally's curated default-disabled PSSA rules
+// into out, skipping any rule the user has explicitly opted into.
+func addDefaultExcludedRules(out map[string]struct{}, rulesCfg *config.RulesConfig) {
+	for name := range defaultExcludedAnalyzerRules {
+		if _, already := out[name]; already {
+			continue
+		}
+		if userOptedIn(rulesCfg, name) {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+}
+
+// userOptedIn reports whether the user has explicitly re-enabled a
+// default-disabled PSSA rule. Re-enable signals:
+//   - an Include pattern naming the rule directly, the powershell/* namespace,
+//     or the universal *. The engine-only selector "powershell/PowerShell"
+//     does NOT count — it toggles the engine, not individual default-off rules.
+//   - a `rules.powershell.<Name>` entry with non-off severity, or with options
+//     (matching the existing per-rule behavior in this file).
+func userOptedIn(rulesCfg *config.RulesConfig, name string) bool {
+	if rulesCfg == nil {
+		return false
+	}
+	code := rules.PowerShellRulePrefix + name
+	for _, pattern := range rulesCfg.Include {
+		switch pattern {
+		case "*", rules.PowerShellRulePrefix + "*", code:
+			return true
+		}
+	}
+	cfg, ok := rulesCfg.Powershell[name]
+	if !ok {
+		return false
+	}
+	if cfg.Severity == config.SeverityOffValue {
+		return false
+	}
+	return cfg.Severity != "" || len(cfg.Options) > 0
 }
 
 func addPowerShellRulePatterns(out map[string]struct{}, rulesCfg *config.RulesConfig, patterns []string) {


### PR DESCRIPTION
## Summary

Closes #662.

A subset of PSScriptAnalyzer rules targets script reusability, function/module authoring, manifest authoring, or Desired State Configuration — concerns that don't apply to a one-shot Dockerfile `RUN`. This PR ships those rules disabled by default so the `powershell/*` diagnostics tally surfaces are correctness, security, and compatibility findings.

### What's default-disabled

- **Reusability concerns** — `PSAvoidUsingWriteHost`, `PSAvoidUsingPositionalParameters`
- **Function / cmdlet authoring** — `PSProvideCommentHelp`, `PSUseShouldProcessForStateChangingFunctions`, `PSUseSupportsShouldProcess`, `PSShouldProcess`, `PSAvoidShouldContinueWithoutForce`, `PSUseSingularNouns`, `PSUseApprovedVerbs`, `PSReservedCmdletChar`, `PSReservedParams`, `PSAvoidNullOrEmptyHelpMessageAttribute`, `PSAvoidDefaultValueForMandatoryParameter`, `PSAvoidDefaultValueSwitchParameter`, `PSAvoidGlobalAliases`, `PSAvoidGlobalFunctions`, `PSAvoidGlobalVars`, `PSReviewUnusedParameter`, `PSUseOutputTypeCorrectly`, `PSUseProcessBlockForPipelineCommand`
- **Module manifest** — `PSMissingModuleManifestField`, `PSUseToExportFieldsInManifest`, `PSAvoidUsingDeprecatedManifestFields`
- **DSC** — all 7 `PSDSC*` rules
- **File encoding** — `PSUseBOMForUnicodeEncodedFile`, `PSUseUTF8EncodingForHelpFile`

Rules left enabled cover correctness, security, bug-likely patterns, and compatibility — `PSAvoidUsingPlainTextForPassword`, `PSAvoidUsingInvokeExpression`, `PSMisleadingBacktick`, `PSPossibleIncorrect*`, `PSUseDeclaredVarsMoreThanAssignments`, `PSAvoidUsingCmdletAliases`, the full `PSUseCompatible*` family, and so on.

### How users opt back in

The default-exclude list ships in `internal/rules/powershell/settings.go` and is overridable:

- `include = ["powershell/<Name>"]` — single rule
- `include = ["powershell/*"]` — entire namespace (re-enables all defaults)
- `[rules.powershell.<Name>]` with `severity = "warning"` or `options = { ... }` — single rule

The engine selector `include = ["powershell/PowerShell"]` only toggles the analyzer engine; it does **not** override per-rule defaults. There's a dedicated test for that semantic.

### Docs

Each affected rule's MDX page got a `Default: Disabled in tally` table row plus a `<Note>` explaining why and how to re-enable. `PowerShell.mdx` documents the policy in a new section.

### Fixture impact

Two real-world fix fixtures (`real-world-metalama`, `real-world-teamcity-nanoserver`) lost a few `PSAvoidUsingWriteHost` violations as expected — snapshots refreshed via `UPDATE_SNAPS=true`.

## Test plan

- [x] `make lint` — clean
- [x] `go test ./internal/rules/powershell/...` — passes (10 new + 2 updated tests)
- [x] `go test ./internal/integration/...` — passes after snapshot refresh
- [ ] CI runs Mintlify validation on `_docs/` (couldn't run locally — Node version mismatch)