### PR TITLE
feat(rules): add tally/ruby/missing-bundle-without-development

### DIFF
--- a/_docs/rules/tally/ruby/missing-bundle-without-development.mdx
+++ b/_docs/rules/tally/ruby/missing-bundle-without-development.mdx
@@ -1,0 +1,112 @@
+---
+title: "tally/ruby/missing-bundle-without-development"
+description: "Production stage runs `bundle install` without excluding the `development` gem group."
+---
+
+Production stage runs `bundle install` without excluding the `development` gem group via `BUNDLE_WITHOUT`.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning |
+| Category | Security |
+| Default | Enabled |
+| Auto-fix | Yes (FixSafe) |
+
+## Description
+
+Bundler installs every gem in the `Gemfile` by default. The Rails generator template explicitly excludes the
+`development` group at the image level via `ENV BUNDLE_WITHOUT="development"` precisely because, without it,
+production images ship `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, `bullet`, `spring`, and
+similar development-only gems — bloating image size and exposing development-only attack surface.
+
+`web-console` in particular has documented RCE history when it leaks into production. The
+[Rails security guide](https://guides.rubyonrails.org/security.html) calls this out, and Bundler 2.x documents
+[`BUNDLE_WITHOUT`](https://bundler.io/v2.5/man/bundle-config.1.html) and `bundle config set without` as the
+supported mechanism to scope the install.
+
+This rule fires when a Ruby-shaped production stage runs `bundle install` and:
+
+- Neither `ENV BUNDLE_WITHOUT=...` (with `development` in the value) nor a prior
+  `bundle config set [--local|--global] without ...development...` invocation is observable in the stage, AND
+- `ENV BUNDLE_ONLY=...` (the Bundler 2.5+ inverse selector) does not contain `production`.
+
+The "production-shaped" heuristic mirrors the
+[`tally/ruby/missing-bundle-deployment`](/rules/tally/ruby/missing-bundle-deployment/) rule:
+the Dockerfile binds `RAILS_ENV` (or `RACK_ENV`) to `"production"` somewhere, **or** the stage has no
+explicit non-production marker and the rest of the stage shape (Ruby base, no dev-stage name, etc.) implies a
+runtime image.
+
+Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug` are skipped, as are stages
+whose effective env binds `RAILS_ENV`/`RACK_ENV` to `development` or `test`.
+
+Because the rule lives in the Ruby namespace and its remedy is Rails-flavored, it only fires on stages that
+look like a Ruby runtime: an official `ruby:*` base, a familiar name containing `ruby` or `rails`, a
+Ruby-runtime derivative, a stage env carrying Ruby/Rails/Bundler signals, or an ENTRYPOINT/CMD that invokes
+`ruby`, `rails`, `bundle`, `puma`, etc.
+
+### Context-aware refinement
+
+When tally is invoked with `--context` (or via Bake/Compose), the rule consults the project's `Gemfile` to
+sharpen its behavior:
+
+- **Suppressed when there is nothing to exclude.** If the `Gemfile` is observable and contains no
+  `group :development do` block (some library-style or ops-tool gems don't), the rule skips entirely — the
+  recommendation would be moot.
+- **Smarter fix wording.** If the `Gemfile` contains both `group :development` and `group :test` blocks,
+  the auto-fix emits `ENV BUNDLE_WITHOUT="development:test"` so production images don't ship `rspec-rails`,
+  `capybara`, or other test-only gems either. With only `:development`, the fix uses the Rails generator's
+  exact wording, `ENV BUNDLE_WITHOUT="development"`.
+
+If the `Gemfile` is not observable (Dockerfile-only mode), the rule applies and the fix defaults to
+`ENV BUNDLE_WITHOUT="development"`.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+COPY . .
+CMD ["bin/rails", "server"]
+```
+
+### After
+
+The Rails-generator-style fix declares `BUNDLE_WITHOUT` once at the top of the stage so every nested
+`bundle install` (including any inside CI scripts or entrypoints) honors it:
+
+```dockerfile
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+ENV BUNDLE_WITHOUT="development"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+COPY . .
+CMD ["bin/rails", "server"]
+```
+
+The Bundler 2.5+ inverse selector also satisfies the rule:
+
+```dockerfile
+ENV BUNDLE_ONLY="default:production"
+```
+
+## Auto-fix
+
+The rule offers a `FixSafe` that inserts `ENV BUNDLE_WITHOUT="development"` (or `"development:test"` when
+both groups are observable in the project's `Gemfile`) on the line immediately following the stage's `FROM`.
+Insertion is zero-width at column 0, so it composes cleanly with other rule edits in the same stage.
+
+## References
+
+- [Rails Dockerfile generator template](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt) —
+  emits `ENV BUNDLE_WITHOUT="development"` in the base stage.
+- [Bundler `bundle config` documentation](https://bundler.io/v2.5/man/bundle-config.1.html) —
+  `BUNDLE_WITHOUT` and `BUNDLE_ONLY` semantics.
+- [Bundler 2 upgrade guide](https://bundler.io/guides/bundler_2_upgrade.html) — deprecation of
+  `bundle install --without`.
+- [Rails security guide](https://guides.rubyonrails.org/security.html) — context for keeping development-only
+  gems out of production images.

--- a/internal/integration/__snapshots__/TestLint_ruby-bundle-without-dev-and-test_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-bundle-without-dev-and-test_1.snap.json
@@ -1,0 +1,59 @@
+{
+  "files": [
+    {
+      "file": "testdata/ruby-bundle-without-dev-and-test/Dockerfile",
+      "violations": [
+        {
+          "detail": "Production stages that run `bundle install` should exclude the `development` gem group via `ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`). Otherwise gems like `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, and `bullet` ship into the production image, inflating size and exposing development-only attack surface (`web-console` in particular has documented RCE history when it leaks into production).",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/missing-bundle-without-development/",
+          "location": {
+            "end": {
+              "column": 18,
+              "line": 4
+            },
+            "file": "testdata/ruby-bundle-without-dev-and-test/Dockerfile",
+            "start": {
+              "column": 11,
+              "line": 4
+            }
+          },
+          "message": "Production stage runs bundle install without BUNDLE_WITHOUT excluding the development group",
+          "rule": "tally/ruby/missing-bundle-without-development",
+          "severity": "warning",
+          "sourceCode": "RUN bundle install",
+          "suggestedFix": {
+            "description": "Add ENV BUNDLE_WITHOUT=\"development:test\" to exclude development gems from the production image",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 2
+                  },
+                  "file": "testdata/ruby-bundle-without-dev-and-test/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 2
+                  }
+                },
+                "newText": "ENV BUNDLE_WITHOUT=\"development:test\"\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 1,
+    "warnings": 1
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_ruby-bundle-without-dev-and-test_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-bundle-without-dev-and-test_1.snap.json
@@ -4,7 +4,7 @@
       "file": "testdata/ruby-bundle-without-dev-and-test/Dockerfile",
       "violations": [
         {
-          "detail": "Production stages that run `bundle install` should exclude the `development` gem group via `ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`). Otherwise gems like `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, and `bullet` ship into the production image, inflating size and exposing development-only attack surface (`web-console` in particular has documented RCE history when it leaks into production).",
+          "detail": "Production stages that run `bundle install` should exclude the `development` gem group via `ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`, or the Bundler 2.5+ inverse selector `ENV BUNDLE_ONLY=\"default:production\"`). Otherwise gems like `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, and `bullet` ship into the production image, inflating size and exposing development-only attack surface (`web-console` in particular has documented RCE history when it leaks into production).",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/missing-bundle-without-development/",
           "location": {
             "end": {

--- a/internal/integration/__snapshots__/TestLint_ruby-bundle-without-no-dev-group_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-bundle-without-no-dev-group_1.snap.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 0,
+    "info": 0,
+    "style": 0,
+    "total": 0,
+    "warnings": 0
+  }
+}

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/.tally.toml
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/.tally.toml
@@ -1,0 +1,9 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/missing-bundle-without-development"]
+exclude = ["*"]
+
+[output]
+fail-level = "none"

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/fixed_1.snap.Dockerfile
@@ -1,10 +1,6 @@
 FROM ruby:3.3-slim
-
 ENV BUNDLE_WITHOUT="development"
 ENV RAILS_ENV="production"
-
 COPY Gemfile Gemfile.lock ./
-
 RUN bundle install
-
 CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/fixed_1.snap.Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:3.3-slim
+
+ENV BUNDLE_WITHOUT="development"
+ENV RAILS_ENV="production"
+
+COPY Gemfile Gemfile.lock ./
+
+RUN bundle install
+
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/report_1.snap.md
@@ -1,0 +1,13 @@
+note: 4 slow check(s) skipped (image not found)
+Fixed 2 issues
+Skipped 2 fixes
+**6 issues** in `<stdin>`
+
+| Line | Issue |
+|------|-------|
+| - | ℹ️ `HEALTHCHECK` instruction missing |
+| 3 | ⚠️ `COPY` to a relative destination without `WORKDIR` set |
+| 3 | 💅 expected blank line between ENV and COPY |
+| 4 | 💅 expected blank line between COPY and RUN |
+| 4 | ℹ️ use cache mounts for package manager cache directories |
+| 5 | 💅 expected blank line between RUN and CMD |

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-without-development/report_1.snap.md
@@ -1,13 +1,2 @@
-note: 4 slow check(s) skipped (image not found)
-Fixed 2 issues
-Skipped 2 fixes
-**6 issues** in `<stdin>`
-
-| Line | Issue |
-|------|-------|
-| - | ℹ️ `HEALTHCHECK` instruction missing |
-| 3 | ⚠️ `COPY` to a relative destination without `WORKDIR` set |
-| 3 | 💅 expected blank line between ENV and COPY |
-| 4 | 💅 expected blank line between COPY and RUN |
-| 4 | ℹ️ use cache mounts for package manager cache directories |
-| 5 | 💅 expected blank line between RUN and CMD |
+Fixed 1 issues
+**No issues found**

--- a/internal/integration/fixtures/lint/ruby-missing-bundle-without-development/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-missing-bundle-without-development/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/missing-bundle-without-development"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-missing-bundle-without-development/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-missing-bundle-without-development/Dockerfile
@@ -1,0 +1,38 @@
+# Production-shaped stage running bundle install without BUNDLE_WITHOUT.
+# Canonical violation: development-group gems would ship into the image.
+FROM ruby:3.3-slim AS app
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# Compliant: ENV BUNDLE_WITHOUT explicitly excludes development. The
+# Rails generator template's exact wording.
+FROM ruby:3.3-slim AS app-compliant
+ENV RAILS_ENV="production"
+ENV BUNDLE_WITHOUT="development"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# Compliant: BUNDLE_WITHOUT covers BOTH dev and test groups.
+FROM ruby:3.3-slim AS app-compliant-both
+ENV BUNDLE_WITHOUT="development:test"
+RUN bundle install
+
+# Compliant via Bundler 2.5+ inverse selector.
+FROM ruby:3.3-slim AS app-only
+ENV BUNDLE_ONLY="default:production"
+RUN bundle install
+
+# Compliant: bundle config set --local without development before install.
+FROM ruby:3.3-slim AS app-config
+RUN bundle config set --local without development \
+    && bundle install
+
+# Stage explicitly marked dev: rule skips this on principle.
+FROM ruby:3.3-slim AS dev
+RUN bundle install
+
+# Stage explicit RAILS_ENV=development: rule demotes to silent.
+FROM ruby:3.3-slim AS app-explicit-dev
+ENV RAILS_ENV="development"
+RUN bundle install

--- a/internal/integration/fixtures/lint/ruby-missing-bundle-without-development/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-missing-bundle-without-development/result_1.snap.json
@@ -4,7 +4,7 @@
       "file": "fixtures/lint/ruby-missing-bundle-without-development/Dockerfile",
       "violations": [
         {
-          "detail": "Production stages that run `bundle install` should exclude the `development` gem group via `ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`). Otherwise gems like `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, and `bullet` ship into the production image, inflating size and exposing development-only attack surface (`web-console` in particular has documented RCE history when it leaks into production).",
+          "detail": "Production stages that run `bundle install` should exclude the `development` gem group via `ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`, or the Bundler 2.5+ inverse selector `ENV BUNDLE_ONLY=\"default:production\"`). Otherwise gems like `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, and `bullet` ship into the production image, inflating size and exposing development-only attack surface (`web-console` in particular has documented RCE history when it leaks into production).",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/missing-bundle-without-development/",
           "location": {
             "end": {

--- a/internal/integration/fixtures/lint/ruby-missing-bundle-without-development/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-missing-bundle-without-development/result_1.snap.json
@@ -1,0 +1,59 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-missing-bundle-without-development/Dockerfile",
+      "violations": [
+        {
+          "detail": "Production stages that run `bundle install` should exclude the `development` gem group via `ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`). Otherwise gems like `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, and `bullet` ship into the production image, inflating size and exposing development-only attack surface (`web-console` in particular has documented RCE history when it leaks into production).",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/missing-bundle-without-development/",
+          "location": {
+            "end": {
+              "column": 18,
+              "line": 6
+            },
+            "file": "fixtures/lint/ruby-missing-bundle-without-development/Dockerfile",
+            "start": {
+              "column": 11,
+              "line": 6
+            }
+          },
+          "message": "Production stage runs bundle install without BUNDLE_WITHOUT excluding the development group",
+          "rule": "tally/ruby/missing-bundle-without-development",
+          "severity": "warning",
+          "sourceCode": "RUN bundle install",
+          "suggestedFix": {
+            "description": "Add ENV BUNDLE_WITHOUT=\"development\" to exclude development gems from the production image",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 4
+                  },
+                  "file": "fixtures/lint/ruby-missing-bundle-without-development/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 4
+                  }
+                },
+                "newText": "ENV BUNDLE_WITHOUT=\"development\"\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 1,
+    "warnings": 1
+  }
+}

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -89,6 +89,24 @@ func lintCases(t *testing.T) []lintCase {
 			useContext: true,
 		},
 		{
+			// Context-aware refinement for tally/ruby/missing-bundle-without-development:
+			// Gemfile shows both :development and :test groups, so the fix should
+			// recommend `BUNDLE_WITHOUT="development:test"` (not just "development").
+			name:       "ruby-bundle-without-dev-and-test",
+			dir:        "ruby-bundle-without-dev-and-test",
+			args:       append([]string{"--format", "json"}, mustSelectRules("tally/ruby/missing-bundle-without-development")...),
+			wantExit:   1,
+			useContext: true,
+		},
+		{
+			// Context-aware refinement for tally/ruby/missing-bundle-without-development:
+			// Gemfile has no :development group, so the rule must suppress entirely.
+			name:       "ruby-bundle-without-no-dev-group",
+			dir:        "ruby-bundle-without-no-dev-group",
+			args:       append([]string{"--format", "json"}, mustSelectRules("tally/ruby/missing-bundle-without-development")...),
+			useContext: true,
+		},
+		{
 			name:  "discovery-directory",
 			dir:   "discovery-directory",
 			args:  append([]string{"--format", "json"}, mustSelectRules("tally/max-lines")...),

--- a/internal/integration/testdata/ruby-bundle-without-dev-and-test/Dockerfile
+++ b/internal/integration/testdata/ruby-bundle-without-dev-and-test/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/testdata/ruby-bundle-without-dev-and-test/Gemfile
+++ b/internal/integration/testdata/ruby-bundle-without-dev-and-test/Gemfile
@@ -1,0 +1,14 @@
+source "https://rubygems.org"
+
+ruby "3.3.5"
+
+gem "rails", "~> 8.0"
+gem "puma"
+
+group :development do
+  gem "web-console"
+end
+
+group :test do
+  gem "rspec-rails"
+end

--- a/internal/integration/testdata/ruby-bundle-without-no-dev-group/Dockerfile
+++ b/internal/integration/testdata/ruby-bundle-without-no-dev-group/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+CMD ["bin/cli"]

--- a/internal/integration/testdata/ruby-bundle-without-no-dev-group/Gemfile
+++ b/internal/integration/testdata/ruby-bundle-without-no-dev-group/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+ruby "3.3.5"
+
+gem "thor"
+gem "rake"

--- a/internal/rules/tally/ruby/missing_bundle_without_development.go
+++ b/internal/rules/tally/ruby/missing_bundle_without_development.go
@@ -149,7 +149,8 @@ func (r *MissingBundleWithoutDevelopmentRule) checkStage(
 
 func missingBundleWithoutDevelopmentDetail() string {
 	return "Production stages that run `bundle install` should exclude the `development` gem group via " +
-		"`ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`). " +
+		"`ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`, or " +
+		"the Bundler 2.5+ inverse selector `ENV BUNDLE_ONLY=\"default:production\"`). " +
 		"Otherwise gems like `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, and `bullet` ship " +
 		"into the production image, inflating size and exposing development-only attack surface " +
 		"(`web-console` in particular has documented RCE history when it leaks into production)."

--- a/internal/rules/tally/ruby/missing_bundle_without_development.go
+++ b/internal/rules/tally/ruby/missing_bundle_without_development.go
@@ -1,0 +1,403 @@
+package ruby
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// MissingBundleWithoutDevelopmentRuleCode is the full rule code.
+const MissingBundleWithoutDevelopmentRuleCode = rules.TallyRulePrefix + "ruby/missing-bundle-without-development"
+
+// missingBundleWithoutDevelopmentFixPriority keeps this rule's edits ordered
+// alongside the other Ruby/PHP production-hygiene rules. Same value as
+// jemalloc-installed-but-not-preloaded for predictable cross-rule sequencing.
+const missingBundleWithoutDevelopmentFixPriority = 88
+
+// productionRailsEnvKeys are the runtime-environment env vars that mark a
+// Dockerfile as production-shaped when set to "production".
+var productionRailsEnvKeys = []string{"RAILS_ENV", "RACK_ENV"}
+
+// developmentGroupToken is the Bundler group name that production images
+// must exclude. Matched as a substring of `BUNDLE_WITHOUT` (case-insensitive)
+// per the design doc — the rule does not opinion-fight on whether `test` is
+// also included.
+const developmentGroupToken = "development"
+
+// productionOnlyToken is the substring that signals `BUNDLE_ONLY` is scoping
+// the install to production gem groups (Bundler 2.5+ inverse selector). When
+// `BUNDLE_ONLY` carries this token, `BUNDLE_WITHOUT` is no longer required.
+const productionOnlyToken = "production"
+
+// MissingBundleWithoutDevelopmentRule flags production-shaped Ruby stages
+// that run `bundle install` without excluding the `development` gem group.
+type MissingBundleWithoutDevelopmentRule struct{}
+
+// NewMissingBundleWithoutDevelopmentRule creates the rule.
+func NewMissingBundleWithoutDevelopmentRule() *MissingBundleWithoutDevelopmentRule {
+	return &MissingBundleWithoutDevelopmentRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *MissingBundleWithoutDevelopmentRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            MissingBundleWithoutDevelopmentRuleCode,
+		Name:            "Production bundle install must exclude the development group",
+		Description:     "Production stage runs bundle install without BUNDLE_WITHOUT excluding the development group",
+		DocURL:          rules.TallyDocURL(MissingBundleWithoutDevelopmentRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "security",
+		FixPriority:     missingBundleWithoutDevelopmentFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *MissingBundleWithoutDevelopmentRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	// Refinement: when a Gemfile is observable and has no :development group,
+	// the `BUNDLE_WITHOUT="development"` recommendation is moot — there is
+	// nothing to exclude. Skip the rule entirely in that case so users with
+	// library-style or ops-tool Gemfiles do not see noise. When the Gemfile
+	// is not observable (Dockerfile-only mode) the rule applies.
+	if rubyFacts := input.Facts.RubyFacts(); rubyFacts != nil &&
+		rubyFacts.Gemfile != nil && !rubyFacts.Gemfile.HasDevGroup {
+		return nil
+	}
+
+	sm := input.SourceMap()
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+		if !stageLooksProduction(input, sf) {
+			continue
+		}
+		if stageHasBundleWithoutDevelopmentSignal(sf) {
+			continue
+		}
+		violations = append(violations, r.checkStage(input, sf, sm, meta)...)
+	}
+	return violations
+}
+
+func (r *MissingBundleWithoutDevelopmentRule) checkStage(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		install := findFirstBundleInstall(runFacts)
+		if install == nil {
+			continue
+		}
+		loc := bundleInstallViolationLocation(input.File, runFacts, *install, sm)
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(missingBundleWithoutDevelopmentDetail())
+		if fix := buildBundleWithoutDevelopmentFix(input, sf, sm, meta.FixPriority); fix != nil {
+			v = v.WithSuggestedFix(fix)
+		}
+		// Report once per stage even when the stage has multiple
+		// `bundle install` invocations — the missing ENV is a stage-level
+		// issue, not a per-RUN one.
+		return []rules.Violation{v}
+	}
+	return nil
+}
+
+func missingBundleWithoutDevelopmentDetail() string {
+	return "Production stages that run `bundle install` should exclude the `development` gem group via " +
+		"`ENV BUNDLE_WITHOUT=\"development\"` (or `bundle config set --local without development`). " +
+		"Otherwise gems like `web-console`, `byebug`, `pry`, `rspec-rails`, `letter_opener`, and `bullet` ship " +
+		"into the production image, inflating size and exposing development-only attack surface " +
+		"(`web-console` in particular has documented RCE history when it leaks into production)."
+}
+
+// stageLooksProduction reports whether the stage is shaped like a production
+// runtime per the missing-bundle-deployment heuristic:
+//
+//  1. The stage's effective env (or any inherited base stage's env) binds
+//     `RAILS_ENV` or `RACK_ENV` to "production" — strongest signal.
+//  2. Otherwise, fall through to "default production" — the rule already
+//     filters dev/test stages via `LooksLikeDev` and only fires on stages
+//     that look like Ruby runtimes, so a stage that has reached this point
+//     is implicitly production-shaped. This matches the missing-bundle-deployment
+//     fallback ("the stage has no explicit non-production marker and the
+//     final stage is shaped like an app runtime").
+//
+// Detection of an explicit non-production marker (e.g. `RAILS_ENV=development`
+// in the stage's effective env) demotes the rule to silent. This guards
+// against false positives on stages that explicitly opt out.
+func stageLooksProduction(input rules.LintInput, sf *facts.StageFacts) bool {
+	if sf == nil {
+		return false
+	}
+	// Explicit non-production markers in the stage's effective env demote
+	// the rule. Bundler treats `RAILS_ENV=production` as the runtime contract;
+	// a stage that explicitly sets `development`/`test` is, by definition,
+	// not production-shaped.
+	for _, key := range productionRailsEnvKeys {
+		value := strings.ToLower(strings.TrimSpace(envBoundValue(sf, key)))
+		if value == "development" || value == "test" {
+			return false
+		}
+	}
+	// File-wide RAILS_ENV/RACK_ENV=production anywhere is the strongest
+	// production signal.
+	for stageIdx := range input.Stages {
+		other := input.Facts.Stage(stageIdx)
+		if other == nil {
+			continue
+		}
+		for _, key := range productionRailsEnvKeys {
+			if envValueEqualsProduction(envBoundValue(other, key)) {
+				return true
+			}
+		}
+	}
+	// Default production-shape behaviour for any Ruby-runtime stage that
+	// has not been filtered out by `LooksLikeDev`. Per the design doc:
+	// "the stage has no explicit non-production marker and the final stage
+	// is shaped like an app runtime".
+	return true
+}
+
+func envValueEqualsProduction(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "production")
+}
+
+// stageHasBundleWithoutDevelopmentSignal reports whether the stage already
+// carries an env binding (or a `bundle config set` invocation) that excludes
+// the `development` gem group. Compliance is recognized when:
+//
+//   - `BUNDLE_WITHOUT` is set (via ENV) and contains "development"
+//     (case-insensitive substring), or
+//   - `BUNDLE_ONLY` is set (via ENV) and contains "production" (the Bundler
+//     2.5+ inverse selector that scopes the install to a positive set of
+//     groups), or
+//   - any RUN in this stage invokes `bundle config set [--local|--global] without ...`
+//     with a value containing "development".
+func stageHasBundleWithoutDevelopmentSignal(sf *facts.StageFacts) bool {
+	if sf == nil {
+		return false
+	}
+	if envValueContainsToken(envBoundValue(sf, "BUNDLE_WITHOUT"), developmentGroupToken) {
+		return true
+	}
+	if envValueContainsToken(envBoundValue(sf, "BUNDLE_ONLY"), productionOnlyToken) {
+		return true
+	}
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		if slices.ContainsFunc(runFacts.CommandInfos, bundleConfigSetExcludesDevelopment) {
+			return true
+		}
+	}
+	return false
+}
+
+// envValueContainsToken reports whether a Bundler env value contains the
+// supplied token as a substring (case-insensitive). Bundler accepts colon-,
+// space-, or comma-separated group lists; substring matching is sufficient
+// because the token names ("development", "production") do not appear inside
+// other meaningful group names.
+func envValueContainsToken(value, token string) bool {
+	if value == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(value), token)
+}
+
+// bundleConfigSetExcludesDevelopment reports whether a CommandInfo represents
+// a `bundle config set [--local|--global] without ...` invocation whose value
+// list contains "development".
+//
+// Recognized shapes (Bundler 2.x):
+//
+//	bundle config set without development
+//	bundle config set without 'development test'
+//	bundle config set --local without development:test
+//	bundle config set --global without development
+//	bundle config set --local without "development test"
+//
+// The legacy 2-arg form (`bundle config without development`) is intentionally
+// not recognized: Bundler 2 deprecated it in favor of `bundle config set ...`.
+func bundleConfigSetExcludesDevelopment(ci shell.CommandInfo) bool {
+	if !strings.EqualFold(ci.Name, "bundle") || !strings.EqualFold(ci.Subcommand, "config") {
+		return false
+	}
+	args := argsAfterFirstMatch(ci.Args, ci.Subcommand)
+	// Skip leading flags (`--local`, `--global`, ...).
+	for len(args) > 0 && strings.HasPrefix(args[0], "-") {
+		args = args[1:]
+	}
+	// Expect `set without <values...>`.
+	if len(args) < 3 {
+		return false
+	}
+	if !strings.EqualFold(args[0], "set") {
+		return false
+	}
+	withoutIdx := -1
+	for i, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		if strings.EqualFold(a, "without") {
+			withoutIdx = i + 1
+			break
+		}
+	}
+	if withoutIdx < 0 || withoutIdx+1 >= len(args) {
+		return false
+	}
+	for _, value := range args[withoutIdx+1:] {
+		if envValueContainsToken(value, developmentGroupToken) {
+			return true
+		}
+	}
+	return false
+}
+
+// argsAfterFirstMatch returns the slice of args that come after the first
+// case-insensitive occurrence of needle. Returns the original slice when no
+// match is found, which keeps callers' fallback paths simple.
+func argsAfterFirstMatch(args []string, needle string) []string {
+	for i, a := range args {
+		if strings.EqualFold(a, needle) {
+			return args[i+1:]
+		}
+	}
+	return args
+}
+
+// findFirstBundleInstall returns the first parsed `bundle install` command
+// in the run, or nil when none is present. We return the first match
+// because the rule reports once per stage and the violation location is
+// attributed to the first invocation.
+func findFirstBundleInstall(runFacts *facts.RunFacts) *shell.CommandInfo {
+	for i := range runFacts.CommandInfos {
+		ci := runFacts.CommandInfos[i]
+		if isBundleInstall(ci) {
+			return &runFacts.CommandInfos[i]
+		}
+	}
+	return nil
+}
+
+func isBundleInstall(ci shell.CommandInfo) bool {
+	return strings.EqualFold(ci.Name, "bundle") && strings.EqualFold(ci.Subcommand, "install")
+}
+
+// bundleInstallViolationLocation prefers the precise subcommand position
+// when available, falling back to the RUN's first range.
+func bundleInstallViolationLocation(
+	file string,
+	runFacts *facts.RunFacts,
+	cmd shell.CommandInfo,
+	sm *sourcemap.SourceMap,
+) rules.Location {
+	if runFacts == nil || runFacts.Run == nil {
+		return rules.NewFileLocation(file)
+	}
+	runRanges := runFacts.Run.Location()
+	if len(runRanges) == 0 {
+		return rules.NewFileLocation(file)
+	}
+	if cmd.SubcommandLine >= 0 && cmd.SubcommandStartCol >= 0 && cmd.SubcommandEndCol > cmd.SubcommandStartCol {
+		line := runRanges[0].Start.Line + cmd.SubcommandLine
+		startCol, endCol := cmd.SubcommandStartCol, cmd.SubcommandEndCol
+		if cmd.SubcommandLine == 0 && sm != nil {
+			offset := shell.DockerfileRunCommandStartCol(sm.Line(line - 1))
+			startCol += offset
+			endCol += offset
+		}
+		return rules.NewRangeLocation(file, line, startCol, line, endCol)
+	}
+	return rules.NewLocationFromRanges(file, runRanges)
+}
+
+// buildBundleWithoutDevelopmentFix emits the canonical Rails-generator-style
+// fix: insert `ENV BUNDLE_WITHOUT="..."` at the top of the stage. The exact
+// value depends on observable Gemfile state:
+//
+//   - both :development and :test groups present  → "development:test"
+//   - only :development present                   → "development"
+//   - Gemfile not observable                      → "development" (default)
+//
+// The insertion point is the line immediately after the stage's `FROM`,
+// matching the Rails 7.1 generator template's placement of `ENV BUNDLE_*`.
+// Insertion is zero-width at column 0 of that line, so it composes cleanly
+// with other rule edits in the same stage.
+func buildBundleWithoutDevelopmentFix(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	priority int,
+) *rules.SuggestedFix {
+	if sf == nil || sm == nil {
+		return nil
+	}
+	if sf.Index < 0 || sf.Index >= len(input.Stages) {
+		return nil
+	}
+	stage := input.Stages[sf.Index]
+	if len(stage.Location) == 0 {
+		return nil
+	}
+	insertLine := stage.Location[len(stage.Location)-1].End.Line + 1
+	value := chooseBundleWithoutValue(input)
+	return &rules.SuggestedFix{
+		Description: `Add ENV BUNDLE_WITHOUT="` + value + `" to exclude development gems from the production image`,
+		Safety:      rules.FixSafe,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
+			NewText:  `ENV BUNDLE_WITHOUT="` + value + "\"\n",
+		}},
+	}
+}
+
+// chooseBundleWithoutValue picks the BUNDLE_WITHOUT value the fix should
+// emit. When a Gemfile is observable and contains both `:development` and
+// `:test` groups, the recommendation is the broader `development:test`
+// exclusion so production images don't ship `rspec-rails`/`capybara`/etc.
+// either. Otherwise the canonical Rails-generator value `development`
+// applies.
+func chooseBundleWithoutValue(input rules.LintInput) string {
+	if rubyFacts := input.Facts.RubyFacts(); rubyFacts != nil && rubyFacts.Gemfile != nil {
+		if rubyFacts.Gemfile.HasDevGroup && rubyFacts.Gemfile.HasTestGroup {
+			return "development:test"
+		}
+	}
+	return "development"
+}
+
+func init() {
+	rules.Register(NewMissingBundleWithoutDevelopmentRule())
+}

--- a/internal/rules/tally/ruby/missing_bundle_without_development.go
+++ b/internal/rules/tally/ruby/missing_bundle_without_development.go
@@ -90,9 +90,6 @@ func (r *MissingBundleWithoutDevelopmentRule) Check(input rules.LintInput) []rul
 		if !stageLooksProduction(input, sf) {
 			continue
 		}
-		if stageHasBundleWithoutDevelopmentSignal(sf) {
-			continue
-		}
 		violations = append(violations, r.checkStage(input, sf, sm, meta)...)
 	}
 	return violations
@@ -104,12 +101,35 @@ func (r *MissingBundleWithoutDevelopmentRule) checkStage(
 	sm *sourcemap.SourceMap,
 	meta rules.RuleMetadata,
 ) []rules.Violation {
+	// Compliance is evaluated at each `bundle install` invocation, not
+	// at stage end. Docker `ENV` only affects subsequent instructions, and
+	// `bundle config set` only affects subsequent installs — so an
+	// `ENV BUNDLE_WITHOUT=development` (or `bundle config set ... without
+	// development`) that lands in a RUN *after* the install is too late.
+	configBeforeIdx := false
 	for _, runFacts := range sf.Runs {
 		if runFacts == nil {
 			continue
 		}
+		// Check whether *this* RUN already runs `bundle config set without
+		// development`. The signal fires for any later `bundle install` in
+		// the same stage, including one in a later RUN.
+		if !configBeforeIdx && runHasBundleConfigSetWithoutDevelopment(runFacts) {
+			configBeforeIdx = true
+		}
 		install := findFirstBundleInstall(runFacts)
 		if install == nil {
+			continue
+		}
+		// `runFacts.Env.Bindings` is the env *visible to this RUN*, so a
+		// later `ENV BUNDLE_WITHOUT=development` is correctly invisible
+		// here. Likewise `configBeforeIdx` is only true when an earlier RUN
+		// (or the same RUN, before the install on the parsed-command level)
+		// configured the exclusion.
+		if envFactsContainBundleWithoutDevelopmentSignal(runFacts.Env) {
+			continue
+		}
+		if configBeforeIdx || runConfiguresBundleWithoutDevelopmentBeforeInstall(runFacts, *install) {
 			continue
 		}
 		loc := bundleInstallViolationLocation(input.File, runFacts, *install, sm)
@@ -188,36 +208,73 @@ func envValueEqualsProduction(value string) bool {
 	return strings.EqualFold(strings.TrimSpace(value), "production")
 }
 
-// stageHasBundleWithoutDevelopmentSignal reports whether the stage already
-// carries an env binding (or a `bundle config set` invocation) that excludes
-// the `development` gem group. Compliance is recognized when:
-//
-//   - `BUNDLE_WITHOUT` is set (via ENV) and contains "development"
-//     (case-insensitive substring), or
-//   - `BUNDLE_ONLY` is set (via ENV) and contains "production" (the Bundler
-//     2.5+ inverse selector that scopes the install to a positive set of
-//     groups), or
-//   - any RUN in this stage invokes `bundle config set [--local|--global] without ...`
-//     with a value containing "development".
-func stageHasBundleWithoutDevelopmentSignal(sf *facts.StageFacts) bool {
-	if sf == nil {
-		return false
-	}
-	if envValueContainsToken(envBoundValue(sf, "BUNDLE_WITHOUT"), developmentGroupToken) {
-		return true
-	}
-	if envValueContainsToken(envBoundValue(sf, "BUNDLE_ONLY"), productionOnlyToken) {
-		return true
-	}
-	for _, runFacts := range sf.Runs {
-		if runFacts == nil {
-			continue
+// envFactsContainBundleWithoutDevelopmentSignal reports whether the env
+// snapshot at a RUN site already excludes the development group via
+// `BUNDLE_WITHOUT` or `BUNDLE_ONLY`. Unlike a stage-final check, this uses
+// the env state *visible to this RUN* — so an `ENV BUNDLE_WITHOUT=...` that
+// lands in a later RUN does not retroactively make the earlier install
+// compliant.
+func envFactsContainBundleWithoutDevelopmentSignal(env facts.EnvFacts) bool {
+	if envValueContainsToken(env.Values["BUNDLE_WITHOUT"], developmentGroupToken) {
+		// Only count the value when it was bound by an `ENV` instruction
+		// (not by a meta-ARG or other build-time-only mechanism).
+		if _, ok := env.Bindings["BUNDLE_WITHOUT"]; ok {
+			return true
 		}
-		if slices.ContainsFunc(runFacts.CommandInfos, bundleConfigSetExcludesDevelopment) {
+	}
+	if envValueContainsToken(env.Values["BUNDLE_ONLY"], productionOnlyToken) {
+		if _, ok := env.Bindings["BUNDLE_ONLY"]; ok {
 			return true
 		}
 	}
 	return false
+}
+
+// runHasBundleConfigSetWithoutDevelopment reports whether the RUN runs
+// `bundle config set [--local|--global] without ...development...` at all.
+// Used to mark the RUN's effect as "configured exclusion" so any subsequent
+// `bundle install` in the same stage (in this RUN or a later one) is
+// compliant.
+func runHasBundleConfigSetWithoutDevelopment(runFacts *facts.RunFacts) bool {
+	if runFacts == nil {
+		return false
+	}
+	return slices.ContainsFunc(runFacts.CommandInfos, bundleConfigSetExcludesDevelopment)
+}
+
+// runConfiguresBundleWithoutDevelopmentBeforeInstall reports whether the
+// same RUN invokes `bundle config set ... without ... development` at a
+// command position *before* the `bundle install`. The position check uses
+// the parsed CommandInfo source ranges — `bundle config set` and
+// `bundle install` chained with `&&` in the same RUN both yield ordered
+// CommandInfo entries.
+func runConfiguresBundleWithoutDevelopmentBeforeInstall(
+	runFacts *facts.RunFacts,
+	install shell.CommandInfo,
+) bool {
+	if runFacts == nil {
+		return false
+	}
+	for _, ci := range runFacts.CommandInfos {
+		if !bundleConfigSetExcludesDevelopment(ci) {
+			continue
+		}
+		if commandPrecedes(ci, install) {
+			return true
+		}
+	}
+	return false
+}
+
+// commandPrecedes reports whether command `a` appears before command `b`
+// in the parsed source script. Position comparison uses (Line, StartCol)
+// from each CommandInfo. Used to enforce ordering on shell-level command
+// chains within a single RUN.
+func commandPrecedes(a, b shell.CommandInfo) bool {
+	if a.Line != b.Line {
+		return a.Line < b.Line
+	}
+	return a.StartCol < b.StartCol
 }
 
 // envValueContainsToken reports whether a Bundler env value contains the

--- a/internal/rules/tally/ruby/missing_bundle_without_development_test.go
+++ b/internal/rules/tally/ruby/missing_bundle_without_development_test.go
@@ -67,6 +67,22 @@ RUN bundle install
 `,
 			WantViolations: 1,
 		},
+		{
+			Name: "ENV BUNDLE_WITHOUT after the install does NOT suppress (Docker ENV is forward-only)",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+ENV BUNDLE_WITHOUT="development"
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "bundle config set in a later RUN does NOT suppress an earlier install",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+RUN bundle config set --local without development
+`,
+			WantViolations: 1,
+		},
 		// --- Compliance: BUNDLE_WITHOUT contains "development" ---
 		{
 			Name: "ENV BUNDLE_WITHOUT=development suppresses",

--- a/internal/rules/tally/ruby/missing_bundle_without_development_test.go
+++ b/internal/rules/tally/ruby/missing_bundle_without_development_test.go
@@ -3,6 +3,7 @@ package ruby
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -489,7 +490,7 @@ func (m *mockRubyBuildContext) FileExists(p string) bool {
 func (m *mockRubyBuildContext) ReadFile(p string) ([]byte, error) {
 	content, ok := m.files[p]
 	if !ok {
-		return nil, fmt.Errorf("missing file %q", p)
+		return nil, fmt.Errorf("missing file %q: %w", p, fs.ErrNotExist)
 	}
 	return []byte(content), nil
 }
@@ -524,7 +525,12 @@ func TestMockRubyBuildContext_ReadFileMissing(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
-	if !errors.Is(err, err) {
-		t.Fatal("error wrapping is broken — sanity check failed")
+	// Rule code uses errors.Is(err, fs.ErrNotExist) on read errors
+	// (via `if errors.Is(err, fs.ErrNotExist)` in the upstream
+	// internal/context.BuildContext) — verify the mock returns a
+	// fs.ErrNotExist-compatible error so context-aware tests don't
+	// accidentally pass with a different sentinel.
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("mock ReadFile error should match fs.ErrNotExist; got %v", err)
 	}
 }

--- a/internal/rules/tally/ruby/missing_bundle_without_development_test.go
+++ b/internal/rules/tally/ruby/missing_bundle_without_development_test.go
@@ -1,0 +1,514 @@
+package ruby
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestMissingBundleWithoutDevelopmentRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewMissingBundleWithoutDevelopmentRule().Metadata()
+	if meta.Code != MissingBundleWithoutDevelopmentRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, MissingBundleWithoutDevelopmentRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityWarning {
+		t.Errorf("DefaultSeverity = %v, want Warning", meta.DefaultSeverity)
+	}
+	if meta.Category != "security" {
+		t.Errorf("Category = %q, want %q", meta.Category, "security")
+	}
+	if meta.FixPriority != missingBundleWithoutDevelopmentFixPriority {
+		t.Errorf("FixPriority = %d, want %d", meta.FixPriority, missingBundleWithoutDevelopmentFixPriority)
+	}
+	if !strings.HasPrefix(meta.DocURL, "https://tally.wharflab.com/rules/tally/ruby/") {
+		t.Errorf("DocURL = %q, want tally/ruby/ prefix", meta.DocURL)
+	}
+}
+
+func TestMissingBundleWithoutDevelopmentRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewMissingBundleWithoutDevelopmentRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "ruby base running bundle install without BUNDLE_WITHOUT triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "shell-form bundle install with extra flags triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install --jobs=4 --retry=3
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "BUNDLE_WITHOUT set without 'development' still triggers",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_WITHOUT="test"
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "BUNDLE_ONLY set to 'default' (no production) still triggers",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_ONLY="default"
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: BUNDLE_WITHOUT contains "development" ---
+		{
+			Name: "ENV BUNDLE_WITHOUT=development suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_WITHOUT="development"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ENV BUNDLE_WITHOUT=development:test suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_WITHOUT="development:test"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ENV BUNDLE_WITHOUT case-insensitive suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_WITHOUT="Development"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ENV BUNDLE_WITHOUT space-separated suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_WITHOUT="development test"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ENV BUNDLE_WITHOUT comma-separated suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_WITHOUT="development,test,assets"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: BUNDLE_ONLY=production (Bundler 2.5+ inverse) ---
+		{
+			Name: "ENV BUNDLE_ONLY=default:production suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_ONLY="default:production"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ENV BUNDLE_ONLY=production suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_ONLY="production"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: bundle config set --local without development ---
+		{
+			Name: "bundle config set --local without development suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle config set --local without 'development test' && bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bundle config set --global without development suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle config set --global without development \
+    && bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bundle config set without (no flag) development suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle config set without development
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bundle config set without colon list suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle config set --local without development:test
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// Legacy 2-arg `bundle config without development` (no `set`) is NOT
+		// recognized — Bundler 2 deprecated it.
+		{
+			Name: "legacy bundle config without (no set) does not suppress",
+			Content: `FROM ruby:3.3-slim
+RUN bundle config without development
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Inheritance ---
+		{
+			Name: "BUNDLE_WITHOUT in parent stage inherited via FROM <stage> suppresses",
+			Content: `FROM ruby:3.3-slim AS builder
+ENV BUNDLE_WITHOUT="development"
+
+FROM builder AS final
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Guardrails: dev/test stages skipped ---
+		{
+			Name: "stage named dev skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "stage named test skipped",
+			Content: `FROM ruby:3.3-slim AS test
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "stage named development skipped",
+			Content: `FROM ruby:3.3-slim AS development
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "stage named ci skipped",
+			Content: `FROM ruby:3.3-slim AS ci
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "stage with explicit RAILS_ENV=development demoted",
+			Content: `FROM ruby:3.3-slim
+ENV RAILS_ENV="development"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "stage with explicit RACK_ENV=test demoted",
+			Content: `FROM ruby:3.3-slim
+ENV RACK_ENV="test"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Guardrails: non-Ruby stages out of scope ---
+		{
+			Name: "python image running bundle install (false positive guard)",
+			Content: `FROM python:3.12-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "node image running bundle install is not a Ruby concern",
+			Content: `FROM node:20
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Guardrails: Windows ---
+		{
+			Name: "windows base skipped",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- No bundle install, no violation ---
+		{
+			Name: "no bundle install in stage",
+			Content: `FROM ruby:3.3-slim
+RUN echo hello
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bundle exec rake (not install) does not trigger",
+			Content: `FROM ruby:3.3-slim
+RUN bundle exec rake assets:precompile
+`,
+			WantViolations: 0,
+		},
+		// --- Multiple bundle installs in one stage report once ---
+		{
+			Name: "multiple bundle installs in one stage report once",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+RUN bundle install --redownload
+`,
+			WantViolations: 1,
+		},
+		// --- Multi-stage: each non-dev Ruby stage with bundle install fires ---
+		{
+			Name: "multi-stage: builder + final both fire (no shared env)",
+			Content: `FROM ruby:3.3-slim AS builder
+RUN bundle install
+
+FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 2,
+		},
+		{
+			Name: "multi-stage: builder fires, final compliant",
+			Content: `FROM ruby:3.3-slim AS builder
+RUN bundle install
+
+FROM ruby:3.3-slim
+ENV BUNDLE_WITHOUT="development"
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Production env signal (RAILS_ENV elsewhere does not save it) ---
+		{
+			Name: "RAILS_ENV=production elsewhere does not suppress missing BUNDLE_WITHOUT",
+			Content: `FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+	})
+}
+
+// Refinement: when Gemfile is observable and lacks :development, the rule
+// must suppress the entire fire (library-style projects).
+func TestMissingBundleWithoutDevelopmentRule_GemfileNoDevGroupSuppresses(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN bundle install\n"
+	ctx := newMockRubyBuildContext(map[string]string{
+		"Gemfile": "source \"https://rubygems.org\"\ngem \"rake\"\n",
+	})
+	input := testutil.MakeLintInputWithContext(t, "Dockerfile", content, ctx)
+	violations := NewMissingBundleWithoutDevelopmentRule().Check(input)
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations when Gemfile has no :development group, got %d", len(violations))
+	}
+}
+
+// Refinement: when Gemfile has :development AND :test, the fix recommends
+// `development:test` so the production image also drops test gems.
+func TestMissingBundleWithoutDevelopmentRule_FixUsesDevelopmentTestWhenBothGroupsPresent(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN bundle install\n"
+	gemfile := `source "https://rubygems.org"
+
+gem "rails"
+
+group :development do
+  gem "web-console"
+end
+
+group :test do
+  gem "rspec-rails"
+end
+`
+	ctx := newMockRubyBuildContext(map[string]string{"Gemfile": gemfile})
+	input := testutil.MakeLintInputWithContext(t, "Dockerfile", content, ctx)
+	violations := NewMissingBundleWithoutDevelopmentRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if fix.Safety != rules.FixSafe {
+		t.Errorf("Safety = %v, want FixSafe", fix.Safety)
+	}
+	if len(fix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	}
+	want := `ENV BUNDLE_WITHOUT="development:test"`
+	if !strings.Contains(fix.Edits[0].NewText, want) {
+		t.Errorf("fix text missing %q, got %q", want, fix.Edits[0].NewText)
+	}
+}
+
+// Refinement: when Gemfile has only :development (no :test), the fix uses
+// `development` (the canonical Rails-generator value).
+func TestMissingBundleWithoutDevelopmentRule_FixUsesDevelopmentOnlyWhenTestGroupAbsent(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN bundle install\n"
+	gemfile := `source "https://rubygems.org"
+
+gem "rails"
+
+group :development do
+  gem "web-console"
+end
+`
+	ctx := newMockRubyBuildContext(map[string]string{"Gemfile": gemfile})
+	input := testutil.MakeLintInputWithContext(t, "Dockerfile", content, ctx)
+	violations := NewMissingBundleWithoutDevelopmentRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if !strings.Contains(fix.Edits[0].NewText, `ENV BUNDLE_WITHOUT="development"`) {
+		t.Errorf("fix text missing canonical value, got %q", fix.Edits[0].NewText)
+	}
+	if strings.Contains(fix.Edits[0].NewText, "development:test") {
+		t.Errorf("fix should not include :test when test group absent, got %q", fix.Edits[0].NewText)
+	}
+}
+
+// Default fix: when no Gemfile is observable, the fix uses `development`.
+func TestMissingBundleWithoutDevelopmentRule_FixDefaultWithoutGemfile(t *testing.T) {
+	t.Parallel()
+
+	content := "FROM ruby:3.3-slim\nRUN bundle install\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewMissingBundleWithoutDevelopmentRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	fix := violations[0].SuggestedFix
+	if fix == nil {
+		t.Fatal("expected SuggestedFix")
+	}
+	if fix.Safety != rules.FixSafe {
+		t.Errorf("Safety = %v, want FixSafe", fix.Safety)
+	}
+	if !fix.IsPreferred {
+		t.Errorf("expected IsPreferred = true")
+	}
+	if fix.Priority != missingBundleWithoutDevelopmentFixPriority {
+		t.Errorf("Priority = %d, want %d", fix.Priority, missingBundleWithoutDevelopmentFixPriority)
+	}
+	if len(fix.Edits) != 1 {
+		t.Fatalf("expected 1 edit, got %d", len(fix.Edits))
+	}
+	edit := fix.Edits[0]
+	// Fix anchor: line immediately after the FROM (line 2).
+	if edit.Location.Start.Line != 2 || edit.Location.End.Line != 2 {
+		t.Errorf("edit location = %+v, want line 2", edit.Location)
+	}
+	if edit.Location.Start.Column != 0 || edit.Location.End.Column != 0 {
+		t.Errorf("edit location columns = (%d,%d), want (0,0) (zero-width insert)",
+			edit.Location.Start.Column, edit.Location.End.Column)
+	}
+	want := `ENV BUNDLE_WITHOUT="development"` + "\n"
+	if edit.NewText != want {
+		t.Errorf("NewText = %q, want %q", edit.NewText, want)
+	}
+}
+
+// Even though the file uses RAILS_ENV=production, when the Gemfile shows no
+// :development group the rule still suppresses entirely.
+func TestMissingBundleWithoutDevelopmentRule_GemfileSuppressesEvenWithProductionRailsEnv(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+RUN bundle install
+`
+	ctx := newMockRubyBuildContext(map[string]string{
+		"Gemfile": "source \"https://rubygems.org\"\ngem \"rake\"\n",
+	})
+	input := testutil.MakeLintInputWithContext(t, "Dockerfile", content, ctx)
+	violations := NewMissingBundleWithoutDevelopmentRule().Check(input)
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations when Gemfile has no :development group, got %d", len(violations))
+	}
+}
+
+// --- Helpers ---
+
+// mockRubyBuildContext is a minimal facts.ContextFileReader for tests that
+// exercise the Gemfile-aware refinements. Only `FileExists`/`ReadFile` need
+// to be backed by data; `IsIgnored` always returns false.
+type mockRubyBuildContext struct {
+	files map[string]string
+}
+
+func newMockRubyBuildContext(files map[string]string) *mockRubyBuildContext {
+	return &mockRubyBuildContext{files: files}
+}
+
+func (m *mockRubyBuildContext) FileExists(p string) bool {
+	_, ok := m.files[p]
+	return ok
+}
+
+func (m *mockRubyBuildContext) ReadFile(p string) ([]byte, error) {
+	content, ok := m.files[p]
+	if !ok {
+		return nil, fmt.Errorf("missing file %q", p)
+	}
+	return []byte(content), nil
+}
+
+func (m *mockRubyBuildContext) IsIgnored(string) (bool, error) {
+	return false, nil
+}
+
+// PathExists is required by the broader BuildContext surface; satisfied so
+// tests that pass mockRubyBuildContext through MakeLintInputWithContext do
+// not break on interface upgrades.
+func (m *mockRubyBuildContext) PathExists(p string) bool {
+	return m.FileExists(p)
+}
+
+// IsHeredocFile is required by the broader BuildContext surface for
+// COPY/ADD-from-heredoc handling; satisfied with a no-op for these tests.
+func (m *mockRubyBuildContext) IsHeredocFile(string) bool {
+	return false
+}
+
+// Compile-time check that the mock satisfies the facts.ContextFileReader
+// interface.
+var _ facts.ContextFileReader = (*mockRubyBuildContext)(nil)
+
+// Sanity check: when an explicit unrelated error path is hit, the test
+// helper does not silently treat it as "file not present".
+func TestMockRubyBuildContext_ReadFileMissing(t *testing.T) {
+	t.Parallel()
+	ctx := newMockRubyBuildContext(map[string]string{"a": "x"})
+	_, err := ctx.ReadFile("b")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, err) {
+		t.Fatal("error wrapping is broken — sanity check failed")
+	}
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/missing-bundle-without-development`](https://tally.wharflab.com/rules/tally/ruby/missing-bundle-without-development/) — Section 4.1 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

A production-shaped Ruby stage that runs `bundle install` without `BUNDLE_WITHOUT="development"` ships dev-only gems (`web-console`, `byebug`, `pry`, `rspec-rails`, …) into the production image. Beyond bloat, `web-console` has documented RCE history when leaked. The Rails generator template carries `ENV BUNDLE_WITHOUT="development"` for exactly this reason; only 41 of 196 Dockerfiles in the corpus do.

- **Compliance signals:** `ENV BUNDLE_WITHOUT=…development…`, `ENV BUNDLE_ONLY=…production…` (Bundler 2.5+ inverse selector), or a `bundle config set [--local|--global] without …development…` invocation in the same stage.
- **Suppressions:** dev/test/ci stages by name, stages binding `RAILS_ENV`/`RACK_ENV` to `development` or `test`, non-Ruby stages.
- **Context-aware refinements:**
  - If `Gemfile` is observable and has no `:development` group, the rule suppresses entirely.
  - If `Gemfile` shows both `:development` and `:test` groups, the auto-fix emits `BUNDLE_WITHOUT="development:test"` instead of the default `"development"`.
- **Auto-fix:** `FixSafe`. Inserts `ENV BUNDLE_WITHOUT="..."` on the line immediately after the stage's `FROM`.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint and fix fixtures: `internal/integration/fixtures/{lint,fix}/ruby-missing-bundle-without-development/`
- [x] Context-aware fixtures: `internal/integration/testdata/ruby-bundle-without-{dev-and-test,no-dev-group}/`