### PR TITLE
feat(rules): add tally/ruby/asset-precompile-without-dummy-key

### DIFF
--- a/_docs/rules/tally/ruby/asset-precompile-without-dummy-key.mdx
+++ b/_docs/rules/tally/ruby/asset-precompile-without-dummy-key.mdx
@@ -8,10 +8,10 @@ Rails `assets:precompile` runs without `SECRET_KEY_BASE_DUMMY=1`, which pushes u
 
 | Property | Value |
 |----------|-------|
-| Severity | Warning (Rails 7.1+) / Suggestion (older Rails) |
+| Severity | Warning (default) / Info (no observable Rails credentials in the build context) |
 | Category | Security |
 | Default | Enabled |
-| Auto-fix | Yes (FixSafe — Rails 7.1+) |
+| Auto-fix | Yes — `FixSafe` on Rails 7.1+, `FixSuggestion` on older Rails |
 
 ## Description
 

--- a/_docs/rules/tally/ruby/asset-precompile-without-dummy-key.mdx
+++ b/_docs/rules/tally/ruby/asset-precompile-without-dummy-key.mdx
@@ -1,0 +1,120 @@
+---
+title: "tally/ruby/asset-precompile-without-dummy-key"
+description: "Rails `assets:precompile` runs without `SECRET_KEY_BASE_DUMMY=1`, forcing real secrets into image history."
+---
+
+Rails `assets:precompile` runs without `SECRET_KEY_BASE_DUMMY=1`, which pushes users toward baking
+`RAILS_MASTER_KEY` (or a real `SECRET_KEY_BASE`) into image history.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning (Rails 7.1+) / Suggestion (older Rails) |
+| Category | Security |
+| Default | Enabled |
+| Auto-fix | Yes (FixSafe — Rails 7.1+) |
+
+## Description
+
+Rails 7.1 added `SECRET_KEY_BASE_DUMMY=1` so that `bin/rails assets:precompile` can run at build time without
+a real `secret_key_base` and without `RAILS_MASTER_KEY`. Without this placeholder, projects are pushed toward
+exactly the wrong workaround: passing `RAILS_MASTER_KEY` (or a real `SECRET_KEY_BASE`) into the build via
+`ARG`/`ENV`, which bakes the secret into the image's per-layer history. Anyone who can pull the image can then
+read `docker history --no-trunc <image>` and recover the secret.
+
+The Rails generator template runs:
+
+```dockerfile
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+```
+
+…and explicitly comments that this avoids requiring the real master key at build time. This rule fires when a
+Ruby-shaped stage runs one of:
+
+- `rails assets:precompile`
+- `bin/rails assets:precompile`
+- `bundle exec rake assets:precompile`
+- `rake assets:precompile`
+
+…and that same `RUN` does **not** set `SECRET_KEY_BASE_DUMMY=1` and does **not** set `SECRET_KEY_BASE=1`
+(which Rails accepts as the placeholder contract too). Stage-level `ENV SECRET_KEY_BASE_DUMMY=1` (or
+`SECRET_KEY_BASE=1`) set before the offending RUN also satisfies the rule.
+
+A BuildKit secret-mount-driven precompile is the supported alternative path:
+
+```dockerfile
+RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY \
+    bin/rails assets:precompile
+```
+
+The rule recognizes this shape and stays silent. The secret is exposed only inside that one `RUN` and never
+reaches the image cache key.
+
+Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug` are skipped, as are
+non-Ruby and Windows-based stages.
+
+### Context-aware refinements
+
+When tally is invoked with `--context` (or via Bake/Compose), the rule consults the project's `Gemfile`,
+`Gemfile.lock`, and `config/credentials*.yml.enc` files to sharpen its behavior:
+
+- **Rails-version gating.** The Rails 7.1 release note that introduced `SECRET_KEY_BASE_DUMMY=1` doesn't
+  apply to older Rails. If `Gemfile.lock` shows Rails `< 7.1`, the rule's auto-fix demotes from `FixSafe` to
+  a `FixSuggestion` and the wording recommends the BuildKit secret-mount path
+  (`RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY`) instead of the dummy constant. The
+  violation still fires.
+- **Severity demotion when credentials aren't used.** If neither `config/credentials.yml.enc` nor any
+  `config/credentials/<env>.yml.enc` file exists in the build context, the rule's severity demotes from
+  `warning` to `info`: the dummy key is hygiene rather than a hard correctness fix when the project doesn't
+  use Rails encrypted credentials at all.
+
+When the build context is unobservable (Dockerfile-only mode), the rule applies with default severity and
+emits the Rails 7.1+ fix.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim AS app
+COPY . .
+RUN bin/rails assets:precompile
+CMD ["bin/rails", "server"]
+```
+
+### After
+
+The Rails-generator-style fix prepends `SECRET_KEY_BASE_DUMMY=1` directly to the offending command:
+
+```dockerfile
+FROM ruby:3.3-slim AS app
+COPY . .
+RUN SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile
+CMD ["bin/rails", "server"]
+```
+
+For projects on Rails &lt; 7.1, the recommended alternative is BuildKit secret mounts:
+
+```dockerfile
+RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY \
+    bin/rails assets:precompile
+```
+
+This is also the right shape for any Rails version when the precompile genuinely needs the master key
+(for example, decrypting per-environment configuration during the asset build).
+
+## Auto-fix
+
+On Rails 7.1+ projects (and in Dockerfile-only mode), the rule offers a `FixSafe` that prepends
+`SECRET_KEY_BASE_DUMMY=1` directly to the offending command in the same `RUN`. The fix preserves any
+chained commands (`&&`/`;`) and any continuation lines.
+
+When tally observes `Gemfile.lock` showing Rails older than 7.1, the auto-fix demotes to `FixSuggestion`
+and recommends the BuildKit secret-mount path instead. The user is expected to wire `--secret` into their
+build invocation explicitly.
+
+## References
+
+- [Rails 7.1 release notes — `assets:precompile` no longer requires credentials](https://guides.rubyonrails.org/7_1_release_notes.html#assets-precompile-no-longer-requires-credentials)
+- [Rails security guide — environmental security](https://guides.rubyonrails.org/security.html#environmental-security)
+- [Rails Dockerfile generator template](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt)
+- [BuildKit `RUN --mount=type=secret` documentation](https://docs.docker.com/build/building/secrets/)

--- a/internal/facts/ruby/facts.go
+++ b/internal/facts/ruby/facts.go
@@ -31,6 +31,18 @@ type RubyFacts struct {
 	//
 	// Empty when none of the sources yield a value.
 	RubyVersion string
+
+	// HasEncryptedCredentials reports whether the project ships any of the
+	// canonical Rails encrypted-credentials files (config/credentials.yml.enc
+	// or config/credentials/<env>.yml.enc for one of the standard envs).
+	// Rules that need to know whether RAILS_MASTER_KEY is actually load-bearing
+	// at build time (e.g. asset-precompile-without-dummy-key) consult this.
+	HasEncryptedCredentials bool
+
+	// EncryptedCredentialsPaths records the observed credentials files in the
+	// build context. Order matches the probe order. Empty when no credentials
+	// files are observable.
+	EncryptedCredentialsPaths []string
 }
 
 // ContextFileReader is the minimal subset of internal/context.BuildContext
@@ -53,12 +65,25 @@ type ContextFileReader interface {
 
 // Standard project-root paths the loader inspects. Using slashes matches the
 // build context's path semantics across operating systems.
+//
+// The credentialsEnc* names are file paths the loader probes with
+// FileExists, not secret material — gosec G101 false-positives on the
+// "credentials" substring.
 const (
-	gemfileLockPath  = "Gemfile.lock"
-	gemfilePath      = "Gemfile"
-	rubyVersionPath  = ".ruby-version"
-	toolVersionsPath = ".tool-versions"
+	gemfileLockPath              = "Gemfile.lock"
+	gemfilePath                  = "Gemfile"
+	rubyVersionPath              = ".ruby-version"
+	toolVersionsPath             = ".tool-versions"
+	credentialsEncFilePath       = "config/credentials.yml.enc" // #nosec G101 -- file path, not a secret
+	credentialsEncEnvDirPath     = "config/credentials"         // #nosec G101 -- directory path, not a secret
+	credentialsEncFilenameSuffix = ".yml.enc"                   // #nosec G101 -- filename suffix, not a secret
 )
+
+// credentialsEncEnvNames is the curated list of Rails environments whose
+// per-env encrypted credentials file we probe. Rails ships `production`,
+// `development`, and `test` by default; `staging` is the most common
+// custom env we see in the corpus.
+var credentialsEncEnvNames = []string{"production", "development", "test", "staging"}
 
 // Load reads the four well-known Ruby project files from the build context
 // and returns parsed RubyFacts. A nil reader yields a non-nil RubyFacts with
@@ -81,7 +106,49 @@ func Load(reader ContextFileReader) *RubyFacts {
 		facts.Gemfile = ParseGemfile(data)
 	}
 	facts.RubyVersion = resolveRubyVersion(reader, facts.Lockfile)
+	facts.EncryptedCredentialsPaths = probeEncryptedCredentials(reader)
+	facts.HasEncryptedCredentials = len(facts.EncryptedCredentialsPaths) > 0
 	return facts
+}
+
+// probeEncryptedCredentials returns every observable Rails encrypted-credentials
+// file in the build context. Both the canonical single-file form
+// (`config/credentials.yml.enc`) and the per-environment form
+// (`config/credentials/<env>.yml.enc`) are supported. Paths returned by this
+// function pass the .dockerignore filter — i.e. they are observable to the
+// build process.
+func probeEncryptedCredentials(reader ContextFileReader) []string {
+	if reader == nil {
+		return nil
+	}
+	candidates := make([]string, 0, 1+len(credentialsEncEnvNames))
+	candidates = append(candidates, credentialsEncFilePath)
+	for _, env := range credentialsEncEnvNames {
+		candidates = append(candidates, credentialsEncEnvDirPath+"/"+env+credentialsEncFilenameSuffix)
+	}
+	var found []string
+	for _, candidate := range candidates {
+		if !contextFileObservable(reader, candidate) {
+			continue
+		}
+		found = append(found, candidate)
+	}
+	return found
+}
+
+// contextFileObservable reports whether path resolves to a regular file in
+// the build context that is not excluded by .dockerignore. Read errors are
+// treated as "not observable" so rules degrade gracefully when the build
+// context cannot answer.
+func contextFileObservable(reader ContextFileReader, path string) bool {
+	if reader == nil {
+		return false
+	}
+	ignored, err := reader.IsIgnored(path)
+	if err != nil || ignored {
+		return false
+	}
+	return reader.FileExists(path)
 }
 
 // resolveRubyVersion picks the highest-priority Ruby version available.

--- a/internal/facts/ruby/facts_test.go
+++ b/internal/facts/ruby/facts_test.go
@@ -207,6 +207,79 @@ func TestLoad_ReadErrorsTreatedAsAbsent(t *testing.T) {
 	}
 }
 
+func TestLoad_EncryptedCredentials_NotPresent(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeReader{files: map[string][]byte{}}
+	facts := Load(reader)
+
+	if facts.HasEncryptedCredentials {
+		t.Errorf("HasEncryptedCredentials = true, want false")
+	}
+	if len(facts.EncryptedCredentialsPaths) != 0 {
+		t.Errorf("EncryptedCredentialsPaths = %v, want empty", facts.EncryptedCredentialsPaths)
+	}
+}
+
+func TestLoad_EncryptedCredentials_RootFile(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeReader{
+		files: map[string][]byte{
+			credentialsEncFilePath: []byte("encrypted-blob"),
+		},
+	}
+	facts := Load(reader)
+
+	if !facts.HasEncryptedCredentials {
+		t.Errorf("HasEncryptedCredentials = false, want true")
+	}
+	if got, want := len(facts.EncryptedCredentialsPaths), 1; got != want {
+		t.Fatalf("len(EncryptedCredentialsPaths) = %d, want %d", got, want)
+	}
+	if facts.EncryptedCredentialsPaths[0] != credentialsEncFilePath {
+		t.Errorf("EncryptedCredentialsPaths[0] = %q, want %q",
+			facts.EncryptedCredentialsPaths[0], credentialsEncFilePath)
+	}
+}
+
+func TestLoad_EncryptedCredentials_PerEnvironment(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeReader{
+		files: map[string][]byte{
+			"config/credentials/production.yml.enc": []byte("encrypted-blob"),
+			"config/credentials/staging.yml.enc":    []byte("encrypted-blob"),
+		},
+	}
+	facts := Load(reader)
+
+	if !facts.HasEncryptedCredentials {
+		t.Errorf("HasEncryptedCredentials = false, want true")
+	}
+	if len(facts.EncryptedCredentialsPaths) != 2 {
+		t.Errorf("EncryptedCredentialsPaths = %v, want 2 entries",
+			facts.EncryptedCredentialsPaths)
+	}
+}
+
+func TestLoad_EncryptedCredentials_DockerignoredSkipped(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeReader{
+		files: map[string][]byte{
+			credentialsEncFilePath: []byte("encrypted-blob"),
+		},
+		ignored: map[string]bool{
+			credentialsEncFilePath: true,
+		},
+	}
+	facts := Load(reader)
+	if facts.HasEncryptedCredentials {
+		t.Errorf("HasEncryptedCredentials = true, want false (file is .dockerignored)")
+	}
+}
+
 func TestExtractRubyVersionFromLockfile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/__snapshots__/TestLint_ruby-asset-precompile-no-credentials_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-asset-precompile-no-credentials_1.snap.json
@@ -1,0 +1,59 @@
+{
+  "files": [
+    {
+      "file": "testdata/ruby-asset-precompile-no-credentials/Dockerfile",
+      "violations": [
+        {
+          "detail": "This build context does not appear to ship a Rails encrypted-credentials file (`config/credentials.yml.enc` or `config/credentials/\u003cenv\u003e.yml.enc`), so the dummy key is just hygiene — but still recommended for image-cache reproducibility. Prepend `SECRET_KEY_BASE_DUMMY=1` to the asset-precompile command so future credential rollouts don't bake `RAILS_MASTER_KEY` into image history.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/asset-precompile-without-dummy-key/",
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 3
+            },
+            "file": "testdata/ruby-asset-precompile-no-credentials/Dockerfile",
+            "start": {
+              "column": 14,
+              "line": 3
+            }
+          },
+          "message": "Rails assets:precompile runs without SECRET_KEY_BASE_DUMMY=1, which forces RAILS_MASTER_KEY into image history",
+          "rule": "tally/ruby/asset-precompile-without-dummy-key",
+          "severity": "info",
+          "sourceCode": "RUN bin/rails assets:precompile",
+          "suggestedFix": {
+            "description": "Prepend SECRET_KEY_BASE_DUMMY=1 to the assets:precompile command so the build never needs RAILS_MASTER_KEY",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 4,
+                    "line": 3
+                  },
+                  "file": "testdata/ruby-asset-precompile-no-credentials/Dockerfile",
+                  "start": {
+                    "column": 4,
+                    "line": 3
+                  }
+                },
+                "newText": "SECRET_KEY_BASE_DUMMY=1 "
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_ruby-asset-precompile-rails-old_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-asset-precompile-rails-old_1.snap.json
@@ -1,0 +1,43 @@
+{
+  "files": [
+    {
+      "file": "testdata/ruby-asset-precompile-rails-old/Dockerfile",
+      "violations": [
+        {
+          "detail": "Rails 7.0.8 predates SECRET_KEY_BASE_DUMMY (added in Rails 7.1). Pass RAILS_MASTER_KEY through a BuildKit secret mount (`--mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY`) or set SECRET_KEY_BASE to a random ephemeral value for this build so neither secret ends up in image history.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/asset-precompile-without-dummy-key/",
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 3
+            },
+            "file": "testdata/ruby-asset-precompile-rails-old/Dockerfile",
+            "start": {
+              "column": 14,
+              "line": 3
+            }
+          },
+          "message": "Rails assets:precompile runs without SECRET_KEY_BASE_DUMMY=1, which forces RAILS_MASTER_KEY into image history",
+          "rule": "tally/ruby/asset-precompile-without-dummy-key",
+          "severity": "info",
+          "sourceCode": "RUN bin/rails assets:precompile",
+          "suggestedFix": {
+            "description": "Pass RAILS_MASTER_KEY via a BuildKit secret mount (Rails \u003c 7.1 does not honor SECRET_KEY_BASE_DUMMY)",
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/integration/fixtures/fix/ruby-asset-precompile-without-dummy-key/.tally.toml
+++ b/internal/integration/fixtures/fix/ruby-asset-precompile-without-dummy-key/.tally.toml
@@ -1,0 +1,9 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/asset-precompile-without-dummy-key"]
+exclude = ["*"]
+
+[output]
+fail-level = "none"

--- a/internal/integration/fixtures/fix/ruby-asset-precompile-without-dummy-key/Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-asset-precompile-without-dummy-key/Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.3-slim
+COPY . .
+RUN bin/rails assets:precompile
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-asset-precompile-without-dummy-key/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-asset-precompile-without-dummy-key/fixed_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.3-slim
+COPY . .
+RUN SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-asset-precompile-without-dummy-key/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-asset-precompile-without-dummy-key/report_1.snap.md
@@ -1,0 +1,2 @@
+Fixed 1 issues
+**No issues found**

--- a/internal/integration/fixtures/lint/ruby-asset-precompile-without-dummy-key/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-asset-precompile-without-dummy-key/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/asset-precompile-without-dummy-key"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-asset-precompile-without-dummy-key/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-asset-precompile-without-dummy-key/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+# Build stage: invokes assets:precompile without the dummy key. The rule
+# fires here because the stage is Ruby-shaped and not marked dev/test.
+FROM ruby:3.3-slim AS builder
+RUN bundle install && bundle exec rake assets:precompile
+
+# Compliant: stage-level ENV provides the placeholder for every RUN below it.
+FROM ruby:3.3-slim AS app-env-set
+ENV SECRET_KEY_BASE_DUMMY=1
+RUN bin/rails assets:precompile
+
+# Compliant: inline placeholder on the offending command itself.
+FROM ruby:3.3-slim AS app-inline
+RUN SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile
+
+# Compliant: BuildKit secret mount with env-injection — RAILS_MASTER_KEY is
+# never written to image history.
+FROM ruby:3.3-slim AS app-secret-mount
+RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY \
+    bin/rails assets:precompile
+
+# Skipped: dev stage. The rule applies only to production-shaped images.
+FROM ruby:3.3-slim AS dev
+RUN bin/rails assets:precompile
+
+# Final non-compliant runtime stage: rails CLI form, no placeholder anywhere.
+# This is the canonical violation shape.
+FROM ruby:3.3-slim
+RUN bin/rails assets:precompile
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/lint/ruby-asset-precompile-without-dummy-key/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-asset-precompile-without-dummy-key/result_1.snap.json
@@ -1,0 +1,99 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-asset-precompile-without-dummy-key/Dockerfile",
+      "violations": [
+        {
+          "detail": "Running `assets:precompile` without `SECRET_KEY_BASE_DUMMY=1` forces Rails to decrypt credentials at build time, which pushes users toward passing `RAILS_MASTER_KEY` via `ARG`/`ENV` — both end up in image history. Prepend `SECRET_KEY_BASE_DUMMY=1` to the command (Rails 7.1+ honors it as the build-time placeholder) or consume the master key through `RUN --mount=type=secret`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/asset-precompile-without-dummy-key/",
+          "location": {
+            "end": {
+              "column": 56,
+              "line": 5
+            },
+            "file": "fixtures/lint/ruby-asset-precompile-without-dummy-key/Dockerfile",
+            "start": {
+              "column": 39,
+              "line": 5
+            }
+          },
+          "message": "Rails assets:precompile runs without SECRET_KEY_BASE_DUMMY=1, which forces RAILS_MASTER_KEY into image history",
+          "rule": "tally/ruby/asset-precompile-without-dummy-key",
+          "severity": "warning",
+          "sourceCode": "RUN bundle install \u0026\u0026 bundle exec rake assets:precompile",
+          "suggestedFix": {
+            "description": "Prepend SECRET_KEY_BASE_DUMMY=1 to the assets:precompile command so the build never needs RAILS_MASTER_KEY",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 22,
+                    "line": 5
+                  },
+                  "file": "fixtures/lint/ruby-asset-precompile-without-dummy-key/Dockerfile",
+                  "start": {
+                    "column": 22,
+                    "line": 5
+                  }
+                },
+                "newText": "SECRET_KEY_BASE_DUMMY=1 "
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88
+          }
+        },
+        {
+          "detail": "Running `assets:precompile` without `SECRET_KEY_BASE_DUMMY=1` forces Rails to decrypt credentials at build time, which pushes users toward passing `RAILS_MASTER_KEY` via `ARG`/`ENV` — both end up in image history. Prepend `SECRET_KEY_BASE_DUMMY=1` to the command (Rails 7.1+ honors it as the build-time placeholder) or consume the master key through `RUN --mount=type=secret`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/asset-precompile-without-dummy-key/",
+          "location": {
+            "end": {
+              "column": 31,
+              "line": 29
+            },
+            "file": "fixtures/lint/ruby-asset-precompile-without-dummy-key/Dockerfile",
+            "start": {
+              "column": 14,
+              "line": 29
+            }
+          },
+          "message": "Rails assets:precompile runs without SECRET_KEY_BASE_DUMMY=1, which forces RAILS_MASTER_KEY into image history",
+          "rule": "tally/ruby/asset-precompile-without-dummy-key",
+          "severity": "warning",
+          "sourceCode": "RUN bin/rails assets:precompile",
+          "suggestedFix": {
+            "description": "Prepend SECRET_KEY_BASE_DUMMY=1 to the assets:precompile command so the build never needs RAILS_MASTER_KEY",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 4,
+                    "line": 29
+                  },
+                  "file": "fixtures/lint/ruby-asset-precompile-without-dummy-key/Dockerfile",
+                  "start": {
+                    "column": 4,
+                    "line": 29
+                  }
+                },
+                "newText": "SECRET_KEY_BASE_DUMMY=1 "
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 2,
+    "warnings": 2
+  }
+}

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -107,6 +107,26 @@ func lintCases(t *testing.T) []lintCase {
 			useContext: true,
 		},
 		{
+			// Context-aware refinement for tally/ruby/asset-precompile-without-dummy-key:
+			// Gemfile.lock shows Rails 7.0 (older than 7.1), so the rule should
+			// emit FixSuggestion (not FixSafe) and recommend BuildKit secret mounts.
+			name:       "ruby-asset-precompile-rails-old",
+			dir:        "ruby-asset-precompile-rails-old",
+			args:       append([]string{"--format", "json"}, mustSelectRules("tally/ruby/asset-precompile-without-dummy-key")...),
+			wantExit:   1,
+			useContext: true,
+		},
+		{
+			// Context-aware refinement for tally/ruby/asset-precompile-without-dummy-key:
+			// No Rails encrypted credentials file exists, so the rule should
+			// demote severity from warning to info.
+			name:       "ruby-asset-precompile-no-credentials",
+			dir:        "ruby-asset-precompile-no-credentials",
+			args:       append([]string{"--format", "json"}, mustSelectRules("tally/ruby/asset-precompile-without-dummy-key")...),
+			wantExit:   1,
+			useContext: true,
+		},
+		{
 			name:  "discovery-directory",
 			dir:   "discovery-directory",
 			args:  append([]string{"--format", "json"}, mustSelectRules("tally/max-lines")...),

--- a/internal/integration/testdata/ruby-asset-precompile-no-credentials/Dockerfile
+++ b/internal/integration/testdata/ruby-asset-precompile-no-credentials/Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.3-slim
+COPY . .
+RUN bin/rails assets:precompile
+CMD ["bin/rails", "server"]

--- a/internal/integration/testdata/ruby-asset-precompile-no-credentials/Gemfile.lock
+++ b/internal/integration/testdata/ruby-asset-precompile-no-credentials/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (8.0.0)
+      actionpack (= 8.0.0)
+    actionpack (8.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails (= 8.0.0)
+
+RUBY VERSION
+   ruby 3.3.5p100
+
+BUNDLED WITH
+   2.5.6

--- a/internal/integration/testdata/ruby-asset-precompile-rails-old/Dockerfile
+++ b/internal/integration/testdata/ruby-asset-precompile-rails-old/Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.2-slim
+COPY . .
+RUN bin/rails assets:precompile
+CMD ["bin/rails", "server"]

--- a/internal/integration/testdata/ruby-asset-precompile-rails-old/Gemfile.lock
+++ b/internal/integration/testdata/ruby-asset-precompile-rails-old/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.0.8)
+      actionpack (= 7.0.8)
+    actionpack (7.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails (= 7.0.8)
+
+RUBY VERSION
+   ruby 3.2.2p53
+
+BUNDLED WITH
+   2.4.10

--- a/internal/rules/tally/ruby/asset_precompile_without_dummy_key.go
+++ b/internal/rules/tally/ruby/asset_precompile_without_dummy_key.go
@@ -361,16 +361,21 @@ var masterKeyFromSecretFileRe = regexp.MustCompile(
 	`RAILS_MASTER_KEY\s*=\s*["']?\$\(\s*cat\s+["']?/run/secrets/[A-Za-z0-9_./-]+`,
 )
 
-// runScriptHasInlineDummyAssignment reports whether the RUN script contains
-// an inline "SECRET_KEY_BASE_DUMMY=<non-empty>" (or "SECRET_KEY_BASE=1") on
-// the same logical line as, and immediately preceding, the asset-compile
-// command. The parser's CommandInfo doesn't expose Bash assignment-prefix
-// tokens, so we fall back to a small text scan over the script.
+// runScriptHasInlineDummyAssignment reports whether the RUN script's
+// preface preceding the asset-compile command sets the dummy key in a way
+// that actually applies to the command:
 //
-// The check tolerates `export SECRET_KEY_BASE_DUMMY=1 && ...` chains because
-// it matches anywhere in the script that precedes the asset-compile command.
-// That is intentionally generous: setting the dummy key earlier in the same
-// RUN is functionally equivalent to inline.
+//  1. As an inline assignment-prefix attached directly to the precompile
+//     command itself (`SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile`).
+//     POSIX `VAR=value cmd` semantics: the assignment is scoped to that
+//     single command's environment.
+//  2. As an `export` statement earlier in the same shell — those persist for
+//     every command that follows in the same shell, so the precompile
+//     inherits the setting.
+//
+// Plain assignments without `export` (e.g. `SECRET_KEY_BASE_DUMMY=1 echo ok &&
+// bin/rails ...`) are NOT counted: those scope only to the single command
+// they prefix (`echo ok`), not to the subsequent `bin/rails`.
 func runScriptHasInlineDummyAssignment(script string, ac assetPrecompileCommand) bool {
 	if script == "" {
 		return false
@@ -384,13 +389,51 @@ func runScriptHasInlineDummyAssignment(script string, ac assetPrecompileCommand)
 		cutoff = len(script)
 	}
 	preface := script[:cutoff]
-	if dummyAssignmentRe.MatchString(preface) {
+
+	// Case 1: assignment-prefix immediately before the command. The prefix
+	// is the run of `VAR=value` tokens that ends at the command itself, with
+	// no `&&`/`;`/`|`/`\n` in between. We anchor the scan at the cutoff and
+	// walk backwards to find the closest preceding shell separator; the
+	// assignment must live in that final segment.
+	finalSegment := preface
+	if sep := lastShellSeparatorOffset(preface); sep >= 0 {
+		finalSegment = preface[sep+1:]
+	}
+	if dummyAssignmentRe.MatchString(finalSegment) {
 		return true
 	}
-	if realKeyEqualsOneRe.MatchString(preface) {
+	if realKeyEqualsOneRe.MatchString(finalSegment) {
+		return true
+	}
+
+	// Case 2: `export SECRET_KEY_BASE_DUMMY=...` (or `SECRET_KEY_BASE=1`)
+	// anywhere in the preface. Exported values persist across separators
+	// so they affect any subsequent command in the same shell.
+	if exportedDummyAssignmentRe.MatchString(preface) {
+		return true
+	}
+	if exportedRealKeyEqualsOneRe.MatchString(preface) {
 		return true
 	}
 	return false
+}
+
+// lastShellSeparatorOffset returns the byte offset of the last shell
+// command separator in the input (the position of the separator character
+// itself), or -1 if none. Recognized separators: `;`, `&`, `&&`, `|`,
+// `||`, `\n`. Quoting is not modeled here — a separator inside `"..."`
+// would still match — but `RUN` scripts in the corpus that we're trying
+// to match against (Rails-generator-style) don't put separators inside
+// quoted strings, so this is acceptable.
+func lastShellSeparatorOffset(s string) int {
+	last := -1
+	for i := range len(s) {
+		switch s[i] {
+		case ';', '&', '|', '\n':
+			last = i
+		}
+	}
+	return last
 }
 
 // dummyAssignmentRe matches SECRET_KEY_BASE_DUMMY=<non-empty>, where the
@@ -411,6 +454,19 @@ var dummyAssignmentRe = regexp.MustCompile(
 // SECRET_KEY_BASE=1 as also acceptable as the placeholder contract.
 var realKeyEqualsOneRe = regexp.MustCompile(
 	`(?:^|[\s;&|(])` + regexp.QuoteMeta(realKeyVar) + `=(?:1|"1"|'1')(?:\s|$|[;&|)])`,
+)
+
+// exportedDummyAssignmentRe matches `export SECRET_KEY_BASE_DUMMY=...`. Unlike
+// the bare assignment form, an exported value persists across separators in
+// the same shell, so it counts as compliant for any subsequent command.
+var exportedDummyAssignmentRe = regexp.MustCompile(
+	`(?:^|[\s;&|(])export\s+` + regexp.QuoteMeta(dummyKeyVar) + `=(?:"[^"]+"|'[^']+'|\S+)`,
+)
+
+// exportedRealKeyEqualsOneRe matches `export SECRET_KEY_BASE=1`. Same scoping
+// rationale as exportedDummyAssignmentRe.
+var exportedRealKeyEqualsOneRe = regexp.MustCompile(
+	`(?:^|[\s;&|(])export\s+` + regexp.QuoteMeta(realKeyVar) + `=(?:1|"1"|'1')(?:\s|$|[;&|)])`,
 )
 
 // assetPrecompileScriptOffset returns the byte offset within the
@@ -483,7 +539,7 @@ func assetPrecompileLocation(
 	if ac.cmd.HasCommandRange {
 		line := runRanges[0].Start.Line + ac.cmd.Line
 		startCol, endCol := ac.cmd.StartCol, ac.cmd.EndCol
-		if ac.cmd.Line == 0 {
+		if ac.cmd.Line == 0 && sm != nil {
 			offset := shell.DockerfileRunCommandStartCol(sm.Line(line - 1))
 			startCol += offset
 			endCol += offset

--- a/internal/rules/tally/ruby/asset_precompile_without_dummy_key.go
+++ b/internal/rules/tally/ruby/asset_precompile_without_dummy_key.go
@@ -1,0 +1,653 @@
+package ruby
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/runmount"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// AssetPrecompileWithoutDummyKeyRuleCode is the full rule code.
+const AssetPrecompileWithoutDummyKeyRuleCode = rules.TallyRulePrefix + "ruby/asset-precompile-without-dummy-key"
+
+// Same fix-priority tier as the jemalloc rule so cross-rule edit ordering
+// stays predictable when both fire on the same Dockerfile.
+const assetPrecompileFixPriority = 88
+
+// dummyKeyVar is the Rails 7.1+ build-time placeholder env var. Setting it to
+// any non-empty value tells Rails to skip credential decryption for asset
+// compilation.
+const dummyKeyVar = "SECRET_KEY_BASE_DUMMY"
+
+// realKeyVar is the Rails secret-key env var. When set to the literal "1" the
+// Rails 7.1 release notes accept it as the placeholder contract too — equivalent
+// to dummyKeyVar for the purpose of this rule.
+const realKeyVar = "SECRET_KEY_BASE"
+
+// railsMasterKeyEnv is the runtime env var Rails uses to decrypt
+// credentials.yml.enc. When the same RUN reads this from a BuildKit secret
+// mount, the asset-precompile invocation is the supported alternative path
+// to SECRET_KEY_BASE_DUMMY.
+const railsMasterKeyEnv = "RAILS_MASTER_KEY"
+
+// rails71MajorMinor is the Rails major*100+minor encoding for 7.1 — the
+// release that introduced SECRET_KEY_BASE_DUMMY support. Older Rails versions
+// don't honor the dummy key constant, so the rule's fix becomes a suggestion
+// pointing at secret-mount alternatives instead.
+const rails71MajorMinor = 7*100 + 1
+
+// AssetPrecompileWithoutDummyKeyRule flags Rails asset:precompile invocations
+// that lack SECRET_KEY_BASE_DUMMY (and don't use the BuildKit secret-mount
+// alternative).
+type AssetPrecompileWithoutDummyKeyRule struct{}
+
+// NewAssetPrecompileWithoutDummyKeyRule creates the rule.
+func NewAssetPrecompileWithoutDummyKeyRule() *AssetPrecompileWithoutDummyKeyRule {
+	return &AssetPrecompileWithoutDummyKeyRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *AssetPrecompileWithoutDummyKeyRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            AssetPrecompileWithoutDummyKeyRuleCode,
+		Name:            "Set SECRET_KEY_BASE_DUMMY for asset precompile",
+		Description:     "Rails assets:precompile runs without SECRET_KEY_BASE_DUMMY=1, which forces RAILS_MASTER_KEY into image history",
+		DocURL:          rules.TallyDocURL(AssetPrecompileWithoutDummyKeyRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "security",
+		FixPriority:     assetPrecompileFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *AssetPrecompileWithoutDummyKeyRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	rubyFacts := input.Facts.RubyFacts()
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+
+		// Skip when the same stage already has SECRET_KEY_BASE_DUMMY
+		// (or SECRET_KEY_BASE=1) bound by an ENV before any RUN —
+		// those bindings are visible at every RUN as part of EffectiveEnv.
+
+		// Ruby-namespaced rule: only fire on stages that look like a Ruby
+		// runtime. A non-Ruby image (Node, Python, ...) running an
+		// asset:precompile-named binary for unrelated reasons shouldn't get
+		// a Rails-flavored warning.
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+
+		violations = append(violations, r.checkStage(input.File, sf, input.SourceMap(), meta, rubyFacts)...)
+	}
+	return violations
+}
+
+func (r *AssetPrecompileWithoutDummyKeyRule) checkStage(
+	file string,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	meta rules.RuleMetadata,
+	rubyFacts *rubyfacts.RubyFacts,
+) []rules.Violation {
+	var violations []rules.Violation
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		assetCompiles := findAssetPrecompileCommands(runFacts)
+		if len(assetCompiles) == 0 {
+			continue
+		}
+		if runFacts.Env.Values[dummyKeyVar] != "" {
+			// Stage-level ENV already provides the placeholder.
+			continue
+		}
+		if envValueIsPlaceholderOne(runFacts.Env.Values[realKeyVar]) {
+			// SECRET_KEY_BASE=1 is also accepted as the placeholder contract.
+			continue
+		}
+		// Each RUN can contain multiple asset-compile invocations (rare but
+		// possible: chained `... && rake assets:precompile && bin/rails assets:precompile`).
+		// We emit one violation per invocation so the suggested fix targets
+		// each command precisely.
+		for _, ac := range assetCompiles {
+			if runScriptHasInlineDummyAssignment(runFacts.SourceScript, ac) {
+				continue
+			}
+			if runHasMasterKeyFromSecret(runFacts) {
+				continue
+			}
+			violations = append(violations, r.violationFor(file, sf, runFacts, ac, sm, meta, rubyFacts))
+		}
+	}
+	return violations
+}
+
+func (r *AssetPrecompileWithoutDummyKeyRule) violationFor(
+	file string,
+	sf *facts.StageFacts,
+	runFacts *facts.RunFacts,
+	ac assetPrecompileCommand,
+	sm *sourcemap.SourceMap,
+	meta rules.RuleMetadata,
+	rubyFacts *rubyfacts.RubyFacts,
+) rules.Violation {
+	severity := meta.DefaultSeverity
+	rubyVersionInfo := detectRailsVersion(rubyFacts)
+	supportsDummyKey := !rubyVersionInfo.detected || rubyVersionInfo.supportsDummyKey
+	credentialsObservable := rubyFacts != nil && rubyFacts.HasEncryptedCredentials
+	contextWasInspected := rubyFacts != nil &&
+		(rubyFacts.Lockfile != nil ||
+			rubyFacts.Gemfile != nil ||
+			len(rubyFacts.EncryptedCredentialsPaths) > 0)
+
+	if contextWasInspected && !credentialsObservable {
+		// No credentials file in this build — the dummy key is just
+		// hygiene; the rule still fires but at info severity.
+		severity = rules.SeverityInfo
+	}
+
+	loc := assetPrecompileLocation(file, runFacts, ac, sm)
+	v := rules.NewViolation(loc, meta.Code, meta.Description, severity).
+		WithDocURL(meta.DocURL).
+		WithDetail(buildDetail(supportsDummyKey, credentialsObservable, contextWasInspected, rubyVersionInfo))
+
+	if fix := buildAssetPrecompileFix(file, runFacts, ac, sm, meta.FixPriority, supportsDummyKey); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+
+	// Suppress unused warning when sf is later needed.
+	_ = sf
+	return v
+}
+
+// assetPrecompileCommand bundles the parsed shell command that invokes
+// assets:precompile together with the variable-prefix style we want our fix
+// to emit. The fix builder needs to know whether the caller is Rake-shaped
+// (`rake assets:precompile`) or Rails-shaped (`bin/rails assets:precompile`)
+// — both honor the inline env-var prefix Bash uses for assignments.
+type assetPrecompileCommand struct {
+	cmd      shell.CommandInfo
+	form     assetPrecompileForm
+	flagSpan tokenSpan // span of "assets:precompile" arg, used for diagnostics
+}
+
+type assetPrecompileForm int
+
+const (
+	formUnknown assetPrecompileForm = iota
+	formRails
+	formRake
+	formBundleExecRake
+	formBundleExecRails
+)
+
+type tokenSpan struct {
+	line     int // 0-based line within the script
+	startCol int // 0-based column
+	endCol   int // 0-based exclusive column
+}
+
+// findAssetPrecompileCommands returns every assets:precompile invocation in
+// the RUN, normalized to a small set of supported shapes. Order matches
+// source order.
+func findAssetPrecompileCommands(runFacts *facts.RunFacts) []assetPrecompileCommand {
+	if runFacts == nil {
+		return nil
+	}
+	var out []assetPrecompileCommand
+	for _, ci := range runFacts.CommandInfos {
+		ac, ok := classifyAssetPrecompile(ci)
+		if !ok {
+			continue
+		}
+		out = append(out, ac)
+	}
+	return out
+}
+
+// classifyAssetPrecompile tests whether a parsed command invokes
+// assets:precompile in one of the four supported shapes. Returns the
+// classified command on match.
+func classifyAssetPrecompile(ci shell.CommandInfo) (assetPrecompileCommand, bool) {
+	switch ci.Name {
+	case "rails":
+		if argsHaveAssetsPrecompile(ci.Args, 0) {
+			span := assetsPrecompileTokenSpan(ci, "assets:precompile")
+			return assetPrecompileCommand{cmd: ci, form: formRails, flagSpan: span}, true
+		}
+	case "rake":
+		if argsHaveAssetsPrecompile(ci.Args, 0) {
+			span := assetsPrecompileTokenSpan(ci, "assets:precompile")
+			return assetPrecompileCommand{cmd: ci, form: formRake, flagSpan: span}, true
+		}
+	case "bundle":
+		// Look for `bundle exec <rake|rails> ... assets:precompile ...`.
+		// We tolerate intermediate flags between `exec` and the wrapped
+		// command, but the shapes the design doc cares about both have
+		// `bundle exec <tool>` directly.
+		if len(ci.Args) < 2 {
+			return assetPrecompileCommand{}, false
+		}
+		if ci.Args[0] != "exec" {
+			return assetPrecompileCommand{}, false
+		}
+		wrapped := ci.Args[1]
+		var form assetPrecompileForm
+		switch {
+		case wrapped == "rake":
+			form = formBundleExecRake
+		case wrapped == "rails", strings.HasSuffix(wrapped, "/rails"):
+			form = formBundleExecRails
+		default:
+			return assetPrecompileCommand{}, false
+		}
+		if !argsHaveAssetsPrecompile(ci.Args, 2) {
+			return assetPrecompileCommand{}, false
+		}
+		span := assetsPrecompileTokenSpan(ci, "assets:precompile")
+		return assetPrecompileCommand{cmd: ci, form: form, flagSpan: span}, true
+	}
+	return assetPrecompileCommand{}, false
+}
+
+// argsHaveAssetsPrecompile reports whether the args slice contains the
+// literal "assets:precompile" task name at or after fromIndex. Tasks with
+// trailing arguments (`assets:precompile RAILS_ENV=production`) are also
+// matched on the leading token.
+func argsHaveAssetsPrecompile(args []string, fromIndex int) bool {
+	if fromIndex < 0 {
+		fromIndex = 0
+	}
+	for i := fromIndex; i < len(args); i++ {
+		if args[i] == "assets:precompile" {
+			return true
+		}
+	}
+	return false
+}
+
+// assetsPrecompileTokenSpan returns the script-relative span of the
+// assets:precompile arg in the parsed command. Returns a zero span when the
+// parser did not preserve arg ranges or the token is not present.
+func assetsPrecompileTokenSpan(ci shell.CommandInfo, token string) tokenSpan {
+	for i, arg := range ci.Args {
+		if arg != token {
+			continue
+		}
+		if i >= len(ci.ArgRanges) {
+			return tokenSpan{}
+		}
+		r := ci.ArgRanges[i]
+		return tokenSpan{line: r.Line, startCol: r.StartCol, endCol: r.EndCol}
+	}
+	return tokenSpan{}
+}
+
+// envValueIsPlaceholderOne reports whether an env value is the literal "1"
+// (any optional surrounding whitespace ignored). This is the form Rails 7.1
+// release notes call out as accepted alongside SECRET_KEY_BASE_DUMMY=1.
+func envValueIsPlaceholderOne(v string) bool {
+	return strings.TrimSpace(v) == "1"
+}
+
+// runHasMasterKeyFromSecret returns true when the RUN consumes
+// RAILS_MASTER_KEY through a BuildKit secret mount. Two equivalent shapes are
+// recognized:
+//
+//   - --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY
+//     (BuildKit's env-injecting secret mount, no shell read needed).
+//   - --mount=type=secret,id=rails_master_key + a shell expression that
+//     reads the secret file (e.g. `RAILS_MASTER_KEY="$(cat /run/secrets/rails_master_key)"`).
+//
+// Both are the alternative compliant path called out in the design doc.
+func runHasMasterKeyFromSecret(runFacts *facts.RunFacts) bool {
+	if runFacts == nil || runFacts.Run == nil {
+		return false
+	}
+	mounts := runmount.GetMounts(runFacts.Run)
+	hasSecretMount := false
+	for _, m := range mounts {
+		if m == nil || m.Type != instructions.MountTypeSecret {
+			continue
+		}
+		// env=RAILS_MASTER_KEY case: BuildKit injects the env var directly.
+		if m.Env != nil && *m.Env == railsMasterKeyEnv {
+			return true
+		}
+		hasSecretMount = true
+	}
+	if !hasSecretMount {
+		return false
+	}
+	// Otherwise look for an explicit read of the secret file inside the
+	// shell script. Match RAILS_MASTER_KEY="$(cat /run/secrets/...)" and
+	// the equivalent forms tally's corpus uses.
+	return masterKeyFromSecretFileRe.MatchString(runFacts.SourceScript)
+}
+
+// masterKeyFromSecretFileRe matches a typical bash assignment that pulls
+// RAILS_MASTER_KEY out of a BuildKit secret mount file. The pattern is
+// intentionally loose around whitespace and quoting; false positives only
+// suppress the rule, which is the safe direction for "the user is wiring
+// the master key from a real secret".
+var masterKeyFromSecretFileRe = regexp.MustCompile(
+	`RAILS_MASTER_KEY\s*=\s*["']?\$\(\s*cat\s+["']?/run/secrets/[A-Za-z0-9_./-]+`,
+)
+
+// runScriptHasInlineDummyAssignment reports whether the RUN script contains
+// an inline "SECRET_KEY_BASE_DUMMY=<non-empty>" (or "SECRET_KEY_BASE=1") on
+// the same logical line as, and immediately preceding, the asset-compile
+// command. The parser's CommandInfo doesn't expose Bash assignment-prefix
+// tokens, so we fall back to a small text scan over the script.
+//
+// The check tolerates `export SECRET_KEY_BASE_DUMMY=1 && ...` chains because
+// it matches anywhere in the script that precedes the asset-compile command.
+// That is intentionally generous: setting the dummy key earlier in the same
+// RUN is functionally equivalent to inline.
+func runScriptHasInlineDummyAssignment(script string, ac assetPrecompileCommand) bool {
+	if script == "" {
+		return false
+	}
+	cutoff := assetPrecompileScriptOffset(script, ac)
+	if cutoff < 0 {
+		// Couldn't locate the command inside the reconstructed script —
+		// fall back to scanning the whole script. The risk is a placeholder
+		// later in the script suppressing the violation, which is the safe
+		// direction for this rule.
+		cutoff = len(script)
+	}
+	preface := script[:cutoff]
+	if dummyAssignmentRe.MatchString(preface) {
+		return true
+	}
+	if realKeyEqualsOneRe.MatchString(preface) {
+		return true
+	}
+	return false
+}
+
+// dummyAssignmentRe matches SECRET_KEY_BASE_DUMMY=<non-empty>, where the
+// value can be quoted or bare and may appear after `export`.
+//
+// Forms it accepts (each on the LHS of the regex):
+//
+//	SECRET_KEY_BASE_DUMMY=1
+//	export SECRET_KEY_BASE_DUMMY=1
+//	SECRET_KEY_BASE_DUMMY="any-string"
+//	SECRET_KEY_BASE_DUMMY='any-string'
+var dummyAssignmentRe = regexp.MustCompile(
+	`(?:^|[\s;&|(])` + regexp.QuoteMeta(dummyKeyVar) + `=(?:"[^"]+"|'[^']+'|\S+)`,
+)
+
+// realKeyEqualsOneRe matches SECRET_KEY_BASE=1 and the quoted variants
+// (single- or double-quoted "1"). The Rails 7.1 release notes describe
+// SECRET_KEY_BASE=1 as also acceptable as the placeholder contract.
+var realKeyEqualsOneRe = regexp.MustCompile(
+	`(?:^|[\s;&|(])` + regexp.QuoteMeta(realKeyVar) + `=(?:1|"1"|'1')(?:\s|$|[;&|)])`,
+)
+
+// assetPrecompileScriptOffset returns the byte offset within the
+// reconstructed script where the assets:precompile invocation starts, or -1
+// when the parser didn't preserve enough position info to locate it.
+func assetPrecompileScriptOffset(script string, ac assetPrecompileCommand) int {
+	if !ac.cmd.HasCommandRange {
+		return -1
+	}
+	return scriptOffsetForLineCol(script, ac.cmd.Line, ac.cmd.StartCol)
+}
+
+// scriptOffsetForLineCol converts a 0-based (line, column) coordinate inside
+// the reconstructed script to a byte offset. Columns are byte offsets from
+// the start of their line. Returns -1 when the requested line is out of
+// range.
+func scriptOffsetForLineCol(script string, line, col int) int {
+	if line < 0 || col < 0 {
+		return -1
+	}
+	currentLine := 0
+	offset := 0
+	for offset < len(script) {
+		if currentLine == line {
+			if col > len(script)-offset {
+				return -1
+			}
+			return offset + col
+		}
+		nl := strings.IndexByte(script[offset:], '\n')
+		if nl < 0 {
+			return -1
+		}
+		offset += nl + 1
+		currentLine++
+	}
+	return -1
+}
+
+// assetPrecompileLocation returns the violation's reported source location:
+// prefer the line of the assets:precompile token itself, falling back to the
+// command name span, then the RUN's first line.
+func assetPrecompileLocation(
+	file string,
+	runFacts *facts.RunFacts,
+	ac assetPrecompileCommand,
+	sm *sourcemap.SourceMap,
+) rules.Location {
+	if runFacts == nil || runFacts.Run == nil {
+		return rules.NewFileLocation(file)
+	}
+	runRanges := runFacts.Run.Location()
+	if len(runRanges) == 0 {
+		return rules.NewFileLocation(file)
+	}
+
+	// Prefer the assets:precompile token span when the parser preserved it.
+	if ac.flagSpan.endCol > ac.flagSpan.startCol {
+		line := runRanges[0].Start.Line + ac.flagSpan.line
+		startCol, endCol := ac.flagSpan.startCol, ac.flagSpan.endCol
+		if ac.flagSpan.line == 0 && sm != nil {
+			offset := shell.DockerfileRunCommandStartCol(sm.Line(line - 1))
+			startCol += offset
+			endCol += offset
+		}
+		return rules.NewRangeLocation(file, line, startCol, line, endCol)
+	}
+
+	// Fallback: command-name span.
+	if ac.cmd.HasCommandRange {
+		line := runRanges[0].Start.Line + ac.cmd.Line
+		startCol, endCol := ac.cmd.StartCol, ac.cmd.EndCol
+		if ac.cmd.Line == 0 {
+			offset := shell.DockerfileRunCommandStartCol(sm.Line(line - 1))
+			startCol += offset
+			endCol += offset
+		}
+		return rules.NewRangeLocation(file, line, startCol, line, endCol)
+	}
+	return rules.NewLocationFromRanges(file, runRanges)
+}
+
+// detectRailsVersion returns the project's Rails major.minor when an
+// observable Gemfile.lock supplies it. Falls back to "unknown" so the rule
+// keeps its default fix wording when there's nothing to gate on.
+func detectRailsVersion(rubyFacts *rubyfacts.RubyFacts) railsVersionInfo {
+	info := railsVersionInfo{supportsDummyKey: true}
+	if rubyFacts == nil || rubyFacts.Lockfile == nil {
+		return info
+	}
+	version := rubyFacts.Lockfile.Specs["rails"]
+	if version == "" {
+		return info
+	}
+	major, minor, ok := parseMajorMinor(version)
+	if !ok {
+		return info
+	}
+	info.detected = true
+	info.major = major
+	info.minor = minor
+	info.versionString = version
+	info.supportsDummyKey = (major*100 + minor) >= rails71MajorMinor
+	return info
+}
+
+// railsVersionInfo packages the rule's view of the project's Rails version.
+type railsVersionInfo struct {
+	detected         bool
+	major            int
+	minor            int
+	versionString    string
+	supportsDummyKey bool
+}
+
+// parseMajorMinor parses "M", "M.N", "M.N.P", "M.N.P.preX" into (M, N).
+// Returns ok=false for empty or non-numeric M.
+func parseMajorMinor(version string) (int, int, bool) {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) == 0 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor := 0
+	if len(parts) >= 2 {
+		// Strip suffixes like "1.beta1" -> "1".
+		minorRaw := parts[1]
+		minorClean := strings.Builder{}
+		for _, r := range minorRaw {
+			if r >= '0' && r <= '9' {
+				minorClean.WriteRune(r)
+				continue
+			}
+			break
+		}
+		if minorClean.Len() > 0 {
+			n, err := strconv.Atoi(minorClean.String())
+			if err == nil {
+				minor = n
+			}
+		}
+	}
+	return major, minor, true
+}
+
+// buildDetail composes the human-readable detail string for the violation,
+// taking the observable build context into account.
+func buildDetail(
+	supportsDummyKey bool,
+	credentialsObservable bool,
+	contextWasInspected bool,
+	versionInfo railsVersionInfo,
+) string {
+	if !supportsDummyKey {
+		return fmt.Sprintf(
+			"Rails %s predates SECRET_KEY_BASE_DUMMY (added in Rails 7.1). "+
+				"Pass RAILS_MASTER_KEY through a BuildKit secret mount "+
+				"(`--mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY`) "+
+				"or set SECRET_KEY_BASE to a random ephemeral value for this build "+
+				"so neither secret ends up in image history.",
+			versionInfo.versionString,
+		)
+	}
+	if contextWasInspected && !credentialsObservable {
+		return "This build context does not appear to ship a Rails encrypted-credentials file " +
+			"(`config/credentials.yml.enc` or `config/credentials/<env>.yml.enc`), so the dummy " +
+			"key is just hygiene — but still recommended for image-cache reproducibility. " +
+			"Prepend `SECRET_KEY_BASE_DUMMY=1` to the asset-precompile command so future " +
+			"credential rollouts don't bake `RAILS_MASTER_KEY` into image history."
+	}
+	return "Running `assets:precompile` without `SECRET_KEY_BASE_DUMMY=1` forces Rails to " +
+		"decrypt credentials at build time, which pushes users toward passing `RAILS_MASTER_KEY` " +
+		"via `ARG`/`ENV` — both end up in image history. " +
+		"Prepend `SECRET_KEY_BASE_DUMMY=1` to the command (Rails 7.1+ honors it as the build-time " +
+		"placeholder) or consume the master key through `RUN --mount=type=secret`."
+}
+
+// buildAssetPrecompileFix builds the suggested fix. For Rails 7.1+ projects
+// (the default when the linter has no observable Rails version) the fix
+// inserts `SECRET_KEY_BASE_DUMMY=1 ` immediately before the asset-compile
+// command at FixSafe — exactly the patch the Rails 7.1 release notes
+// recommend. For Rails < 7.1 we drop the safety down to FixSuggestion and
+// suggest the BuildKit secret-mount path instead.
+func buildAssetPrecompileFix(
+	file string,
+	runFacts *facts.RunFacts,
+	ac assetPrecompileCommand,
+	sm *sourcemap.SourceMap,
+	priority int,
+	supportsDummyKey bool,
+) *rules.SuggestedFix {
+	if runFacts == nil || runFacts.Run == nil || sm == nil {
+		return nil
+	}
+	if !ac.cmd.HasCommandRange {
+		return nil
+	}
+	runRanges := runFacts.Run.Location()
+	if len(runRanges) == 0 {
+		return nil
+	}
+
+	// For Rails < 7.1, the dummy key constant doesn't work. Surface the
+	// secret-mount alternative as a structural suggestion instead of a
+	// drop-in textual fix — the user must decide which CI secret to wire.
+	if !supportsDummyKey {
+		return &rules.SuggestedFix{
+			Description: "Pass RAILS_MASTER_KEY via a BuildKit secret mount (Rails < 7.1 does not honor SECRET_KEY_BASE_DUMMY)",
+			Safety:      rules.FixSuggestion,
+			Priority:    priority,
+		}
+	}
+
+	line := runRanges[0].Start.Line + ac.cmd.Line
+	startCol := ac.cmd.StartCol
+	if ac.cmd.Line == 0 {
+		offset := shell.DockerfileRunCommandStartCol(sm.Line(line - 1))
+		startCol += offset
+	}
+	if startCol < 0 {
+		return nil
+	}
+	return &rules.SuggestedFix{
+		Description: "Prepend SECRET_KEY_BASE_DUMMY=1 to the assets:precompile command so the build never needs RAILS_MASTER_KEY",
+		Safety:      rules.FixSafe,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(file, line, startCol, line, startCol),
+			NewText:  dummyKeyVar + "=1 ",
+		}},
+	}
+}
+
+func init() {
+	rules.Register(NewAssetPrecompileWithoutDummyKeyRule())
+}

--- a/internal/rules/tally/ruby/asset_precompile_without_dummy_key_test.go
+++ b/internal/rules/tally/ruby/asset_precompile_without_dummy_key_test.go
@@ -36,6 +36,21 @@ func TestAssetPrecompileWithoutDummyKeyRule_Check(t *testing.T) {
 	t.Parallel()
 
 	testutil.RunRuleTests(t, NewAssetPrecompileWithoutDummyKeyRule(), []testutil.RuleTestCase{
+		// --- Regression: inline assignment must be scoped to the precompile command ---
+		{
+			Name: "inline assignment on a chained earlier command does NOT suppress (POSIX scoping)",
+			Content: `FROM ruby:3.3-slim
+RUN SECRET_KEY_BASE_DUMMY=1 echo ok && bin/rails assets:precompile
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "inline assignment after a separator before the precompile does NOT suppress",
+			Content: `FROM ruby:3.3-slim
+RUN echo first; SECRET_KEY_BASE_DUMMY=1 echo second && bin/rails assets:precompile
+`,
+			WantViolations: 1,
+		},
 		// --- Violations ---
 		{
 			Name: "rails assets:precompile triggers",

--- a/internal/rules/tally/ruby/asset_precompile_without_dummy_key_test.go
+++ b/internal/rules/tally/ruby/asset_precompile_without_dummy_key_test.go
@@ -1,0 +1,395 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/facts"
+	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
+	"github.com/wharflab/tally/internal/fix"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestAssetPrecompileWithoutDummyKeyRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewAssetPrecompileWithoutDummyKeyRule().Metadata()
+	if meta.Code != AssetPrecompileWithoutDummyKeyRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, AssetPrecompileWithoutDummyKeyRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityWarning {
+		t.Errorf("DefaultSeverity = %v, want Warning", meta.DefaultSeverity)
+	}
+	if meta.Category != "security" {
+		t.Errorf("Category = %q, want %q", meta.Category, "security")
+	}
+	if meta.FixPriority != assetPrecompileFixPriority {
+		t.Errorf("FixPriority = %d, want %d", meta.FixPriority, assetPrecompileFixPriority)
+	}
+	if !strings.HasPrefix(meta.DocURL, "https://tally.wharflab.com/rules/tally/ruby/") {
+		t.Errorf("DocURL = %q, want tally/ruby/ prefix", meta.DocURL)
+	}
+}
+
+func TestAssetPrecompileWithoutDummyKeyRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewAssetPrecompileWithoutDummyKeyRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "rails assets:precompile triggers",
+			Content: `FROM ruby:3.3-slim
+RUN rails assets:precompile
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "bin/rails assets:precompile triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bin/rails assets:precompile
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "bundle exec rake assets:precompile triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bundle exec rake assets:precompile
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "rake assets:precompile triggers",
+			Content: `FROM ruby:3.3-slim
+RUN rake assets:precompile
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "bundle exec rails assets:precompile triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bundle exec rails assets:precompile
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "multi-step RUN with chained assets:precompile triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install && bin/rails assets:precompile
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "non-final stage still fires when ruby base",
+			Content: `FROM ruby:3.3-slim AS builder
+RUN bin/rails assets:precompile
+
+FROM ruby:3.3-slim
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		// --- Compliant: inline placeholder ---
+		{
+			Name: "inline SECRET_KEY_BASE_DUMMY=1 prefix suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "inline SECRET_KEY_BASE=1 (rails-accepted alternative) suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN SECRET_KEY_BASE=1 bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "exported SECRET_KEY_BASE_DUMMY=1 earlier in same RUN suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN export SECRET_KEY_BASE_DUMMY=1 && bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "quoted SECRET_KEY_BASE_DUMMY value suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN SECRET_KEY_BASE_DUMMY="dummy-value" bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		// --- Compliant: stage-level ENV ---
+		{
+			Name: "stage-level ENV SECRET_KEY_BASE_DUMMY suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV SECRET_KEY_BASE_DUMMY=1
+RUN bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "stage-level ENV SECRET_KEY_BASE=1 suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV SECRET_KEY_BASE=1
+RUN bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		// --- Compliant: BuildKit secret mount path ---
+		{
+			Name: "secret mount with env=RAILS_MASTER_KEY suppresses",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY \
+    bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "secret mount with shell read of /run/secrets suppresses",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --mount=type=secret,id=rails_master_key \
+    RAILS_MASTER_KEY="$(cat /run/secrets/rails_master_key)" \
+    bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		// --- Compliant: dev/test stages ---
+		{
+			Name: "dev stage skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+RUN bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "test stage skipped",
+			Content: `FROM ruby:3.3-slim AS test
+RUN bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		// --- Guardrails: non-Ruby stage ignored ---
+		{
+			Name: "non-ruby base does not fire",
+			Content: `FROM debian:stable-slim
+RUN bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "windows base does not fire",
+			Content: `FROM mcr.microsoft.com/windows/servercore:ltsc2022
+RUN bin/rails assets:precompile
+`,
+			WantViolations: 0,
+		},
+		// --- False trigger guards ---
+		{
+			Name: "rake without assets:precompile does not fire",
+			Content: `FROM ruby:3.3-slim
+RUN bundle exec rake db:migrate
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "rails without assets:precompile does not fire",
+			Content: `FROM ruby:3.3-slim
+RUN bin/rails routes
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bundle install alone does not fire",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestAssetPrecompileWithoutDummyKey_Fix_PrependsInline(t *testing.T) {
+	t.Parallel()
+
+	src := `FROM ruby:3.3-slim
+RUN bin/rails assets:precompile
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", src)
+	violations := NewAssetPrecompileWithoutDummyKeyRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatalf("expected a suggested fix, got nil")
+	}
+	if v.SuggestedFix.Safety != rules.FixSafe {
+		t.Errorf("Safety = %v, want FixSafe", v.SuggestedFix.Safety)
+	}
+	got := string(fix.ApplyFix([]byte(src), v.SuggestedFix))
+	if !strings.Contains(got, "RUN SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile") {
+		t.Errorf("fixed source missing inline prefix:\n%s", got)
+	}
+}
+
+func TestAssetPrecompileWithoutDummyKey_Fix_RakePrefix(t *testing.T) {
+	t.Parallel()
+
+	src := `FROM ruby:3.3-slim
+RUN bundle install && bundle exec rake assets:precompile
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", src)
+	violations := NewAssetPrecompileWithoutDummyKeyRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	got := string(fix.ApplyFix([]byte(src), violations[0].SuggestedFix))
+	// The prefix must be applied to the asset-compile sub-command, not at the
+	// front of the whole RUN, so unrelated bundle install isn't affected.
+	wantSub := "&& SECRET_KEY_BASE_DUMMY=1 bundle exec rake assets:precompile"
+	if !strings.Contains(got, wantSub) {
+		t.Errorf("fixed source missing rake prefix; got:\n%s", got)
+	}
+}
+
+func TestAssetPrecompileWithoutDummyKey_ContextDemotesSeverity(t *testing.T) {
+	t.Parallel()
+
+	// Build context observable but no encrypted credentials file: severity
+	// should drop to info and detail should explain the demotion.
+	reader := &fakeContextReader{
+		files: map[string][]byte{
+			"Gemfile.lock": []byte(`GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (8.0.0)
+
+DEPENDENCIES
+  rails
+
+BUNDLED WITH
+   2.5.6
+`),
+		},
+	}
+	src := `FROM ruby:3.3-slim
+RUN bin/rails assets:precompile
+`
+	input := testutil.MakeLintInputWithContext(t, "Dockerfile", src, reader)
+	violations := NewAssetPrecompileWithoutDummyKeyRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	if violations[0].Severity != rules.SeverityInfo {
+		t.Errorf("Severity = %v, want Info (no credentials.yml.enc observable)", violations[0].Severity)
+	}
+	if !strings.Contains(violations[0].Detail, "encrypted-credentials") {
+		t.Errorf("Detail missing credentials note:\n%s", violations[0].Detail)
+	}
+}
+
+func TestAssetPrecompileWithoutDummyKey_ContextWithCredentialsKeepsWarning(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeContextReader{
+		files: map[string][]byte{
+			"Gemfile.lock": []byte(`GEM
+  specs:
+    rails (8.0.0)
+
+DEPENDENCIES
+  rails
+
+BUNDLED WITH
+   2.5.6
+`),
+			"config/credentials.yml.enc": []byte("encrypted-blob"),
+		},
+	}
+	src := `FROM ruby:3.3-slim
+RUN bin/rails assets:precompile
+`
+	input := testutil.MakeLintInputWithContext(t, "Dockerfile", src, reader)
+	violations := NewAssetPrecompileWithoutDummyKeyRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	if violations[0].Severity != rules.SeverityWarning {
+		t.Errorf("Severity = %v, want Warning", violations[0].Severity)
+	}
+}
+
+func TestAssetPrecompileWithoutDummyKey_ContextOldRailsSwitchesToSecretMountSuggestion(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeContextReader{
+		files: map[string][]byte{
+			"Gemfile.lock": []byte(`GEM
+  specs:
+    rails (7.0.4)
+
+DEPENDENCIES
+  rails
+
+BUNDLED WITH
+   2.4.10
+`),
+		},
+	}
+	src := `FROM ruby:3.0-slim
+RUN bin/rails assets:precompile
+`
+	input := testutil.MakeLintInputWithContext(t, "Dockerfile", src, reader)
+	violations := NewAssetPrecompileWithoutDummyKeyRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	if violations[0].SuggestedFix == nil {
+		t.Fatalf("expected a suggested fix, got nil")
+	}
+	if violations[0].SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion (Rails < 7.1)", violations[0].SuggestedFix.Safety)
+	}
+	if !strings.Contains(violations[0].Detail, "Rails 7.1") {
+		t.Errorf("Detail missing Rails 7.1 explanation:\n%s", violations[0].Detail)
+	}
+	// Edits should be empty for the structural suggestion.
+	if len(violations[0].SuggestedFix.Edits) != 0 {
+		t.Errorf("Edits = %d, want 0 for structural suggestion", len(violations[0].SuggestedFix.Edits))
+	}
+}
+
+// --- helpers ---
+
+// fakeContextReader is a minimal facts.ContextFileReader for tests.
+type fakeContextReader struct {
+	files   map[string][]byte
+	ignored map[string]bool
+}
+
+var _ facts.ContextFileReader = (*fakeContextReader)(nil)
+var _ rubyfacts.ContextFileReader = (*fakeContextReader)(nil)
+
+func (r *fakeContextReader) FileExists(path string) bool {
+	_, ok := r.files[path]
+	return ok
+}
+
+func (r *fakeContextReader) ReadFile(path string) ([]byte, error) {
+	if data, ok := r.files[path]; ok {
+		return append([]byte(nil), data...), nil
+	}
+	return nil, fakeNotFoundError{}
+}
+
+func (r *fakeContextReader) IsIgnored(path string) (bool, error) {
+	return r.ignored[path], nil
+}
+
+func (r *fakeContextReader) IsHeredocFile(string) bool { return false }
+
+type fakeNotFoundError struct{}
+
+func (fakeNotFoundError) Error() string { return "file not found" }


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/asset-precompile-without-dummy-key`](https://tally.wharflab.com/rules/tally/ruby/asset-precompile-without-dummy-key/) — Section 4.1 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

Rails 7.1 added `SECRET_KEY_BASE_DUMMY=1` so that `bin/rails assets:precompile` can run at build time without `RAILS_MASTER_KEY`. Without this placeholder, projects bake the master key into image history via `ARG`/`ENV` — exactly the wrong workaround. 27 of 67 Dockerfiles in the corpus run `assets:precompile` without it.

- **Compliance signals:** inline `SECRET_KEY_BASE_DUMMY=1` (or `SECRET_KEY_BASE=1`) on the same RUN, stage-level `ENV` set before the RUN, or a BuildKit secret-mount-driven precompile (`--mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY`).
- **Suppressions:** dev/test/ci stages, non-Ruby stages, Windows stages.
- **Context-aware refinements:**
  - **Rails version gating.** When `Gemfile.lock` shows Rails `< 7.1`, the auto-fix demotes from `FixSafe` to `FixSuggestion` and recommends BuildKit secret mounts (the pre-7.1 supported path). Detail text quotes the observed Rails version.
  - **Severity demotion when credentials aren't used.** When neither `config/credentials.yml.enc` nor any `config/credentials/<env>.yml.enc` file exists in the build context, severity demotes from `warning` to `info`: the dummy key is hygiene without observable credentials.
- **Auto-fix:** Rails 7.1+ → `FixSafe`. Rails &lt; 7.1 → `FixSuggestion` pointing at secret-mount alternative.

The internal/facts/ruby package now also probes Rails encrypted credentials via `RubyFacts.HasEncryptedCredentials` and `RubyFacts.EncryptedCredentialsPaths` — multiple downstream rules can share the same observation.

## Test plan

- [x] \`make build\`
- [x] \`make test\` — ruby package, integration suite, and facts/ruby pass
- [x] \`make lint\` — 0 issues
- [x] Lint and fix fixtures: \`internal/integration/fixtures/{lint,fix}/ruby-asset-precompile-without-dummy-key/\`
- [x] Context-aware fixtures: \`internal/integration/testdata/ruby-asset-precompile-{rails-old,no-credentials}/\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New check flags Rails asset precompile runs that may bake secrets into image history and offers safe fixes (inline dummy key or BuildKit secret guidance).
  * Rule behavior now uses observable project context (encrypted credentials, Rails version) to adjust severity and suggested fix.

* **Documentation**
  * Added comprehensive rule docs with before/after examples and alternative fix patterns.

* **Tests & Fixtures**
  * Added unit, integration tests and fixtures covering detection, fixes, and context-driven behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wharflab/tally/pull/668)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->