### PR TITLE
feat(rules): add tally/ruby/missing-bundle-deployment

### DIFF
--- a/_docs/rules/tally/ruby/missing-bundle-deployment.mdx
+++ b/_docs/rules/tally/ruby/missing-bundle-deployment.mdx
@@ -1,0 +1,109 @@
+---
+title: "tally/ruby/missing-bundle-deployment"
+description: "Production stage runs `bundle install` without enforcing Bundler deployment mode."
+---
+
+Production stage runs `bundle install` without enforcing Bundler deployment mode.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning (default) / Error (no observable `Gemfile.lock` in build context) |
+| Category | Correctness |
+| Default | Enabled |
+| Auto-fix | Yes (FixSafe) |
+
+## Description
+
+Bundler 2.x's deployment mode is the production contract: it requires `Gemfile.lock` to exist, refuses to mutate
+the lockfile at build time, installs gems into `BUNDLE_PATH`, and skips dev/test gem groups (when
+`BUNDLE_WITHOUT` is set). The Rails generator template enables it via `ENV BUNDLE_DEPLOYMENT="1"` in the base
+stage precisely because the alternative — letting Bundler resolve afresh on every build — defeats the "the
+lockfile is the build input" property and pushes Bundler back into 1.x semantics.
+
+This rule fires when a Ruby-shaped production stage runs `bundle install` and:
+
+- Neither `ENV BUNDLE_DEPLOYMENT=...` (truthy: `1`/`true`) nor `bundle config set [--local|--global] deployment 'true'`
+  is in scope at the install site.
+- `bundle install --deployment` (the deprecated 2.x flag) is treated as compliant for this rule — the separate
+  [`tally/ruby/deprecated-bundler-install-flags`](/rules/tally/ruby/deprecated-bundler-install-flags/) rule
+  catches that pattern.
+
+The "production-shaped" heuristic mirrors
+[`tally/ruby/missing-bundle-without-development`](/rules/tally/ruby/missing-bundle-without-development/):
+the Dockerfile binds `RAILS_ENV` (or `RACK_ENV`) to `"production"` somewhere, **or** the stage has no explicit
+non-production marker and the rest of the stage shape (Ruby base, no dev-stage name) implies a runtime image.
+
+Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug` are skipped, as are stages
+whose effective env binds `RAILS_ENV`/`RACK_ENV` to `development` or `test`. Non-Ruby stages and Windows
+stages are also skipped.
+
+The compliance check honors POSIX/Docker ordering semantics:
+
+- **`ENV BUNDLE_DEPLOYMENT`** is evaluated at the env state *visible to the install RUN*. An `ENV` that
+  lands AFTER the install does not retroactively make the install compliant.
+- **`bundle config set ... deployment ...`** is recognized either when it runs in an earlier RUN, or when it
+  precedes the `bundle install` in the same RUN's parsed command chain. A `bundle config set` in a LATER RUN
+  is not enough — Bundler config only affects subsequent installs.
+
+### Context-aware refinement
+
+When tally is invoked with `--context` (or via Bake/Compose), the rule consults the project's `Gemfile.lock`:
+
+- **Severity escalation when no lockfile exists.** If `Gemfile.lock` is not observable in the build context
+  (no checked-in lockfile, or `.dockerignore` excludes it), the rule's severity escalates from `warning` to
+  `error`. Without a lockfile, Bundler resolves dependencies from `Gemfile` afresh on every build, which
+  produces non-deterministic images. Combined with the missing `BUNDLE_DEPLOYMENT`, this is a hard
+  reproducibility failure, not just a hygiene issue.
+- **Fix wording when the stage has `bundle config set frozen 'true'`.** The detail text mentions that
+  `BUNDLE_DEPLOYMENT=1` is the strict superset — `frozen` only locks the lockfile, while `deployment` also
+  pins `BUNDLE_PATH`, requires the lockfile to exist, and excludes dev/test gems. The fix itself is unchanged.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+COPY . .
+CMD ["bin/rails", "server"]
+```
+
+### After
+
+The Rails-generator-style fix declares `BUNDLE_DEPLOYMENT` once at the top of the stage so every nested
+`bundle install` (including any inside CI scripts or entrypoints) honors it:
+
+```dockerfile
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+ENV BUNDLE_DEPLOYMENT="1"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+COPY . .
+CMD ["bin/rails", "server"]
+```
+
+`bundle config set --local deployment 'true'` is also accepted:
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle config set --local deployment 'true' \
+    && bundle install
+```
+
+## Auto-fix
+
+The rule offers a `FixSafe` that inserts `ENV BUNDLE_DEPLOYMENT="1"` on the line immediately following the
+stage's `FROM`. Insertion is zero-width at column 0, so it composes cleanly with other rule edits in the same
+stage.
+
+## References
+
+- [Rails Dockerfile generator template](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt) —
+  emits `ENV BUNDLE_DEPLOYMENT="1"` in the base stage.
+- [Bundler `bundle install` documentation](https://bundler.io/v2.5/man/bundle-install.1.html) — deployment-mode contract.
+- [Bundler 2 upgrade guide](https://bundler.io/guides/bundler_2_upgrade.html) — deprecation of `bundle install --deployment` flag form.

--- a/internal/integration/__snapshots__/TestLint_ruby-bundle-deployment-no-lockfile_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-bundle-deployment-no-lockfile_1.snap.json
@@ -1,0 +1,59 @@
+{
+  "files": [
+    {
+      "file": "testdata/ruby-bundle-deployment-no-lockfile/Dockerfile",
+      "violations": [
+        {
+          "detail": "Production stages that run `bundle install` should set `ENV BUNDLE_DEPLOYMENT=\"1\"` (or `bundle config set --local deployment 'true'`). Without it, Bundler may mutate `Gemfile.lock` at build time, install gems outside the project, and skip the lockfile-required check — defeating the \"the lockfile is the build input\" property. No `Gemfile.lock` is observable in the build context — without one, Bundler resolves from `Gemfile` fresh on every build and produces an undeterministic image.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/missing-bundle-deployment/",
+          "location": {
+            "end": {
+              "column": 18,
+              "line": 4
+            },
+            "file": "testdata/ruby-bundle-deployment-no-lockfile/Dockerfile",
+            "start": {
+              "column": 11,
+              "line": 4
+            }
+          },
+          "message": "Production stage runs bundle install without BUNDLE_DEPLOYMENT=1",
+          "rule": "tally/ruby/missing-bundle-deployment",
+          "severity": "error",
+          "sourceCode": "RUN bundle install",
+          "suggestedFix": {
+            "description": "Add ENV BUNDLE_DEPLOYMENT=\"1\" to enforce Bundler deployment-mode contract",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 2
+                  },
+                  "file": "testdata/ruby-bundle-deployment-no-lockfile/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 2
+                  }
+                },
+                "newText": "ENV BUNDLE_DEPLOYMENT=\"1\"\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 1,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/integration/__snapshots__/TestLint_ruby-bundle-deployment-no-lockfile_1.snap.json
+++ b/internal/integration/__snapshots__/TestLint_ruby-bundle-deployment-no-lockfile_1.snap.json
@@ -4,7 +4,7 @@
       "file": "testdata/ruby-bundle-deployment-no-lockfile/Dockerfile",
       "violations": [
         {
-          "detail": "Production stages that run `bundle install` should set `ENV BUNDLE_DEPLOYMENT=\"1\"` (or `bundle config set --local deployment 'true'`). Without it, Bundler may mutate `Gemfile.lock` at build time, install gems outside the project, and skip the lockfile-required check — defeating the \"the lockfile is the build input\" property. No `Gemfile.lock` is observable in the build context — without one, Bundler resolves from `Gemfile` fresh on every build and produces an undeterministic image.",
+          "detail": "Production stages that run `bundle install` should set `ENV BUNDLE_DEPLOYMENT=\"1\"` (or `bundle config set --local deployment 'true'`). Without it, Bundler may mutate `Gemfile.lock` at build time, install gems outside the project, and skip the lockfile-required check — defeating the \"the lockfile is the build input\" property. No `Gemfile.lock` is observable in the build context — without one, Bundler resolves from `Gemfile` fresh on every build and produces an indeterministic image.",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/missing-bundle-deployment/",
           "location": {
             "end": {

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-deployment/.tally.toml
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-deployment/.tally.toml
@@ -1,0 +1,9 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/missing-bundle-deployment"]
+exclude = ["*"]
+
+[output]
+fail-level = "none"

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-deployment/Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-deployment/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-deployment/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-deployment/fixed_1.snap.Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:3.3-slim
+ENV BUNDLE_DEPLOYMENT="1"
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-missing-bundle-deployment/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-missing-bundle-deployment/report_1.snap.md
@@ -1,0 +1,2 @@
+Fixed 1 issues
+**No issues found**

--- a/internal/integration/fixtures/lint/ruby-missing-bundle-deployment/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-missing-bundle-deployment/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/missing-bundle-deployment"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-missing-bundle-deployment/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-missing-bundle-deployment/Dockerfile
@@ -1,0 +1,31 @@
+# Production-shaped stage running bundle install without BUNDLE_DEPLOYMENT.
+# Canonical violation.
+FROM ruby:3.3-slim AS app
+ENV RAILS_ENV="production"
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# Compliant: ENV BUNDLE_DEPLOYMENT="1" matches the Rails generator template.
+FROM ruby:3.3-slim AS app-compliant
+ENV RAILS_ENV="production"
+ENV BUNDLE_DEPLOYMENT="1"
+RUN bundle install
+
+# Compliant: bundle config set --local deployment 'true' before install.
+FROM ruby:3.3-slim AS app-config
+RUN bundle config set --local deployment 'true' \
+    && bundle install
+
+# Compliant: bundle install --deployment (deprecated 2.x flag, but counts
+# for THIS rule — deprecated-flags rule catches it separately).
+FROM ruby:3.3-slim AS app-deprecated-flag
+RUN bundle install --deployment
+
+# Stage marked dev: rule skips on principle.
+FROM ruby:3.3-slim AS dev
+RUN bundle install
+
+# RAILS_ENV=development demotes the stage to non-production.
+FROM ruby:3.3-slim AS app-explicit-dev
+ENV RAILS_ENV="development"
+RUN bundle install

--- a/internal/integration/fixtures/lint/ruby-missing-bundle-deployment/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-missing-bundle-deployment/result_1.snap.json
@@ -1,0 +1,59 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-missing-bundle-deployment/Dockerfile",
+      "violations": [
+        {
+          "detail": "Production stages that run `bundle install` should set `ENV BUNDLE_DEPLOYMENT=\"1\"` (or `bundle config set --local deployment 'true'`). Without it, Bundler may mutate `Gemfile.lock` at build time, install gems outside the project, and skip the lockfile-required check — defeating the \"the lockfile is the build input\" property. No `Gemfile.lock` is observable in the build context — without one, Bundler resolves from `Gemfile` fresh on every build and produces an indeterministic image.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/missing-bundle-deployment/",
+          "location": {
+            "end": {
+              "column": 18,
+              "line": 6
+            },
+            "file": "fixtures/lint/ruby-missing-bundle-deployment/Dockerfile",
+            "start": {
+              "column": 11,
+              "line": 6
+            }
+          },
+          "message": "Production stage runs bundle install without BUNDLE_DEPLOYMENT=1",
+          "rule": "tally/ruby/missing-bundle-deployment",
+          "severity": "error",
+          "sourceCode": "RUN bundle install",
+          "suggestedFix": {
+            "description": "Add ENV BUNDLE_DEPLOYMENT=\"1\" to enforce Bundler deployment-mode contract",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 4
+                  },
+                  "file": "fixtures/lint/ruby-missing-bundle-deployment/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 4
+                  }
+                },
+                "newText": "ENV BUNDLE_DEPLOYMENT=\"1\"\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 1,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/integration/lint_cases_test.go
+++ b/internal/integration/lint_cases_test.go
@@ -127,6 +127,16 @@ func lintCases(t *testing.T) []lintCase {
 			useContext: true,
 		},
 		{
+			// Context-aware refinement for tally/ruby/missing-bundle-deployment:
+			// no Gemfile.lock observable in the build context — severity should
+			// escalate to error.
+			name:       "ruby-bundle-deployment-no-lockfile",
+			dir:        "ruby-bundle-deployment-no-lockfile",
+			args:       append([]string{"--format", "json"}, mustSelectRules("tally/ruby/missing-bundle-deployment")...),
+			wantExit:   1,
+			useContext: true,
+		},
+		{
 			name:  "discovery-directory",
 			dir:   "discovery-directory",
 			args:  append([]string{"--format", "json"}, mustSelectRules("tally/max-lines")...),

--- a/internal/integration/testdata/ruby-bundle-deployment-no-lockfile/Dockerfile
+++ b/internal/integration/testdata/ruby-bundle-deployment-no-lockfile/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+COPY Gemfile ./
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/testdata/ruby-bundle-deployment-no-lockfile/Gemfile
+++ b/internal/integration/testdata/ruby-bundle-deployment-no-lockfile/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+ruby "3.3.5"
+
+gem "rails", "~> 8.0"
+gem "puma"

--- a/internal/rules/tally/ruby/missing_bundle_deployment.go
+++ b/internal/rules/tally/ruby/missing_bundle_deployment.go
@@ -1,0 +1,323 @@
+package ruby
+
+import (
+	"slices"
+	"strings"
+
+	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// MissingBundleDeploymentRuleCode is the full rule code.
+const MissingBundleDeploymentRuleCode = rules.TallyRulePrefix + "ruby/missing-bundle-deployment"
+
+// missingBundleDeploymentFixPriority keeps this rule's edits ordered alongside
+// the other Ruby production-hygiene rules. Same value as the jemalloc rule for
+// predictable cross-rule sequencing.
+const missingBundleDeploymentFixPriority = 88
+
+// MissingBundleDeploymentRule flags production-shaped Ruby stages that run
+// `bundle install` without `BUNDLE_DEPLOYMENT=1` (or the equivalent
+// `bundle config set deployment 'true'`).
+type MissingBundleDeploymentRule struct{}
+
+// NewMissingBundleDeploymentRule creates the rule.
+func NewMissingBundleDeploymentRule() *MissingBundleDeploymentRule {
+	return &MissingBundleDeploymentRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *MissingBundleDeploymentRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            MissingBundleDeploymentRuleCode,
+		Name:            "Production bundle install must run in deployment mode",
+		Description:     "Production stage runs bundle install without BUNDLE_DEPLOYMENT=1",
+		DocURL:          rules.TallyDocURL(MissingBundleDeploymentRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "correctness",
+		FixPriority:     missingBundleDeploymentFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *MissingBundleDeploymentRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	sm := input.SourceMap()
+	rubyFacts := input.Facts.RubyFacts()
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+		if !stageLooksProduction(input, sf) {
+			continue
+		}
+		violations = append(violations, r.checkStage(input, sf, sm, rubyFacts, meta)...)
+	}
+	return violations
+}
+
+func (r *MissingBundleDeploymentRule) checkStage(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	rubyFacts *rubyfacts.RubyFacts,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	// Compliance is evaluated at each `bundle install` invocation, not at
+	// stage end. Docker ENV is forward-only and `bundle config set deployment`
+	// only affects subsequent installs, so an env or config landing AFTER an
+	// install can't retroactively make that install compliant.
+	configBeforeIdx := false
+	stageHasFrozenSignal := stageHasFrozenConfig(sf)
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		if !configBeforeIdx && runHasBundleConfigSetDeployment(runFacts) {
+			configBeforeIdx = true
+		}
+		install := findFirstBundleInstall(runFacts)
+		if install == nil {
+			continue
+		}
+		// `bundle install --deployment` is the deprecated 2.x flag form;
+		// the deprecated-flags rule will catch it separately, so for THIS
+		// rule it counts as compliant.
+		if installHasDeploymentFlag(*install) {
+			continue
+		}
+		if envFactsContainBundleDeploymentSignal(runFacts.Env) {
+			continue
+		}
+		if configBeforeIdx || runConfiguresBundleDeploymentBeforeInstall(runFacts, *install) {
+			continue
+		}
+
+		severity := meta.DefaultSeverity
+		// Refinement: when Gemfile.lock is not observable in the build
+		// context, running `bundle install` in production is more dangerous
+		// — Bundler resolves from Gemfile fresh on every build, so the
+		// build is non-deterministic. Bump severity to error.
+		if rubyFacts != nil && rubyFacts.Lockfile == nil {
+			severity = rules.SeverityError
+		}
+
+		loc := bundleInstallViolationLocation(input.File, runFacts, *install, sm)
+		v := rules.NewViolation(loc, meta.Code, meta.Description, severity).
+			WithDocURL(meta.DocURL).
+			WithDetail(missingBundleDeploymentDetail(stageHasFrozenSignal, severity))
+		if fix := buildBundleDeploymentFix(input, sf, sm, meta.FixPriority); fix != nil {
+			v = v.WithSuggestedFix(fix)
+		}
+		// Report once per stage even when the stage has multiple
+		// `bundle install` invocations — the missing ENV is a stage-level
+		// issue, not a per-RUN one.
+		return []rules.Violation{v}
+	}
+	return nil
+}
+
+func missingBundleDeploymentDetail(hasFrozenSignal bool, severity rules.Severity) string {
+	base := "Production stages that run `bundle install` should set " +
+		"`ENV BUNDLE_DEPLOYMENT=\"1\"` (or `bundle config set --local deployment 'true'`). " +
+		"Without it, Bundler may mutate `Gemfile.lock` at build time, install gems outside the project, " +
+		"and skip the lockfile-required check — defeating the \"the lockfile is the build input\" property."
+	if hasFrozenSignal {
+		base += " The stage already runs `bundle config set frozen 'true'`, but `BUNDLE_DEPLOYMENT=1` is the " +
+			"strict superset: it also pins `BUNDLE_PATH`, requires the lockfile to exist, and excludes dev/test gems."
+	}
+	if severity == rules.SeverityError {
+		base += " No `Gemfile.lock` is observable in the build context — without one, Bundler resolves from " +
+			"`Gemfile` fresh on every build and produces an indeterministic image."
+	}
+	return base
+}
+
+// envFactsContainBundleDeploymentSignal reports whether the env snapshot at
+// a RUN site already declares `BUNDLE_DEPLOYMENT=1` (or any non-empty
+// truthy value) via an ENV instruction. Only ENV-bound values count;
+// build-time-only ARG values do not affect runtime install behaviour.
+func envFactsContainBundleDeploymentSignal(env facts.EnvFacts) bool {
+	value := strings.TrimSpace(env.Values["BUNDLE_DEPLOYMENT"])
+	if value == "" || strings.EqualFold(value, "false") || value == "0" {
+		return false
+	}
+	if _, ok := env.Bindings["BUNDLE_DEPLOYMENT"]; !ok {
+		return false
+	}
+	return true
+}
+
+// runHasBundleConfigSetDeployment reports whether the RUN runs
+// `bundle config set [--local|--global] deployment <truthy>`.
+func runHasBundleConfigSetDeployment(runFacts *facts.RunFacts) bool {
+	if runFacts == nil {
+		return false
+	}
+	return slices.ContainsFunc(runFacts.CommandInfos, bundleConfigSetEnablesDeployment)
+}
+
+// runConfiguresBundleDeploymentBeforeInstall reports whether the RUN invokes
+// `bundle config set ... deployment ...` at a command position *before* the
+// `bundle install`. The position check uses the parsed CommandInfo source
+// ranges — `bundle config set` and `bundle install` chained with `&&` in the
+// same RUN both yield ordered CommandInfo entries.
+func runConfiguresBundleDeploymentBeforeInstall(
+	runFacts *facts.RunFacts,
+	install shell.CommandInfo,
+) bool {
+	if runFacts == nil {
+		return false
+	}
+	for _, ci := range runFacts.CommandInfos {
+		if !bundleConfigSetEnablesDeployment(ci) {
+			continue
+		}
+		if commandPrecedes(ci, install) {
+			return true
+		}
+	}
+	return false
+}
+
+// bundleConfigSetEnablesDeployment reports whether a CommandInfo represents
+// a `bundle config set [--local|--global] deployment <truthy>` invocation.
+//
+// Recognized shapes (Bundler 2.x):
+//
+//	bundle config set deployment true
+//	bundle config set deployment 'true'
+//	bundle config set --local deployment true
+//	bundle config set --global deployment 'true'
+//
+// The legacy 2-arg form (`bundle config deployment true`) is intentionally
+// not recognized: Bundler 2 deprecated it in favor of `bundle config set ...`.
+func bundleConfigSetEnablesDeployment(ci shell.CommandInfo) bool {
+	return bundleConfigSetEnablesKey(ci, "deployment")
+}
+
+// bundleConfigSetEnablesFrozen reports whether a CommandInfo represents
+// `bundle config set ... frozen <truthy>`.
+func bundleConfigSetEnablesFrozen(ci shell.CommandInfo) bool {
+	return bundleConfigSetEnablesKey(ci, "frozen")
+}
+
+// bundleConfigSetEnablesKey reports whether a CommandInfo represents
+// `bundle config set [--local|--global] <key> <truthy>` for the given key.
+// Truthy values: "true", "1" (case-insensitive, with surrounding quotes
+// stripped). Used to detect deployment / frozen settings.
+func bundleConfigSetEnablesKey(ci shell.CommandInfo, key string) bool {
+	if !strings.EqualFold(ci.Name, "bundle") || !strings.EqualFold(ci.Subcommand, "config") {
+		return false
+	}
+	args := argsAfterFirstMatch(ci.Args, ci.Subcommand)
+	for len(args) > 0 && strings.HasPrefix(args[0], "-") {
+		args = args[1:]
+	}
+	if len(args) < 3 {
+		return false
+	}
+	if !strings.EqualFold(args[0], "set") {
+		return false
+	}
+	keyIdx := -1
+	for i, a := range args[1:] {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		if strings.EqualFold(a, key) {
+			keyIdx = i + 1
+			break
+		}
+	}
+	if keyIdx < 0 || keyIdx+1 >= len(args) {
+		return false
+	}
+	value := strings.Trim(args[keyIdx+1], `"'`)
+	return strings.EqualFold(value, "true") || value == "1"
+}
+
+// stageHasFrozenConfig reports whether any RUN in the stage runs
+// `bundle config set ... frozen <truthy>`. Used only for fix wording —
+// the rule still fires because frozen-only is not equivalent to deployment.
+func stageHasFrozenConfig(sf *facts.StageFacts) bool {
+	if sf == nil {
+		return false
+	}
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		if slices.ContainsFunc(runFacts.CommandInfos, bundleConfigSetEnablesFrozen) {
+			return true
+		}
+	}
+	return false
+}
+
+// installHasDeploymentFlag reports whether a parsed `bundle install` command
+// carries the deprecated `--deployment` flag. The deprecated-flags rule will
+// fire on it separately, but for THIS rule it counts as compliant.
+func installHasDeploymentFlag(install shell.CommandInfo) bool {
+	for _, a := range install.Args {
+		if a == "--deployment" || strings.HasPrefix(a, "--deployment=") {
+			return true
+		}
+	}
+	return false
+}
+
+// buildBundleDeploymentFix emits the canonical Rails-generator-style fix:
+// insert `ENV BUNDLE_DEPLOYMENT="1"` at the top of the stage. Insertion is
+// zero-width at column 0 of the line immediately after the stage's `FROM`,
+// matching the Rails 7.1 generator template's placement of `ENV BUNDLE_*`.
+func buildBundleDeploymentFix(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	priority int,
+) *rules.SuggestedFix {
+	if sf == nil || sm == nil {
+		return nil
+	}
+	if sf.Index < 0 || sf.Index >= len(input.Stages) {
+		return nil
+	}
+	stage := input.Stages[sf.Index]
+	if len(stage.Location) == 0 {
+		return nil
+	}
+	insertLine := stage.Location[len(stage.Location)-1].End.Line + 1
+	return &rules.SuggestedFix{
+		Description: `Add ENV BUNDLE_DEPLOYMENT="1" to enforce Bundler deployment-mode contract`,
+		Safety:      rules.FixSafe,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
+			NewText:  "ENV BUNDLE_DEPLOYMENT=\"1\"\n",
+		}},
+	}
+}
+
+func init() {
+	rules.Register(NewMissingBundleDeploymentRule())
+}

--- a/internal/rules/tally/ruby/missing_bundle_deployment_test.go
+++ b/internal/rules/tally/ruby/missing_bundle_deployment_test.go
@@ -1,0 +1,193 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestMissingBundleDeploymentRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewMissingBundleDeploymentRule().Metadata()
+	if meta.Code != MissingBundleDeploymentRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, MissingBundleDeploymentRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityWarning {
+		t.Errorf("DefaultSeverity = %v, want Warning", meta.DefaultSeverity)
+	}
+	if meta.Category != "correctness" {
+		t.Errorf("Category = %q, want %q", meta.Category, "correctness")
+	}
+	if meta.FixPriority != missingBundleDeploymentFixPriority {
+		t.Errorf("FixPriority = %d, want %d", meta.FixPriority, missingBundleDeploymentFixPriority)
+	}
+	if !strings.HasPrefix(meta.DocURL, "https://tally.wharflab.com/rules/tally/ruby/") {
+		t.Errorf("DocURL = %q, want tally/ruby/ prefix", meta.DocURL)
+	}
+}
+
+func TestMissingBundleDeploymentRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewMissingBundleDeploymentRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "ruby base running bundle install without BUNDLE_DEPLOYMENT triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "shell-form bundle install with extra flags triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install --jobs=4 --retry=3
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "BUNDLE_DEPLOYMENT explicitly false still triggers",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_DEPLOYMENT="false"
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Regression: ordering matters ---
+		{
+			Name: "ENV BUNDLE_DEPLOYMENT after the install does NOT suppress (Docker ENV is forward-only)",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+ENV BUNDLE_DEPLOYMENT="1"
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "bundle config set deployment in a later RUN does NOT suppress an earlier install",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+RUN bundle config set --local deployment 'true'
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: ENV BUNDLE_DEPLOYMENT=1 ---
+		{
+			Name: "ENV BUNDLE_DEPLOYMENT=1 (numeric) suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_DEPLOYMENT="1"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ENV BUNDLE_DEPLOYMENT=true suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_DEPLOYMENT=true
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: bundle config set deployment ---
+		{
+			Name: "bundle config set deployment 'true' before install in same RUN suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle config set --local deployment 'true' && bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bundle config set deployment in earlier RUN suppresses subsequent install",
+			Content: `FROM ruby:3.3-slim
+RUN bundle config set --global deployment true
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: bundle install --deployment (deprecated, but compliant for THIS rule) ---
+		{
+			Name: "bundle install --deployment (deprecated 2.x flag) suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install --deployment
+`,
+			WantViolations: 0,
+		},
+		// --- Suppressions ---
+		{
+			Name: "dev stage skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "RAILS_ENV=development demotes",
+			Content: `FROM ruby:3.3-slim
+ENV RAILS_ENV="development"
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Ruby stage skipped",
+			Content: `FROM debian:bookworm-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Frozen-only is partial-compliance: rule still fires, detail mentions frozen ---
+		{
+			Name: "bundle config set frozen alone still triggers (frozen != deployment)",
+			Content: `FROM ruby:3.3-slim
+RUN bundle config set --local frozen 'true' && bundle install
+`,
+			WantViolations: 1,
+		},
+	})
+}
+
+func TestMissingBundleDeploymentRule_FixSafety(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+RUN bundle install
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewMissingBundleDeploymentRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSafe {
+		t.Errorf("Safety = %v, want FixSafe", v.SuggestedFix.Safety)
+	}
+	if !strings.Contains(v.SuggestedFix.Edits[0].NewText, `BUNDLE_DEPLOYMENT="1"`) {
+		t.Errorf("fix text missing BUNDLE_DEPLOYMENT: %q", v.SuggestedFix.Edits[0].NewText)
+	}
+}
+
+func TestMissingBundleDeploymentRule_FrozenSignalAddsDetailText(t *testing.T) {
+	t.Parallel()
+
+	// Frozen-only configuration: the rule still fires but the detail text
+	// should mention that BUNDLE_DEPLOYMENT is the strict superset.
+	content := `FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+RUN bundle config set --local frozen 'true' && bundle install
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewMissingBundleDeploymentRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	if !strings.Contains(violations[0].Detail, "strict superset") {
+		t.Errorf("detail should mention 'strict superset' when frozen is set; got: %q",
+			violations[0].Detail)
+	}
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/missing-bundle-deployment`](https://tally.wharflab.com/rules/tally/ruby/missing-bundle-deployment/) — Section 4.1 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

A production-shaped Ruby stage that runs `bundle install` without `BUNDLE_DEPLOYMENT=1` (or `bundle config set deployment 'true'`) silently lets Bundler mutate `Gemfile.lock`, install gems outside the project, and skip the lockfile-required check — defeating the "the lockfile is the build input" property and pushing Bundler back into 1.x semantics. The Rails generator template carries `ENV BUNDLE_DEPLOYMENT="1"` for exactly this reason; only 37 of 196 Dockerfiles in the corpus do.

- **Compliance signals:** `ENV BUNDLE_DEPLOYMENT=1`/`true`, `bundle config set [--local|--global] deployment 'true'`, or the deprecated `bundle install --deployment` flag (caught separately by `tally/ruby/deprecated-bundler-install-flags`).
- **Suppressions:** dev/test/ci stages, stages binding `RAILS_ENV`/`RACK_ENV` to `development`/`test`, non-Ruby stages.
- **Per-RUN ordering:** ENV in a later RUN does not retroactively make an earlier install compliant. `bundle config set deployment` only counts when it precedes the install (in an earlier RUN, or earlier in the same RUN's parsed command chain).
- **Context-aware refinements:**
  - When `Gemfile.lock` is NOT observable in the build context, severity escalates from `warning` to `error` — running `bundle install` without a lockfile produces non-deterministic builds. The detail text explains why.
  - When the stage already runs `bundle config set frozen 'true'`, the detail text mentions that `BUNDLE_DEPLOYMENT=1` is the strict superset (it also pins `BUNDLE_PATH`, requires the lockfile, excludes dev/test gems).
- **Auto-fix:** `FixSafe`. Inserts `ENV BUNDLE_DEPLOYMENT="1"` on the line immediately after the stage's `FROM`.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint and fix fixtures: `internal/integration/fixtures/{lint,fix}/ruby-missing-bundle-deployment/`
- [x] Context-aware fixture: `internal/integration/testdata/ruby-bundle-deployment-no-lockfile/` (Gemfile but no Gemfile.lock → severity escalates to error)