### PR TITLE
feat(rules): add tally/ruby/redundant-bundler-install

### DIFF
--- a/_docs/rules/tally/ruby/redundant-bundler-install.mdx
+++ b/_docs/rules/tally/ruby/redundant-bundler-install.mdx
@@ -1,0 +1,97 @@
+---
+title: "tally/ruby/redundant-bundler-install"
+description: "`gem install bundler` on official `ruby:*` images is redundant and re-installs an already-present tool."
+---
+
+`gem install bundler` on official `ruby:*` images is redundant — Bundler 2.x already ships with the image.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning |
+| Category | Performance |
+| Default | Enabled |
+| Auto-fix | Yes (`FixSuggestion`) |
+
+## Description
+
+The official [`docker-library/ruby`](https://github.com/docker-library/ruby/blob/master/Dockerfile-debian.template)
+image installs and pre-resolves Bundler before publishing each tag. Bundler is on `$PATH` immediately, ready
+to use. Running `gem install bundler` after `FROM ruby:...` re-downloads, recompiles, and re-installs the
+same tool — wasting build time and introducing version drift between local development and CI.
+
+The corpus shows this pattern in **55 of 196 Dockerfiles**, including some from large projects
+(`basecamp/kamal`, `basecamp/fizzy`, `chatwoot/chatwoot`).
+
+This rule fires when:
+
+- The stage's effective base image is an official `ruby:*` image (or a known devcontainer Ruby image).
+- A `RUN` instruction invokes `gem install bundler` (in any of its parsed forms).
+
+The rule treats stage refs (`FROM <stage>`) as inheriting the original external base, so a stage that's
+based on an earlier `FROM ruby:3.3-slim AS builder` is also flagged.
+
+Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug` are skipped.
+
+### Suppressions
+
+The rule does NOT fire when the base image is **not** an official `ruby:*` image — for example
+`FROM debian:bookworm-slim` followed by manual Ruby installation, or `FROM alpine` plus `apk add ruby`. In
+those cases `gem install bundler` may be the right thing to do because the base image doesn't ship Bundler.
+
+It also does NOT fire on Ruby derivatives like `jruby:*`, `truffleruby:*`, or `phusion/passenger-ruby:*`.
+These images don't carry the same Bundler-pre-install guarantee, so a manual install may be intentional.
+
+### Context-aware refinement
+
+When tally is invoked with `--context` and `Gemfile.lock` is observable, the violation detail mentions the
+exact Bundler version recorded in the lockfile's `BUNDLED WITH` block. If a project genuinely needs that
+specific Bundler version, the recommended replacement is Bundler's own version-aware shim:
+
+```dockerfile
+RUN bundle _2.5.6_ install
+```
+
+— which uses the BUNDLED WITH version from `Gemfile.lock` directly, without a fresh `gem install`.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+RUN gem install bundler
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+```
+
+### After
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+```
+
+If a specific Bundler version is required:
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle _2.5.6_ install
+```
+
+## Auto-fix
+
+The rule offers a `FixSuggestion`:
+
+- When the offending `RUN` contains **only** `gem install bundler`, the fix deletes the entire `RUN` line.
+- When the install is part of a chained command (`RUN gem install bundler && bundle install`), the fix is a
+  non-edit suggestion — chained command rewrites are too easy to get wrong, so the rule explains what to do
+  but doesn't auto-rewrite. Edit the chain manually.
+
+## References
+
+- [docker-library/ruby Dockerfile.template](https://github.com/docker-library/ruby/blob/master/Dockerfile-debian.template) —
+  Bundler is installed and pre-resolved before publishing.
+- [Bundler `bundle _<version>_` version-shim documentation](https://bundler.io/v2.5/man/bundle.1.html) —
+  the right way to pin a specific Bundler version.

--- a/internal/integration/fixtures/fix/ruby-redundant-bundler-install/.tally.toml
+++ b/internal/integration/fixtures/fix/ruby-redundant-bundler-install/.tally.toml
@@ -1,0 +1,11 @@
+unsafe-fixes = true
+
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/redundant-bundler-install"]
+exclude = ["*"]
+
+[output]
+fail-level = "none"

--- a/internal/integration/fixtures/fix/ruby-redundant-bundler-install/Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-redundant-bundler-install/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+RUN gem install bundler
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-redundant-bundler-install/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-redundant-bundler-install/fixed_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-redundant-bundler-install/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-redundant-bundler-install/report_1.snap.md
@@ -1,0 +1,2 @@
+Fixed 1 issues
+**No issues found**

--- a/internal/integration/fixtures/lint/ruby-redundant-bundler-install/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-redundant-bundler-install/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/redundant-bundler-install"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-redundant-bundler-install/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-redundant-bundler-install/Dockerfile
@@ -1,0 +1,26 @@
+# Canonical violation: gem install bundler on official ruby:* base.
+FROM ruby:3.3-slim AS app
+RUN gem install bundler
+CMD ["bin/rails", "server"]
+
+# Version-pinned form also triggers — pin matches lockfile's BUNDLED WITH
+# would still be a no-op since the image's Bundler is already on PATH.
+FROM ruby:3.3-slim AS app-pinned
+RUN gem install bundler -v 2.5.6
+
+# Chained-command form triggers; fix is a non-edit suggestion.
+FROM ruby:3.3-slim AS app-chained
+RUN apt-get update && gem install bundler && bundle install
+
+# Compliant: alpine base not from official ruby:*, manual install of Ruby.
+FROM alpine:3.20 AS alpine-app
+RUN apk add ruby ruby-dev && gem install bundler
+
+# Compliant: jruby is a Ruby derivative, not official ruby:*; no Bundler
+# pre-install guarantee, so manual install may be intentional.
+FROM jruby:9.4 AS jruby-app
+RUN gem install bundler
+
+# Skipped: dev stage.
+FROM ruby:3.3-slim AS dev
+RUN gem install bundler

--- a/internal/integration/fixtures/lint/ruby-redundant-bundler-install/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-redundant-bundler-install/result_1.snap.json
@@ -1,0 +1,125 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-redundant-bundler-install/Dockerfile",
+      "violations": [
+        {
+          "detail": "Official `ruby:*` images ship Bundler 2.x pre-installed and resolved on `$PATH`. Reinstalling Bundler via `gem install bundler` re-downloads and recompiles a tool that's already there, slowing every build and introducing version drift between development and CI. If a specific Bundler version is required, the `Gemfile.lock` BUNDLED WITH block plus Bundler's version-aware shim (`bundle _\u003cversion\u003e_ install`) handles it without a fresh `gem install`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/redundant-bundler-install/",
+          "location": {
+            "end": {
+              "column": 23,
+              "line": 3
+            },
+            "file": "fixtures/lint/ruby-redundant-bundler-install/Dockerfile",
+            "start": {
+              "column": 4,
+              "line": 3
+            }
+          },
+          "message": "`gem install bundler` is redundant on official ruby:* images that already ship Bundler 2.x",
+          "rule": "tally/ruby/redundant-bundler-install",
+          "severity": "warning",
+          "sourceCode": "RUN gem install bundler",
+          "suggestedFix": {
+            "description": "Remove `gem install bundler` — Bundler 2.x ships with the official ruby:* image",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 4
+                  },
+                  "file": "fixtures/lint/ruby-redundant-bundler-install/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 3
+                  }
+                },
+                "newText": ""
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Official `ruby:*` images ship Bundler 2.x pre-installed and resolved on `$PATH`. Reinstalling Bundler via `gem install bundler` re-downloads and recompiles a tool that's already there, slowing every build and introducing version drift between development and CI. If a specific Bundler version is required, the `Gemfile.lock` BUNDLED WITH block plus Bundler's version-aware shim (`bundle _\u003cversion\u003e_ install`) handles it without a fresh `gem install`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/redundant-bundler-install/",
+          "location": {
+            "end": {
+              "column": 32,
+              "line": 9
+            },
+            "file": "fixtures/lint/ruby-redundant-bundler-install/Dockerfile",
+            "start": {
+              "column": 4,
+              "line": 9
+            }
+          },
+          "message": "`gem install bundler` is redundant on official ruby:* images that already ship Bundler 2.x",
+          "rule": "tally/ruby/redundant-bundler-install",
+          "severity": "warning",
+          "sourceCode": "RUN gem install bundler -v 2.5.6",
+          "suggestedFix": {
+            "description": "Remove `gem install bundler` — Bundler 2.x ships with the official ruby:* image",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 10
+                  },
+                  "file": "fixtures/lint/ruby-redundant-bundler-install/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 9
+                  }
+                },
+                "newText": ""
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Official `ruby:*` images ship Bundler 2.x pre-installed and resolved on `$PATH`. Reinstalling Bundler via `gem install bundler` re-downloads and recompiles a tool that's already there, slowing every build and introducing version drift between development and CI. If a specific Bundler version is required, the `Gemfile.lock` BUNDLED WITH block plus Bundler's version-aware shim (`bundle _\u003cversion\u003e_ install`) handles it without a fresh `gem install`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/redundant-bundler-install/",
+          "location": {
+            "end": {
+              "column": 41,
+              "line": 13
+            },
+            "file": "fixtures/lint/ruby-redundant-bundler-install/Dockerfile",
+            "start": {
+              "column": 22,
+              "line": 13
+            }
+          },
+          "message": "`gem install bundler` is redundant on official ruby:* images that already ship Bundler 2.x",
+          "rule": "tally/ruby/redundant-bundler-install",
+          "severity": "warning",
+          "sourceCode": "RUN apt-get update \u0026\u0026 gem install bundler \u0026\u0026 bundle install",
+          "suggestedFix": {
+            "description": "Remove the `gem install bundler` step from this chain — Bundler 2.x ships with the official ruby:* image",
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 3,
+    "warnings": 3
+  }
+}

--- a/internal/rules/tally/ruby/redundant_bundler_install.go
+++ b/internal/rules/tally/ruby/redundant_bundler_install.go
@@ -171,11 +171,57 @@ func isGemInstallBundler(ci shell.CommandInfo) bool {
 			// Skip the `install` subcommand token itself.
 			continue
 		}
-		if a == "bundler" {
+		if strings.EqualFold(a, "bundler") {
 			return true
 		}
 	}
 	return false
+}
+
+// gemInstallTargetsOnlyBundler reports whether the `gem install` invocation
+// installs ONLY bundler (with optional version-pin flags). Used by the fix
+// builder to avoid auto-deleting RUNs that install bundler alongside other
+// gems, which would silently remove dependencies the user explicitly listed.
+//
+// Recognized "bundler-only" shapes:
+//
+//	gem install bundler
+//	gem install bundler -v 2.5.6
+//	gem install bundler -v=2.5.6
+//	gem install bundler --version 2.5.6
+//	gem install bundler --version=2.5.6
+//	gem install -v 2.5.6 bundler
+//
+// Returns false for `gem install bundler rails`, `gem install bundler:2.5.6 rake`,
+// or any other multi-target install.
+func gemInstallTargetsOnlyBundler(ci shell.CommandInfo) bool {
+	sawBundler := false
+	skipNext := false
+	for i, a := range ci.Args {
+		if i == 0 && strings.EqualFold(a, ci.Subcommand) {
+			continue
+		}
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		// Version-pin flags consume a following arg as the value.
+		if a == "-v" || a == "--version" {
+			skipNext = true
+			continue
+		}
+		// Any other flag-shaped arg is harmless to the rule.
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		// Non-flag arg: must be exactly "bundler". Any other gem name
+		// (rails, rake, etc.) means this is a multi-target install.
+		if !strings.EqualFold(a, "bundler") {
+			return false
+		}
+		sawBundler = true
+	}
+	return sawBundler
 }
 
 // redundantBundlerInstallLocation prefers the precise command-name span when
@@ -233,9 +279,15 @@ func buildRedundantBundlerInstallFix(
 	if sm == nil {
 		return nil
 	}
-	// When the RUN has only a single command, delete the whole RUN line.
-	// Detect "single command" via CommandInfos length.
-	if len(runFacts.CommandInfos) == 1 && runFacts.CommandInfos[0].Name == cmd.Name {
+	// When the RUN has only a single command AND the install targets only
+	// bundler (no other gems chained as positional args), delete the whole
+	// RUN line. The "only bundler" guard is critical: `gem install bundler
+	// rails` is a single CommandInfo, but auto-deleting that RUN silently
+	// removes the `rails` install too. For multi-target installs we fall
+	// through to the no-edit suggestion below.
+	if len(runFacts.CommandInfos) == 1 &&
+		runFacts.CommandInfos[0].Name == cmd.Name &&
+		gemInstallTargetsOnlyBundler(cmd) {
 		runRanges := runFacts.Run.Location()
 		if len(runRanges) == 0 {
 			return nil

--- a/internal/rules/tally/ruby/redundant_bundler_install.go
+++ b/internal/rules/tally/ruby/redundant_bundler_install.go
@@ -1,0 +1,275 @@
+package ruby
+
+import (
+	"strings"
+
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// RedundantBundlerInstallRuleCode is the full rule code.
+const RedundantBundlerInstallRuleCode = rules.TallyRulePrefix + "ruby/redundant-bundler-install"
+
+// redundantBundlerInstallFixPriority keeps this rule's edits ordered alongside
+// the other Ruby production-hygiene rules.
+const redundantBundlerInstallFixPriority = 88
+
+// RedundantBundlerInstallRule flags `gem install bundler` invocations on
+// stages whose base image is an official `ruby:*` image — Bundler 2.x
+// already ships in the image, so reinstalling it is redundant.
+type RedundantBundlerInstallRule struct{}
+
+// NewRedundantBundlerInstallRule creates the rule.
+func NewRedundantBundlerInstallRule() *RedundantBundlerInstallRule {
+	return &RedundantBundlerInstallRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *RedundantBundlerInstallRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            RedundantBundlerInstallRuleCode,
+		Name:            "Redundant `gem install bundler` on official Ruby base",
+		Description:     "`gem install bundler` is redundant on official ruby:* images that already ship Bundler 2.x",
+		DocURL:          rules.TallyDocURL(RedundantBundlerInstallRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "performance",
+		FixPriority:     redundantBundlerInstallFixPriority,
+	}
+}
+
+// officialRubyImageNames are the familiar names that ship Bundler 2.x
+// pre-installed. Matching is against the parsed reference's familiar name
+// (no domain, no tag).
+var officialRubyImageNames = map[string]bool{
+	"ruby":                            true, // docker.io/library/ruby
+	"ghcr.io/rails/devcontainer/ruby": true,
+}
+
+// Check runs the rule.
+func (r *RedundantBundlerInstallRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	sm := input.SourceMap()
+	rubyFacts := input.Facts.RubyFacts()
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		if !stageBaseIsOfficialRuby(input.Semantic, stageIdx) {
+			continue
+		}
+		violations = append(violations, r.checkStage(input, sf, sm, rubyFacts, meta)...)
+	}
+	return violations
+}
+
+func (r *RedundantBundlerInstallRule) checkStage(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	rubyFacts *rubyfacts.RubyFacts,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	var violations []rules.Violation
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		for _, ci := range runFacts.CommandInfos {
+			if !isGemInstallBundler(ci) {
+				continue
+			}
+			loc := redundantBundlerInstallLocation(input.File, runFacts, ci, sm)
+			v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+				WithDocURL(meta.DocURL).
+				WithDetail(redundantBundlerInstallDetail(rubyFacts))
+			if fix := buildRedundantBundlerInstallFix(input, runFacts, ci, sm, meta.FixPriority); fix != nil {
+				v = v.WithSuggestedFix(fix)
+			}
+			violations = append(violations, v)
+		}
+	}
+	return violations
+}
+
+func redundantBundlerInstallDetail(rubyFacts *rubyfacts.RubyFacts) string {
+	base := "Official `ruby:*` images ship Bundler 2.x pre-installed and resolved on `$PATH`. " +
+		"Reinstalling Bundler via `gem install bundler` re-downloads and recompiles a tool that's " +
+		"already there, slowing every build and introducing version drift between development and CI."
+	if rubyFacts != nil && rubyFacts.Lockfile != nil && rubyFacts.Lockfile.BundledWith != "" {
+		base += " If a specific Bundler version is required, prefer Bundler's own version-shim form " +
+			"(`bundle _" + strings.TrimSpace(rubyFacts.Lockfile.BundledWith) + "_ install`) which uses " +
+			"the version recorded in `Gemfile.lock`'s BUNDLED WITH block — the official image's " +
+			"shim handles this without a fresh `gem install`."
+	} else {
+		base += " If a specific Bundler version is required, the `Gemfile.lock` BUNDLED WITH block " +
+			"plus Bundler's version-aware shim (`bundle _<version>_ install`) handles it without a " +
+			"fresh `gem install`."
+	}
+	return base
+}
+
+// stageBaseIsOfficialRuby reports whether a stage's effective base image is
+// an official ruby:* image (or a known devcontainer Ruby image). Stage refs
+// (`FROM <stage>`) walk the StageRef ancestry to the original external base.
+func stageBaseIsOfficialRuby(sem *semantic.Model, stageIdx int) bool {
+	base := sem.ExternalBase(stageIdx)
+	if base == nil {
+		return false
+	}
+	raw := base.Effective
+	if raw == "" {
+		raw = base.Raw
+	}
+	if raw == "" {
+		return false
+	}
+	named, err := reference.ParseNormalizedNamed(strings.ToLower(raw))
+	if err != nil {
+		return false
+	}
+	familiar := reference.FamiliarName(named)
+	return officialRubyImageNames[familiar]
+}
+
+// isGemInstallBundler reports whether a CommandInfo represents a
+// `gem install bundler` invocation. The shape is:
+//
+//	gem install bundler
+//	gem install bundler -v 2.5.6
+//	gem install bundler --version 2.5.6
+//	gem install -v 2.5.6 bundler
+//
+// We require the literal "bundler" as one of the install targets; other
+// `gem install` lines are out of scope for this rule.
+func isGemInstallBundler(ci shell.CommandInfo) bool {
+	if !strings.EqualFold(ci.Name, "gem") {
+		return false
+	}
+	if !strings.EqualFold(ci.Subcommand, "install") {
+		return false
+	}
+	for i, a := range ci.Args {
+		if i == 0 && strings.EqualFold(a, ci.Subcommand) {
+			// Skip the `install` subcommand token itself.
+			continue
+		}
+		if a == "bundler" {
+			return true
+		}
+	}
+	return false
+}
+
+// redundantBundlerInstallLocation prefers the precise command-name span when
+// available, falling back to the RUN's first range.
+func redundantBundlerInstallLocation(
+	file string,
+	runFacts *facts.RunFacts,
+	cmd shell.CommandInfo,
+	sm *sourcemap.SourceMap,
+) rules.Location {
+	if runFacts == nil || runFacts.Run == nil {
+		return rules.NewFileLocation(file)
+	}
+	runRanges := runFacts.Run.Location()
+	if len(runRanges) == 0 {
+		return rules.NewFileLocation(file)
+	}
+	if cmd.HasCommandRange {
+		line := runRanges[0].Start.Line + cmd.Line
+		startCol := cmd.StartCol
+		endCol := cmd.CommandEndCol
+		// Per-line columns are script-relative on line 0; translate back to
+		// Dockerfile coordinates.
+		if cmd.Line == 0 && sm != nil {
+			offset := shell.DockerfileRunCommandStartCol(sm.Line(line - 1))
+			startCol += offset
+			endCol += offset
+		}
+		// CommandEndLine may be on a later line — fall back to single-line
+		// span when it differs.
+		endLine := runRanges[0].Start.Line + cmd.CommandEndLine
+		if endLine == line {
+			return rules.NewRangeLocation(file, line, startCol, line, endCol)
+		}
+		return rules.NewRangeLocation(file, line, startCol, line, cmd.EndCol+(endCol-startCol))
+	}
+	return rules.NewLocationFromRanges(file, runRanges)
+}
+
+// buildRedundantBundlerInstallFix proposes deleting the entire RUN
+// instruction when it contains *only* the `gem install bundler` step.
+// Otherwise it proposes deleting just the `gem install bundler` from the
+// chained command. In either case the fix is FixSuggestion — the user may
+// have a deliberate reason for the install we can't see.
+func buildRedundantBundlerInstallFix(
+	input rules.LintInput,
+	runFacts *facts.RunFacts,
+	cmd shell.CommandInfo,
+	sm *sourcemap.SourceMap,
+	priority int,
+) *rules.SuggestedFix {
+	if runFacts == nil || runFacts.Run == nil {
+		return nil
+	}
+	if sm == nil {
+		return nil
+	}
+	// When the RUN has only a single command, delete the whole RUN line.
+	// Detect "single command" via CommandInfos length.
+	if len(runFacts.CommandInfos) == 1 && runFacts.CommandInfos[0].Name == cmd.Name {
+		runRanges := runFacts.Run.Location()
+		if len(runRanges) == 0 {
+			return nil
+		}
+		startLine := runRanges[0].Start.Line
+		endLine := sm.ResolveEndLine(runRanges[len(runRanges)-1].End.Line)
+		if endLine <= 0 || startLine <= 0 {
+			return nil
+		}
+		// Delete from column 0 of startLine to column 0 of endLine+1.
+		return &rules.SuggestedFix{
+			Description: "Remove `gem install bundler` — Bundler 2.x ships with the official ruby:* image",
+			Safety:      rules.FixSuggestion,
+			Priority:    priority,
+			IsPreferred: true,
+			Edits: []rules.TextEdit{{
+				Location: rules.NewRangeLocation(input.File, startLine, 0, endLine+1, 0),
+				NewText:  "",
+			}},
+		}
+	}
+	// Multi-command RUN: don't auto-rewrite (chains may have && or ; that
+	// need careful handling). Leave the fix as a non-edit suggestion.
+	return &rules.SuggestedFix{
+		Description: "Remove the `gem install bundler` step from this chain — Bundler 2.x ships with the official ruby:* image",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: false,
+	}
+}
+
+// Compile-time assertion that we use a stable instructions reference.
+var _ = (*instructions.RunCommand)(nil)
+
+func init() {
+	rules.Register(NewRedundantBundlerInstallRule())
+}

--- a/internal/rules/tally/ruby/redundant_bundler_install_test.go
+++ b/internal/rules/tally/ruby/redundant_bundler_install_test.go
@@ -1,0 +1,170 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestRedundantBundlerInstallRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewRedundantBundlerInstallRule().Metadata()
+	if meta.Code != RedundantBundlerInstallRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, RedundantBundlerInstallRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityWarning {
+		t.Errorf("DefaultSeverity = %v, want Warning", meta.DefaultSeverity)
+	}
+	if meta.Category != "performance" {
+		t.Errorf("Category = %q, want %q", meta.Category, "performance")
+	}
+	if !strings.HasPrefix(meta.DocURL, "https://tally.wharflab.com/rules/tally/ruby/") {
+		t.Errorf("DocURL = %q, want tally/ruby/ prefix", meta.DocURL)
+	}
+}
+
+func TestRedundantBundlerInstallRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewRedundantBundlerInstallRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "gem install bundler on official ruby base triggers",
+			Content: `FROM ruby:3.3-slim
+RUN gem install bundler
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "gem install bundler -v <version> triggers",
+			Content: `FROM ruby:3.3-slim
+RUN gem install bundler -v 2.5.6
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "gem install bundler --version=X triggers",
+			Content: `FROM ruby:3.3-slim
+RUN gem install bundler --version=2.5.6
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "gem install bundler in middle of chained command triggers",
+			Content: `FROM ruby:3.3-slim
+RUN apt-get update && gem install bundler && bundle install
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "gem install -v X bundler (flag-first form) triggers",
+			Content: `FROM ruby:3.3-slim
+RUN gem install -v 2.5.6 bundler
+`,
+			WantViolations: 1,
+		},
+		// --- Suppressions ---
+		{
+			Name: "non-official base (debian) does NOT trigger",
+			Content: `FROM debian:bookworm-slim
+RUN apt-get install -y ruby ruby-dev && gem install bundler
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "alpine base (not from official ruby:*) does NOT trigger",
+			Content: `FROM alpine:3.20
+RUN apk add ruby ruby-dev && gem install bundler
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "gem install bundler on jruby (Ruby derivative, but not official) does NOT trigger",
+			Content: `FROM jruby:9.4
+RUN gem install bundler
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "gem install of a different gem (not bundler) does NOT trigger",
+			Content: `FROM ruby:3.3-slim
+RUN gem install rails
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev stage skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+RUN gem install bundler
+`,
+			WantViolations: 0,
+		},
+		// --- Multi-stage propagation ---
+		{
+			Name: "stage based on a ruby:* stage still triggers",
+			Content: `FROM ruby:3.3-slim AS builder
+RUN gem install bundler
+
+FROM builder
+RUN gem install bundler
+`,
+			WantViolations: 2,
+		},
+	})
+}
+
+func TestRedundantBundlerInstallRule_FixSuggestionDeletesWholeRunWhenSingleCommand(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM ruby:3.3-slim
+RUN gem install bundler
+CMD ["bin/rails", "server"]
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewRedundantBundlerInstallRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
+	}
+	if len(v.SuggestedFix.Edits) != 1 {
+		t.Fatalf("expected 1 edit; got %d", len(v.SuggestedFix.Edits))
+	}
+	if v.SuggestedFix.Edits[0].NewText != "" {
+		t.Errorf("expected empty NewText (delete edit); got %q", v.SuggestedFix.Edits[0].NewText)
+	}
+}
+
+func TestRedundantBundlerInstallRule_NoEditFixForChainedCommand(t *testing.T) {
+	t.Parallel()
+
+	// Multi-command RUN chains are too risky to auto-rewrite, so the fix
+	// is a non-edit suggestion: a description explaining what to do, with
+	// no Edits attached.
+	content := `FROM ruby:3.3-slim
+RUN gem install bundler && bundle install
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewRedundantBundlerInstallRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
+	}
+	if len(v.SuggestedFix.Edits) != 0 {
+		t.Errorf("expected no edits for chained command; got %d", len(v.SuggestedFix.Edits))
+	}
+}

--- a/internal/rules/tally/ruby/redundant_bundler_install_test.go
+++ b/internal/rules/tally/ruby/redundant_bundler_install_test.go
@@ -168,3 +168,53 @@ RUN gem install bundler && bundle install
 		t.Errorf("expected no edits for chained command; got %d", len(v.SuggestedFix.Edits))
 	}
 }
+
+func TestRedundantBundlerInstallRule_NoEditFixForMultiGemInstall(t *testing.T) {
+	t.Parallel()
+
+	// Regression for codex/gemini/greptile P1: `gem install bundler rails`
+	// is a SINGLE CommandInfo, but auto-deleting that RUN would silently
+	// remove the `rails` install too. The fix MUST fall back to a no-edit
+	// suggestion so the user explicitly chooses how to disentangle the
+	// chain.
+	content := `FROM ruby:3.3-slim
+RUN gem install bundler rails
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewRedundantBundlerInstallRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if len(v.SuggestedFix.Edits) != 0 {
+		t.Errorf("multi-gem install must produce a no-edit suggestion; got %d edits",
+			len(v.SuggestedFix.Edits))
+	}
+}
+
+func TestRedundantBundlerInstallRule_DeleteFixOKForBundlerWithVersion(t *testing.T) {
+	t.Parallel()
+
+	// `gem install bundler -v 2.5.6` (bundler-only with a version pin)
+	// SHOULD still get the whole-RUN delete fix — the `-v` flag and its
+	// value don't add another gem target.
+	content := `FROM ruby:3.3-slim
+RUN gem install bundler -v 2.5.6
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewRedundantBundlerInstallRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if len(v.SuggestedFix.Edits) != 1 {
+		t.Errorf("bundler-only install with -v should produce a delete edit; got %d edits",
+			len(v.SuggestedFix.Edits))
+	}
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/redundant-bundler-install`](https://tally.wharflab.com/rules/tally/ruby/redundant-bundler-install/) — Section 4.1 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

The official `docker-library/ruby` image installs and pre-resolves Bundler 2.x before publishing each tag. Running `gem install bundler` after `FROM ruby:...` re-downloads, recompiles, and re-installs the same tool — wasting build time and introducing version drift between local development and CI. 55 of 196 Dockerfiles in the corpus do this, including `basecamp/kamal`, `basecamp/fizzy`, and `chatwoot/chatwoot`.

- **Suppressions:** non-official base images (debian + manual ruby install, alpine + `apk add ruby`), Ruby derivatives (`jruby`, `truffleruby`, `phusion/passenger-ruby`), dev/test/ci stages.
- **Stage-ref propagation:** stages based on a builder stage (`FROM builder` where `builder` is `FROM ruby:3.3-slim`) are correctly classified as official-Ruby-derived.
- **Context-aware:** when `Gemfile.lock` is observable, the violation detail names the exact lockfile's `BUNDLED WITH` version and points the user at Bundler's own `bundle _<version>_ install` version-shim as the right replacement when a specific Bundler version is needed.
- **Auto-fix:** `FixSuggestion`. Deletes the entire RUN line when the RUN contains *only* `gem install bundler`. For chained commands (`RUN gem install bundler && bundle install`), the fix is a non-edit suggestion — chain rewrites are too easy to get wrong.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint and fix fixtures: `internal/integration/fixtures/{lint,fix}/ruby-redundant-bundler-install/`