### PR TITLE
feat(rules): add tally/ruby/leftover-bundler-cache

### DIFF
--- a/_docs/rules/tally/ruby/leftover-bundler-cache.mdx
+++ b/_docs/rules/tally/ruby/leftover-bundler-cache.mdx
@@ -1,0 +1,115 @@
+---
+title: "tally/ruby/leftover-bundler-cache"
+description: "`bundle install` leaves Bundler's cache directories behind, bloating the final image."
+---
+
+`bundle install` leaves cache directories behind that ship in the final image layer.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info (default) / Warning (≥ 80 gems in `Gemfile.lock`) |
+| Category | Performance |
+| Default | Enabled |
+| Auto-fix | Yes (`FixSuggestion`) |
+
+## Description
+
+After `bundle install` runs, Bundler leaves three cache directories behind that the Rails generator template
+explicitly removes:
+
+1. `~/.bundle/` — Bundler's user-level config and runtime cache.
+2. `${BUNDLE_PATH}/ruby/*/cache` — gem `.gem` archives that were used to install gems and are no longer needed.
+3. `${BUNDLE_PATH}/ruby/*/bundler/gems/*/.git` — the full git history of any git-sourced gems.
+
+For non-trivial Rails apps these can cost 50–200 MiB of final-image weight. The Rails generator template runs:
+
+```dockerfile
+RUN bundle install \
+    && rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+```
+
+The corpus shows only **38 of 196** Dockerfiles do this cleanup; the other 75 % of `bundle install` invocations
+ship the caches in the final image.
+
+This rule fires when:
+
+- A Ruby-shaped stage runs `bundle install`.
+- Neither the same RUN nor any later RUN in the same stage performs cleanup of the cache directories.
+
+`bundle clean --force` (Bundler's own cleanup mechanism) is recognized as compliant for the `cache/`
+directory.
+
+### Suppressions
+
+The rule does NOT fire on:
+
+- Builder stages whose layers are not part of the final image (any stage referenced by a later
+  `COPY --from=<stage>` is exported, not copied wholesale).
+- Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug`.
+- Non-Ruby stages.
+- Windows stages.
+
+### Context-aware refinement
+
+When tally is invoked with `--context` and `Gemfile.lock` is observable, severity escalates from `info` to
+`warning` for projects with **≥ 80 resolved gems**. The rationale: the absolute size of the leftover cache
+scales with the gem count, so projects with large `Gemfile.lock` files pay a much steeper image-size cost
+when this rule fires.
+
+The detail text also names the exact gem count when the lockfile is observable.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+```
+
+### After
+
+The Rails-generator-style fix appends the cleanup to a RUN after the install:
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+RUN rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+```
+
+The cleanup can also be chained directly to the install RUN to avoid an extra layer:
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install \
+    && rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+```
+
+`bundle clean --force` is also accepted:
+
+```dockerfile
+RUN bundle install && bundle clean --force
+```
+
+## Auto-fix
+
+The rule offers a `FixSuggestion` that inserts a new `RUN` line immediately after the offending `bundle
+install`:
+
+```dockerfile
+RUN rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+```
+
+The fix is `FixSuggestion` (not `FixSafe`) because the canonical paths assume `BUNDLE_PATH` follows the Rails
+generator's default placement. Projects with custom `BUNDLE_PATH` values may need to adjust the paths after
+applying the fix.
+
+## References
+
+- [Rails Dockerfile generator template](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt) —
+  performs the canonical cleanup after `bundle install`.
+- [Bundler `bundle clean` documentation](https://bundler.io/v2.5/man/bundle-clean.1.html) — Bundler's own
+  cleanup mechanism for the `cache/` directory.

--- a/internal/integration/fixtures/fix/ruby-leftover-bundler-cache/.tally.toml
+++ b/internal/integration/fixtures/fix/ruby-leftover-bundler-cache/.tally.toml
@@ -1,0 +1,11 @@
+unsafe-fixes = true
+
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/leftover-bundler-cache"]
+exclude = ["*"]
+
+[output]
+fail-level = "none"

--- a/internal/integration/fixtures/fix/ruby-leftover-bundler-cache/Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-leftover-bundler-cache/Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-leftover-bundler-cache/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-leftover-bundler-cache/fixed_1.snap.Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+RUN rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-leftover-bundler-cache/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-leftover-bundler-cache/report_1.snap.md
@@ -1,0 +1,2 @@
+Fixed 1 issues
+**No issues found**

--- a/internal/integration/fixtures/lint/ruby-leftover-bundler-cache/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-leftover-bundler-cache/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/leftover-bundler-cache"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-leftover-bundler-cache/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-leftover-bundler-cache/Dockerfile
@@ -1,0 +1,30 @@
+# Canonical violation: bundle install with no cleanup.
+FROM ruby:3.3-slim AS app
+RUN bundle install
+CMD ["bin/rails", "server"]
+
+# Compliant: Rails-generator-style cleanup chained to install.
+FROM ruby:3.3-slim AS app-cleaned
+RUN bundle install \
+    && rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+
+# Compliant: cleanup in a later RUN (acceptable; avoids cache shipping
+# in image, just adds a layer).
+FROM ruby:3.3-slim AS app-late-cleanup
+RUN bundle install
+RUN rm -rf ~/.bundle/
+
+# Compliant: bundle clean --force.
+FROM ruby:3.3-slim AS app-bundle-clean
+RUN bundle install && bundle clean --force
+
+# Skipped: builder stage whose layers are exported via COPY --from.
+FROM ruby:3.3-slim AS builder
+RUN bundle install
+
+FROM ruby:3.3-slim AS final
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+
+# Skipped: dev stage.
+FROM ruby:3.3-slim AS dev
+RUN bundle install

--- a/internal/integration/fixtures/lint/ruby-leftover-bundler-cache/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-leftover-bundler-cache/result_1.snap.json
@@ -1,0 +1,60 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-leftover-bundler-cache/Dockerfile",
+      "violations": [
+        {
+          "detail": "After `bundle install` runs, Bundler leaves three cache directories behind that ship in the final image layer: `~/.bundle/`, `${BUNDLE_PATH}/ruby/*/cache` (gem `.gem` archives), and `${BUNDLE_PATH}/ruby/*/bundler/gems/*/.git` (full git history of git-sourced gems). The Rails generator template explicitly removes them after install. For non-trivial Rails apps these can cost 50–200 MiB of final-image weight.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/leftover-bundler-cache/",
+          "location": {
+            "end": {
+              "column": 18,
+              "line": 3
+            },
+            "file": "fixtures/lint/ruby-leftover-bundler-cache/Dockerfile",
+            "start": {
+              "column": 11,
+              "line": 3
+            }
+          },
+          "message": "`bundle install` leaves cache directories behind that bloat the final image",
+          "rule": "tally/ruby/leftover-bundler-cache",
+          "severity": "info",
+          "sourceCode": "RUN bundle install",
+          "suggestedFix": {
+            "description": "Strip Bundler's cache directories after install (matches the Rails generator template)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 4
+                  },
+                  "file": "fixtures/lint/ruby-leftover-bundler-cache/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 4
+                  }
+                },
+                "newText": "RUN rm -rf ~/.bundle/ \"${BUNDLE_PATH}\"/ruby/*/cache \"${BUNDLE_PATH}\"/ruby/*/bundler/gems/*/.git\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/rules/tally/ruby/leftover_bundler_cache.go
+++ b/internal/rules/tally/ruby/leftover_bundler_cache.go
@@ -1,0 +1,330 @@
+package ruby
+
+import (
+	"strconv"
+	"strings"
+
+	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/shell"
+	"github.com/wharflab/tally/internal/sourcemap"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// LeftoverBundlerCacheRuleCode is the full rule code.
+const LeftoverBundlerCacheRuleCode = rules.TallyRulePrefix + "ruby/leftover-bundler-cache"
+
+// leftoverBundlerCacheFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const leftoverBundlerCacheFixPriority = 88
+
+// LeftoverBundlerCacheRule flags stages that run `bundle install` without
+// the canonical Rails-generator cleanup of bundler-cache directories.
+type LeftoverBundlerCacheRule struct{}
+
+// NewLeftoverBundlerCacheRule creates the rule.
+func NewLeftoverBundlerCacheRule() *LeftoverBundlerCacheRule {
+	return &LeftoverBundlerCacheRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *LeftoverBundlerCacheRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            LeftoverBundlerCacheRuleCode,
+		Name:            "Bundler leaves cache directories behind after install",
+		Description:     "`bundle install` leaves cache directories behind that bloat the final image",
+		DocURL:          rules.TallyDocURL(LeftoverBundlerCacheRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "performance",
+		FixPriority:     leftoverBundlerCacheFixPriority,
+	}
+}
+
+// largeLockfileGemCount is the gem-count threshold above which severity
+// bumps from info to warning. The corpus shows that projects with ≥ 80
+// gems pay a much steeper image-size cost when the cleanup is missed.
+const largeLockfileGemCount = 80
+
+// Check runs the rule.
+func (r *LeftoverBundlerCacheRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	sm := input.SourceMap()
+	rubyFacts := input.Facts.RubyFacts()
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+		// Skip stages whose only purpose is to build gems for COPY-out
+		// (the cache only matters in stages whose layers ship in the
+		// final image).
+		if stageIsBuilderForCopyOut(input.Semantic, stageIdx, len(input.Stages)) {
+			continue
+		}
+		violations = append(violations, r.checkStage(input, sf, sm, rubyFacts, meta)...)
+	}
+	return violations
+}
+
+func (r *LeftoverBundlerCacheRule) checkStage(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
+	rubyFacts *rubyfacts.RubyFacts,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	// Find the *last* `bundle install` in the stage; cleanup must happen
+	// after it to be effective. If a later RUN already runs cleanup, the
+	// rule is satisfied.
+	var lastInstall *facts.RunFacts
+	var lastInstallCmd shell.CommandInfo
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		install := findFirstBundleInstall(runFacts)
+		if install != nil {
+			lastInstall = runFacts
+			lastInstallCmd = *install
+		}
+	}
+	if lastInstall == nil {
+		return nil
+	}
+
+	// Did any RUN at-or-after the last install perform cleanup?
+	cleanupAfterIdx := -1
+	for i, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		if i < indexOfRunFacts(sf.Runs, lastInstall) {
+			continue
+		}
+		if runHasBundlerCacheCleanup(runFacts) {
+			cleanupAfterIdx = i
+			break
+		}
+		if runRunsBundleClean(runFacts) {
+			cleanupAfterIdx = i
+			break
+		}
+	}
+	if cleanupAfterIdx >= 0 {
+		return nil
+	}
+
+	severity := meta.DefaultSeverity
+	if rubyFacts != nil && rubyFacts.Lockfile != nil &&
+		len(rubyFacts.Lockfile.Specs) >= largeLockfileGemCount {
+		// Many gems → cleanup matters more. Bump severity.
+		severity = rules.SeverityWarning
+	}
+
+	loc := bundleInstallViolationLocation(input.File, lastInstall, lastInstallCmd, sm)
+	v := rules.NewViolation(loc, meta.Code, meta.Description, severity).
+		WithDocURL(meta.DocURL).
+		WithDetail(leftoverBundlerCacheDetail(rubyFacts))
+	if fix := buildLeftoverBundlerCacheFix(input, sf, lastInstall, sm, meta.FixPriority); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+	return []rules.Violation{v}
+}
+
+func leftoverBundlerCacheDetail(rubyFacts *rubyfacts.RubyFacts) string {
+	base := "After `bundle install` runs, Bundler leaves three cache directories behind that ship in the " +
+		"final image layer: `~/.bundle/`, `${BUNDLE_PATH}/ruby/*/cache` (gem `.gem` archives), and " +
+		"`${BUNDLE_PATH}/ruby/*/bundler/gems/*/.git` (full git history of git-sourced gems). The Rails " +
+		"generator template explicitly removes them after install. For non-trivial Rails apps these can " +
+		"cost 50–200 MiB of final-image weight."
+	if rubyFacts != nil && rubyFacts.Lockfile != nil && len(rubyFacts.Lockfile.Specs) > 0 {
+		base += " (This project resolves " + strconv.Itoa(len(rubyFacts.Lockfile.Specs)) +
+			" gems in `Gemfile.lock`, so the impact is on the higher end.)"
+	}
+	return base
+}
+
+// stageIsBuilderForCopyOut reports whether the stage is referenced by a
+// later stage's `COPY --from=`. Such stages are throwaway — their layers
+// don't ship in the final image, so cache bloat doesn't matter.
+func stageIsBuilderForCopyOut(sem *semantic.Model, stageIdx, stageCount int) bool {
+	if sem == nil {
+		return false
+	}
+	for i := stageIdx + 1; i < stageCount; i++ {
+		other := sem.StageInfo(i)
+		if other == nil {
+			continue
+		}
+		for _, ref := range other.CopyFromRefs {
+			if ref.IsStageRef && ref.StageIndex == stageIdx {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// runHasBundlerCacheCleanup reports whether the RUN deletes (or otherwise
+// invalidates) at least one of the three canonical Bundler cache
+// directories the Rails generator strips after install.
+//
+// Detection is substring-based on the source script — the paths involve
+// shell globs (`*`) and parameter expansion (`${BUNDLE_PATH}`) that the
+// CommandInfo args layer doesn't always preserve verbatim, so a fast
+// substring check is more robust than walking parsed command args.
+func runHasBundlerCacheCleanup(runFacts *facts.RunFacts) bool {
+	if runFacts == nil {
+		return false
+	}
+	script := runFacts.SourceScript
+	if script == "" {
+		return false
+	}
+	// The cleanup typically uses one of these path fragments. Match any.
+	signals := []string{
+		"~/.bundle",
+		"$HOME/.bundle",
+		"${HOME}/.bundle",
+		"/.bundle/",
+		"BUNDLE_PATH/cache",
+		"BUNDLE_PATH}/cache",
+		"/cache",
+		"bundler/gems/*/.git",
+		"/bundler/gems",
+	}
+	// Require an `rm` invocation alongside one of the path fragments so
+	// that a stray reference doesn't trip a false positive.
+	if !runScriptInvokesCleanupCommand(script) {
+		return false
+	}
+	for _, s := range signals {
+		if strings.Contains(script, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// runRunsBundleClean reports whether the RUN runs `bundle clean --force`,
+// which Bundler's own cleanup mechanism produces an equivalent result for
+// the cache/ directory.
+func runRunsBundleClean(runFacts *facts.RunFacts) bool {
+	if runFacts == nil {
+		return false
+	}
+	for _, ci := range runFacts.CommandInfos {
+		if !strings.EqualFold(ci.Name, "bundle") {
+			continue
+		}
+		if !strings.EqualFold(ci.Subcommand, "clean") {
+			continue
+		}
+		// `bundle clean --force` (or `--force --dry-run` etc.) — require
+		// `--force` because that's what actually deletes content.
+		for _, a := range ci.Args {
+			if a == "--force" || a == "-f" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// runScriptInvokesCleanupCommand reports whether a script contains an `rm`
+// invocation. Used to gate substring-based path detection on actual
+// removal commands.
+func runScriptInvokesCleanupCommand(script string) bool {
+	// Word-boundary check: `rm ` or `rm\n` or `rm\t`, with leading-space
+	// tolerance for chained commands.
+	idx := 0
+	for idx < len(script) {
+		next := strings.Index(script[idx:], "rm")
+		if next < 0 {
+			return false
+		}
+		pos := idx + next
+		// Must be at start, after whitespace, or after a separator.
+		if pos > 0 {
+			prev := script[pos-1]
+			if prev != ' ' && prev != '\t' && prev != '\n' && prev != ';' && prev != '&' && prev != '|' {
+				idx = pos + 2
+				continue
+			}
+		}
+		// Followed by whitespace or a flag (- prefix).
+		if pos+2 >= len(script) {
+			return false
+		}
+		nextCh := script[pos+2]
+		if nextCh == ' ' || nextCh == '\t' || nextCh == '\n' || nextCh == '-' {
+			return true
+		}
+		idx = pos + 2
+	}
+	return false
+}
+
+// indexOfRunFacts returns the slice index of target in runs, or -1.
+func indexOfRunFacts(runs []*facts.RunFacts, target *facts.RunFacts) int {
+	for i, r := range runs {
+		if r == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// buildLeftoverBundlerCacheFix appends the canonical Rails-generator-style
+// cleanup to the `bundle install` step. The fix is a FixSuggestion because
+// the exact path varies with Bundler version / BUNDLE_PATH setting, and
+// the user may have configured a non-default location.
+func buildLeftoverBundlerCacheFix(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	installRun *facts.RunFacts,
+	sm *sourcemap.SourceMap,
+	priority int,
+) *rules.SuggestedFix {
+	if sf == nil || sm == nil || installRun == nil || installRun.Run == nil {
+		return nil
+	}
+	runRanges := installRun.Run.Location()
+	if len(runRanges) == 0 {
+		return nil
+	}
+	endLine := sm.ResolveEndLine(runRanges[len(runRanges)-1].End.Line)
+	if endLine <= 0 {
+		return nil
+	}
+	insertLine := endLine + 1
+	cleanup := "RUN rm -rf ~/.bundle/ \"${BUNDLE_PATH}\"/ruby/*/cache \"${BUNDLE_PATH}\"/ruby/*/bundler/gems/*/.git\n"
+	return &rules.SuggestedFix{
+		Description: "Strip Bundler's cache directories after install (matches the Rails generator template)",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
+			NewText:  cleanup,
+		}},
+	}
+}
+
+func init() {
+	rules.Register(NewLeftoverBundlerCacheRule())
+}

--- a/internal/rules/tally/ruby/leftover_bundler_cache_test.go
+++ b/internal/rules/tally/ruby/leftover_bundler_cache_test.go
@@ -1,0 +1,138 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestLeftoverBundlerCacheRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewLeftoverBundlerCacheRule().Metadata()
+	if meta.Code != LeftoverBundlerCacheRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, LeftoverBundlerCacheRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "performance" {
+		t.Errorf("Category = %q, want %q", meta.Category, "performance")
+	}
+	if !strings.HasPrefix(meta.DocURL, "https://tally.wharflab.com/rules/tally/ruby/") {
+		t.Errorf("DocURL = %q, want tally/ruby/ prefix", meta.DocURL)
+	}
+}
+
+func TestLeftoverBundlerCacheRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewLeftoverBundlerCacheRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "bundle install without cleanup triggers",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: cleanup in same RUN ---
+		{
+			Name: "bundle install with Rails-generator cleanup in same RUN suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install \
+    && rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "cleanup of just ~/.bundle suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install \
+    && rm -rf ~/.bundle/
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: cleanup in later RUN ---
+		{
+			Name: "cleanup in a later RUN after install suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+RUN rm -rf ~/.bundle/
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: bundle clean --force ---
+		{
+			Name: "bundle clean --force after install suppresses",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install \
+    && bundle clean --force
+`,
+			WantViolations: 0,
+		},
+		// --- Suppressions ---
+		{
+			Name: "dev stage skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Ruby stage skipped",
+			Content: `FROM debian:bookworm-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "builder stage exporting via COPY --from skipped",
+			Content: `FROM ruby:3.3-slim AS builder
+RUN bundle install
+
+FROM ruby:3.3-slim
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+`,
+			WantViolations: 0,
+		},
+		// --- Ordering: cleanup BEFORE install does NOT count ---
+		{
+			Name: "cleanup before install does NOT suppress",
+			Content: `FROM ruby:3.3-slim
+RUN rm -rf ~/.bundle/
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+	})
+}
+
+func TestLeftoverBundlerCacheRule_FixSafety(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM ruby:3.3-slim
+RUN bundle install
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewLeftoverBundlerCacheRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
+	}
+	got := v.SuggestedFix.Edits[0].NewText
+	wantParts := []string{"~/.bundle/", "BUNDLE_PATH", "/cache", "/bundler/gems"}
+	for _, want := range wantParts {
+		if !strings.Contains(got, want) {
+			t.Errorf("fix should contain %q; got: %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/leftover-bundler-cache`](https://tally.wharflab.com/rules/tally/ruby/leftover-bundler-cache/) — Section 4.2 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

After `bundle install`, Bundler leaves three cache directories behind that ship in the final image: `~/.bundle/`, `${BUNDLE_PATH}/ruby/*/cache` (gem `.gem` archives), and `${BUNDLE_PATH}/ruby/*/bundler/gems/*/.git` (full git history of git-sourced gems). For non-trivial Rails apps these can cost 50–200 MiB. The Rails generator template strips them; only 38 of 196 Dockerfiles in the corpus do.

- **Compliance:** cleanup of any of the three directories at-or-after the last `bundle install`, OR `bundle clean --force` (Bundler's own mechanism).
- **Suppressions:** dev/test/ci stages, non-Ruby stages, builder stages exported via `COPY --from=` (cache directories there don't ship in the final image).
- **Ordering:** cleanup BEFORE the install does NOT count — covered by a regression test.
- **Context-aware:** when `Gemfile.lock` resolves ≥ 80 gems, severity escalates from `info` to `warning`. The detail text also names the exact gem count.
- **Auto-fix:** `FixSuggestion`. Inserts the canonical Rails-generator cleanup line after the install. Marked suggestion (not safe) because non-default `BUNDLE_PATH` configurations may need adjustment.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint and fix fixtures: `internal/integration/fixtures/{lint,fix}/ruby-leftover-bundler-cache/`