### PR TITLE
feat(rules): add tally/ruby/eol-ruby-version

### DIFF
--- a/_docs/rules/tally/ruby/eol-ruby-version.mdx
+++ b/_docs/rules/tally/ruby/eol-ruby-version.mdx
@@ -1,0 +1,81 @@
+---
+title: "tally/ruby/eol-ruby-version"
+description: "`FROM ruby:X.Y` references an end-of-life Ruby branch with no upstream security patches."
+---
+
+`FROM ruby:X.Y` references an end-of-life Ruby branch with no upstream security patches.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning (default) / Error (branch is past its retirement date) |
+| Category | Security |
+| Default | Enabled |
+| Auto-fix | Yes (`FixSuggestion`) |
+
+## Description
+
+The Ruby core team retires Ruby branches on a [published cadence](https://www.ruby-lang.org/en/downloads/branches/).
+Once a branch is retired, upstream stops publishing security patches — production images on retired
+branches accumulate unfixed CVEs over time.
+
+This rule maintains a curated end-of-life table:
+
+| Branch | Status | Retired |
+|--------|--------|---------|
+| 2.4    | EOL    | 2020-04-05 |
+| 2.5    | EOL    | 2021-03-31 |
+| 2.6    | EOL    | 2022-04-12 |
+| 2.7    | EOL    | 2023-03-31 |
+| 3.0    | EOL    | 2024-03-31 |
+| 3.1    | EOL    | 2025-03-31 |
+| 3.2 / 3.3 / 3.4 | Supported | — |
+
+A `FROM` line that resolves to one of the EOL branches fires the rule. Severity is `error` once the branch
+is past its retirement date (which all current EOL branches are), and `warning` for branches we can predict
+will retire soon.
+
+The rule recognizes only the official `ruby:*` image. Ruby derivatives (`jruby`, `truffleruby`,
+`phusion/passenger-ruby`) follow different release cadences and aren't covered by the upstream Ruby EOL
+table.
+
+The corpus shows **48 of 196 Dockerfiles still pinned to Ruby 2.x** and **15 more pinned to 3.0/3.1**.
+This rule's job is to catch them.
+
+### Context-aware refinement
+
+When tally is invoked with `--context`, the rule consults the project's `.ruby-version`,
+`.tool-versions`, or `Gemfile.lock`'s `RUBY VERSION` block to resolve ARG-templated bases. A Dockerfile that
+looks fine on the surface (`FROM ruby:${RUBY_VERSION}-slim`) but resolves against `.ruby-version: 2.7.5`
+will correctly fire as EOL.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:2.7-slim
+RUN bundle install
+```
+
+### After
+
+```dockerfile
+FROM ruby:3.4-slim
+RUN bundle install
+```
+
+The fix preserves the variant suffix (`-slim`, `-alpine`, `-bookworm`, etc.). For ARG-templated bases the
+fix is suppressed — the user has to decide whether to bump the ARG default or rewrite the FROM directly.
+
+## Auto-fix
+
+`FixSuggestion`. Rewrites the `FROM ruby:X.Y[-variant]` reference to use the most recent supported branch.
+
+The fix is `FixSuggestion` (not `FixSafe`) because major version bumps may require gem updates. Run
+`bundle update` and your test suite after applying.
+
+## References
+
+- [Ruby maintenance branches](https://www.ruby-lang.org/en/downloads/branches/) — upstream support matrix.
+- [Ruby 3.3 release notes](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) — context for
+  the current supported branches.

--- a/internal/integration/fixtures/fix/ruby-eol-ruby-version/.tally.toml
+++ b/internal/integration/fixtures/fix/ruby-eol-ruby-version/.tally.toml
@@ -1,0 +1,11 @@
+unsafe-fixes = true
+
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/eol-ruby-version"]
+exclude = ["*"]
+
+[output]
+fail-level = "none"

--- a/internal/integration/fixtures/fix/ruby-eol-ruby-version/Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-eol-ruby-version/Dockerfile
@@ -1,0 +1,3 @@
+FROM ruby:2.7-slim
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-eol-ruby-version/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-eol-ruby-version/fixed_1.snap.Dockerfile
@@ -1,0 +1,3 @@
+FROM rruby:3.4-slim
+RUN bundle install
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-eol-ruby-version/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-eol-ruby-version/fixed_1.snap.Dockerfile
@@ -1,3 +1,3 @@
-FROM rruby:3.4-slim
+FROM ruby:3.4-slim
 RUN bundle install
 CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-eol-ruby-version/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-eol-ruby-version/report_1.snap.md
@@ -1,0 +1,2 @@
+Fixed 1 issues
+**No issues found**

--- a/internal/integration/fixtures/lint/ruby-eol-ruby-version/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-eol-ruby-version/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/eol-ruby-version"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-eol-ruby-version/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-eol-ruby-version/Dockerfile
@@ -1,0 +1,23 @@
+# EOL Ruby 2.x — error severity (long retired).
+FROM ruby:2.7-slim AS app-2x
+RUN bundle install
+
+# EOL Ruby 3.0 — error severity.
+FROM ruby:3.0 AS app-30
+RUN bundle install
+
+# EOL Ruby 3.1 — error severity.
+FROM ruby:3.1.6 AS app-31
+RUN bundle install
+
+# Supported Ruby 3.3 — does not trigger.
+FROM ruby:3.3-slim AS app-supported
+RUN bundle install
+
+# Supported Ruby 3.4 — does not trigger.
+FROM ruby:3.4 AS app-latest
+RUN bundle install
+
+# JRuby — does not trigger (different release cadence).
+FROM jruby:9.4 AS jruby-app
+RUN bundle install

--- a/internal/integration/fixtures/lint/ruby-eol-ruby-version/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-eol-ruby-version/result_1.snap.json
@@ -1,0 +1,142 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
+      "violations": [
+        {
+          "detail": "Ruby 2.7 is past upstream end-of-life — the upstream Ruby team no longer publishes security patches as of 2023-03-31. Production images on this branch will accumulate unfixed CVEs over time. Migrate to a currently-supported branch (Ruby 3.4, Ruby 3.3, Ruby 3.2) — see https://www.ruby-lang.org/en/downloads/branches/ for the upstream support matrix.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/eol-ruby-version/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 2
+            },
+            "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 2
+            }
+          },
+          "message": "Base image uses an end-of-life Ruby version with no upstream security patches",
+          "rule": "tally/ruby/eol-ruby-version",
+          "severity": "error",
+          "sourceCode": "FROM ruby:2.7-slim AS app-2x",
+          "suggestedFix": {
+            "description": "Bump the Ruby base image to a supported branch (3.4)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 19,
+                    "line": 2
+                  },
+                  "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
+                  "start": {
+                    "column": 6,
+                    "line": 2
+                  }
+                },
+                "newText": "ruby:3.4-slim"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Ruby 3.0 is past upstream end-of-life — the upstream Ruby team no longer publishes security patches as of 2024-03-31. Production images on this branch will accumulate unfixed CVEs over time. Migrate to a currently-supported branch (Ruby 3.4, Ruby 3.3, Ruby 3.2) — see https://www.ruby-lang.org/en/downloads/branches/ for the upstream support matrix.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/eol-ruby-version/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 6
+            },
+            "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 6
+            }
+          },
+          "message": "Base image uses an end-of-life Ruby version with no upstream security patches",
+          "rule": "tally/ruby/eol-ruby-version",
+          "severity": "error",
+          "sourceCode": "FROM ruby:3.0 AS app-30",
+          "suggestedFix": {
+            "description": "Bump the Ruby base image to a supported branch (3.4)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 14,
+                    "line": 6
+                  },
+                  "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
+                  "start": {
+                    "column": 6,
+                    "line": 6
+                  }
+                },
+                "newText": "ruby:3.4"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "Ruby 3.1 is past upstream end-of-life — the upstream Ruby team no longer publishes security patches as of 2025-03-31. Production images on this branch will accumulate unfixed CVEs over time. Migrate to a currently-supported branch (Ruby 3.4, Ruby 3.3, Ruby 3.2) — see https://www.ruby-lang.org/en/downloads/branches/ for the upstream support matrix.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/eol-ruby-version/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 10
+            },
+            "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 10
+            }
+          },
+          "message": "Base image uses an end-of-life Ruby version with no upstream security patches",
+          "rule": "tally/ruby/eol-ruby-version",
+          "severity": "error",
+          "sourceCode": "FROM ruby:3.1.6 AS app-31",
+          "suggestedFix": {
+            "description": "Bump the Ruby base image to a supported branch (3.4)",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 16,
+                    "line": 10
+                  },
+                  "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
+                  "start": {
+                    "column": 6,
+                    "line": 10
+                  }
+                },
+                "newText": "ruby:3.4.6"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 3,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 3,
+    "warnings": 0
+  }
+}

--- a/internal/integration/fixtures/lint/ruby-eol-ruby-version/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-eol-ruby-version/result_1.snap.json
@@ -27,12 +27,12 @@
               {
                 "location": {
                   "end": {
-                    "column": 19,
+                    "column": 18,
                     "line": 2
                   },
                   "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
                   "start": {
-                    "column": 6,
+                    "column": 5,
                     "line": 2
                   }
                 },
@@ -68,12 +68,12 @@
               {
                 "location": {
                   "end": {
-                    "column": 14,
+                    "column": 13,
                     "line": 6
                   },
                   "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
                   "start": {
-                    "column": 6,
+                    "column": 5,
                     "line": 6
                   }
                 },
@@ -109,16 +109,16 @@
               {
                 "location": {
                   "end": {
-                    "column": 16,
+                    "column": 15,
                     "line": 10
                   },
                   "file": "fixtures/lint/ruby-eol-ruby-version/Dockerfile",
                   "start": {
-                    "column": 6,
+                    "column": 5,
                     "line": 10
                   }
                 },
-                "newText": "ruby:3.4.6"
+                "newText": "ruby:3.4"
               }
             ],
             "isPreferred": true,

--- a/internal/rules/tally/ruby/eol_ruby_version.go
+++ b/internal/rules/tally/ruby/eol_ruby_version.go
@@ -103,7 +103,6 @@ func (r *EOLRubyVersionRule) Check(input rules.LintInput) []rules.Violation {
 			continue
 		}
 		v := r.checkStage(input, stageIdx, rubyFacts, meta)
-		_ = sf // facts.StageFacts no longer needed after Windows-OS guard
 		if v != nil {
 			violations = append(violations, *v)
 		}
@@ -157,7 +156,7 @@ func (r *EOLRubyVersionRule) checkStage(
 	v := rules.NewViolation(loc, meta.Code, meta.Description, severity).
 		WithDocURL(meta.DocURL).
 		WithDetail(eolRubyVersionDetail(branch, info))
-	if fix := buildEOLRubyVersionFix(input, stageIdx, raw, branch, meta.FixPriority); fix != nil {
+	if fix := buildEOLRubyVersionFix(input, stageIdx, raw, meta.FixPriority); fix != nil {
 		v = v.WithSuggestedFix(fix)
 	}
 	return &v
@@ -259,7 +258,7 @@ func stageBaseLocation(input rules.LintInput, stageIdx int) rules.Location {
 func buildEOLRubyVersionFix(
 	input rules.LintInput,
 	stageIdx int,
-	raw, branch string,
+	raw string,
 	priority int,
 ) *rules.SuggestedFix {
 	// Only emit a fix when the FROM is a literal ruby:X.Y tag we can
@@ -269,14 +268,18 @@ func buildEOLRubyVersionFix(
 		return nil
 	}
 	target := supportedRubyBranches[0]
-	// Preserve the variant suffix (everything after the first occurrence
-	// of the EOL branch in the tag).
-	newRaw := strings.Replace(raw, branch, target, 1)
-	if newRaw == raw {
+	// Rewrite the entire major.minor[.patch[pNNN]] portion of the tag —
+	// not just the major.minor prefix. `strings.Replace(raw, branch,
+	// target, 1)` would carry `ruby:3.1.6` to `ruby:3.4.6`, which may
+	// not be a published tag on Docker Hub. Preserve only the variant
+	// suffix (`-slim`, `-alpine`, `-bookworm`, ...).
+	newRaw := rewriteRubyTagToSupportedBranch(raw, target)
+	if newRaw == "" || newRaw == raw {
 		return nil
 	}
-	// Find the location of the raw tag in the FROM line. Use the stage's
-	// FROM range; the rewrite is the whole base-image reference.
+	// Find the location of the raw tag in the FROM source. Use the
+	// stage's FROM range and search across all lines covered by the
+	// instruction (ARG-templated FROMs may use line continuations).
 	if stageIdx < 0 || stageIdx >= len(input.Stages) {
 		return nil
 	}
@@ -289,12 +292,21 @@ func buildEOLRubyVersionFix(
 		return nil
 	}
 	startLine := stage.Location[0].Start.Line
-	line := sm.Line(startLine - 1)
-	idx := strings.Index(line, raw)
-	if idx < 0 {
+	endLine := stage.Location[len(stage.Location)-1].End.Line
+	var lineNo, idx int
+	for lineNo = startLine; lineNo <= endLine; lineNo++ {
+		line := sm.Line(lineNo - 1)
+		idx = strings.Index(line, raw)
+		if idx >= 0 {
+			break
+		}
+	}
+	if idx < 0 || lineNo > endLine {
 		return nil
 	}
-	startCol := idx + 1
+	// rules.NewRangeLocation columns are 0-based; strings.Index returns
+	// a 0-based offset.
+	startCol := idx
 	endCol := startCol + len(raw)
 	return &rules.SuggestedFix{
 		Description: "Bump the Ruby base image to a supported branch (" + target + ")",
@@ -302,10 +314,39 @@ func buildEOLRubyVersionFix(
 		Priority:    priority,
 		IsPreferred: true,
 		Edits: []rules.TextEdit{{
-			Location: rules.NewRangeLocation(input.File, startLine, startCol, startLine, endCol),
+			Location: rules.NewRangeLocation(input.File, lineNo, startCol, lineNo, endCol),
 			NewText:  newRaw,
 		}},
 	}
+}
+
+// rewriteRubyTagToSupportedBranch rewrites a `ruby:X.Y[.Z[pNNN]][-variant]`
+// reference to use the supplied supported branch (X.Y), preserving only
+// the variant suffix. Returns "" when the input doesn't match a parseable
+// ruby:* reference (the rule should suppress its fix in that case).
+//
+// Examples:
+//
+//	ruby:3.0          -> ruby:3.4
+//	ruby:3.0-slim     -> ruby:3.4-slim
+//	ruby:3.1.6        -> ruby:3.4
+//	ruby:2.7.0-bookworm -> ruby:3.4-bookworm
+//	ruby:2.7.0p100-alpine -> ruby:3.4-alpine
+//	docker.io/library/ruby:3.0 -> docker.io/library/ruby:3.4
+func rewriteRubyTagToSupportedBranch(raw, targetBranch string) string {
+	colon := strings.LastIndex(raw, ":")
+	if colon < 0 || colon == len(raw)-1 {
+		return ""
+	}
+	before, tag := raw[:colon], raw[colon+1:]
+	// Find the variant suffix (everything starting from the first `-`
+	// in the tag — `slim`, `alpine`, `bookworm`, etc. don't appear in
+	// the version itself).
+	variant := ""
+	if dash := strings.IndexByte(tag, '-'); dash >= 0 {
+		variant = tag[dash:] // includes the leading `-`
+	}
+	return before + ":" + targetBranch + variant
 }
 
 func init() {

--- a/internal/rules/tally/ruby/eol_ruby_version.go
+++ b/internal/rules/tally/ruby/eol_ruby_version.go
@@ -1,0 +1,313 @@
+package ruby
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/distribution/reference"
+
+	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+)
+
+// EOLRubyVersionRuleCode is the full rule code.
+const EOLRubyVersionRuleCode = rules.TallyRulePrefix + "ruby/eol-ruby-version"
+
+// eolRubyVersionFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const eolRubyVersionFixPriority = 88
+
+// EOLRubyVersionRule flags `FROM ruby:X.Y` references where X.Y is past
+// upstream end-of-life, plus references resolved from ARG/.ruby-version.
+type EOLRubyVersionRule struct{}
+
+// NewEOLRubyVersionRule creates the rule.
+func NewEOLRubyVersionRule() *EOLRubyVersionRule {
+	return &EOLRubyVersionRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *EOLRubyVersionRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            EOLRubyVersionRuleCode,
+		Name:            "Ruby base image is end-of-life",
+		Description:     "Base image uses an end-of-life Ruby version with no upstream security patches",
+		DocURL:          rules.TallyDocURL(EOLRubyVersionRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "security",
+		FixPriority:     eolRubyVersionFixPriority,
+	}
+}
+
+// rubyBranchEOL is the curated end-of-life table for Ruby major.minor
+// branches. Source: https://www.ruby-lang.org/en/downloads/branches/.
+//
+// Each entry's RetiredAt is the date the branch entered "no upstream support
+// of any kind" — past this date the rule emits at error severity. Branches
+// with a RetiredAt zero value are still receiving security patches; those
+// emit at warning severity.
+//
+// To bump the table, update the dates from the upstream branches page and
+// run `make test`.
+var rubyBranchEOL = map[string]rubyBranchInfo{
+	// Ruby 2.x — fully out of support.
+	"2.4": {RetiredAt: mustParse("2020-04-05"), Status: "EOL"},
+	"2.5": {RetiredAt: mustParse("2021-03-31"), Status: "EOL"},
+	"2.6": {RetiredAt: mustParse("2022-04-12"), Status: "EOL"},
+	"2.7": {RetiredAt: mustParse("2023-03-31"), Status: "EOL"},
+	// Ruby 3.x — 3.0 and 3.1 are retired; 3.2/3.3/3.4 are supported.
+	"3.0": {RetiredAt: mustParse("2024-03-31"), Status: "EOL"},
+	"3.1": {RetiredAt: mustParse("2025-03-31"), Status: "EOL"},
+}
+
+// supportedRubyBranches is the list of currently-supported Ruby branches,
+// most-recent first. The fix uses this list to suggest a replacement.
+var supportedRubyBranches = []string{"3.4", "3.3", "3.2"}
+
+// rubyBranchInfo tracks a Ruby branch's end-of-life metadata.
+type rubyBranchInfo struct {
+	// RetiredAt is the date upstream stopped publishing patches (any kind).
+	RetiredAt time.Time
+	// Status is a short label: "EOL" for fully retired branches.
+	Status string
+}
+
+func mustParse(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic("eol_ruby_version: invalid hardcoded date " + s)
+	}
+	return t
+}
+
+// rubyTagVersionRE extracts the X.Y from a ruby:* image tag, e.g.
+// "3.3-slim", "3.0.6-bookworm", "2.7.0p100-alpine3.18".
+var rubyTagVersionRE = regexp.MustCompile(`^(\d+)\.(\d+)`)
+
+// Check runs the rule.
+func (r *EOLRubyVersionRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	rubyFacts := input.Facts.RubyFacts()
+
+	var violations []rules.Violation
+	for stageIdx := range input.Stages {
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		v := r.checkStage(input, stageIdx, rubyFacts, meta)
+		_ = sf // facts.StageFacts no longer needed after Windows-OS guard
+		if v != nil {
+			violations = append(violations, *v)
+		}
+	}
+	return violations
+}
+
+func (r *EOLRubyVersionRule) checkStage(
+	input rules.LintInput,
+	stageIdx int,
+	rubyFacts *rubyfacts.RubyFacts,
+	meta rules.RuleMetadata,
+) *rules.Violation {
+	base := input.Semantic.ExternalBase(stageIdx)
+	if base == nil {
+		return nil
+	}
+	raw := base.Effective
+	if raw == "" {
+		raw = base.Raw
+	}
+	if raw == "" {
+		return nil
+	}
+	branch, isRuby := parseRubyImageBranch(raw)
+	if !isRuby {
+		return nil
+	}
+	if branch == "" {
+		// Couldn't extract X.Y from the tag (likely an ARG-templated
+		// version). Try to fall back to RubyFacts when observable.
+		if rubyFacts != nil && rubyFacts.RubyVersion != "" {
+			branch = majorMinorFromVersion(rubyFacts.RubyVersion)
+		}
+		if branch == "" {
+			return nil
+		}
+	}
+	info, eol := rubyBranchEOL[branch]
+	if !eol {
+		return nil
+	}
+
+	severity := meta.DefaultSeverity
+	if !info.RetiredAt.IsZero() && info.RetiredAt.Before(time.Now()) {
+		// Branch is past its retirement date — fully out of support.
+		severity = rules.SeverityError
+	}
+
+	loc := stageBaseLocation(input, stageIdx)
+	v := rules.NewViolation(loc, meta.Code, meta.Description, severity).
+		WithDocURL(meta.DocURL).
+		WithDetail(eolRubyVersionDetail(branch, info))
+	if fix := buildEOLRubyVersionFix(input, stageIdx, raw, branch, meta.FixPriority); fix != nil {
+		v = v.WithSuggestedFix(fix)
+	}
+	return &v
+}
+
+func eolRubyVersionDetail(branch string, info rubyBranchInfo) string {
+	var b strings.Builder
+	b.WriteString("Ruby ")
+	b.WriteString(branch)
+	b.WriteString(" is past upstream end-of-life — the upstream Ruby team no longer publishes ")
+	if !info.RetiredAt.IsZero() {
+		b.WriteString("security patches as of ")
+		b.WriteString(info.RetiredAt.Format("2006-01-02"))
+		b.WriteString(". ")
+	} else {
+		b.WriteString("patches of any kind. ")
+	}
+	b.WriteString("Production images on this branch will accumulate unfixed CVEs over time. " +
+		"Migrate to a currently-supported branch (")
+	for i, br := range supportedRubyBranches {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("Ruby ")
+		b.WriteString(br)
+	}
+	b.WriteString(") — see https://www.ruby-lang.org/en/downloads/branches/ for the upstream support matrix.")
+	return b.String()
+}
+
+// parseRubyImageBranch parses a ruby:* image reference and returns the
+// X.Y branch and a boolean indicating whether the image is in fact an
+// official Ruby image (or a familiar derivative). Returns ("", true) when
+// the image IS Ruby but the tag doesn't carry a parseable major.minor.
+func parseRubyImageBranch(raw string) (string, bool) {
+	named, err := reference.ParseNormalizedNamed(strings.ToLower(raw))
+	if err != nil {
+		return "", false
+	}
+	familiar := reference.FamiliarName(named)
+	if familiar != "ruby" {
+		// Non-official Ruby derivatives (jruby, truffleruby, …) follow
+		// different release cadences; the upstream-Ruby EOL table doesn't
+		// apply.
+		return "", false
+	}
+	tagged, ok := named.(reference.Tagged)
+	if !ok {
+		// untagged or digest-only
+		return "", true
+	}
+	tag := tagged.Tag()
+	m := rubyTagVersionRE.FindStringSubmatch(tag)
+	if m == nil {
+		return "", true
+	}
+	return m[1] + "." + m[2], true
+}
+
+// majorMinorFromVersion extracts the X.Y prefix from a full Ruby version
+// string like "3.3.5p100" or "3.3.5". Returns "" when the version is
+// malformed.
+func majorMinorFromVersion(version string) string {
+	parts := strings.Split(strings.TrimSpace(version), ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	if _, err := strconv.Atoi(parts[0]); err != nil {
+		return ""
+	}
+	// Minor may have non-digit suffix like "5p100"; just take the first
+	// run of digits.
+	minor := parts[1]
+	end := 0
+	for end < len(minor) && minor[end] >= '0' && minor[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return ""
+	}
+	return parts[0] + "." + minor[:end]
+}
+
+// stageBaseLocation returns the source location of the FROM line for a stage.
+func stageBaseLocation(input rules.LintInput, stageIdx int) rules.Location {
+	if stageIdx < 0 || stageIdx >= len(input.Stages) {
+		return rules.NewFileLocation(input.File)
+	}
+	stage := input.Stages[stageIdx]
+	if len(stage.Location) == 0 {
+		return rules.NewFileLocation(input.File)
+	}
+	return rules.NewLocationFromRanges(input.File, stage.Location)
+}
+
+// buildEOLRubyVersionFix proposes rewriting the FROM tag to the most
+// recent supported Ruby branch, preserving any variant suffix
+// (`-slim`, `-alpine`, `-bookworm`, etc.).
+func buildEOLRubyVersionFix(
+	input rules.LintInput,
+	stageIdx int,
+	raw, branch string,
+	priority int,
+) *rules.SuggestedFix {
+	// Only emit a fix when the FROM is a literal ruby:X.Y tag we can
+	// rewrite cleanly. ARG-templated bases need user judgment about
+	// whether to update the ARG default vs the FROM value.
+	if strings.Contains(raw, "$") {
+		return nil
+	}
+	target := supportedRubyBranches[0]
+	// Preserve the variant suffix (everything after the first occurrence
+	// of the EOL branch in the tag).
+	newRaw := strings.Replace(raw, branch, target, 1)
+	if newRaw == raw {
+		return nil
+	}
+	// Find the location of the raw tag in the FROM line. Use the stage's
+	// FROM range; the rewrite is the whole base-image reference.
+	if stageIdx < 0 || stageIdx >= len(input.Stages) {
+		return nil
+	}
+	stage := input.Stages[stageIdx]
+	if len(stage.Location) == 0 {
+		return nil
+	}
+	sm := input.SourceMap()
+	if sm == nil {
+		return nil
+	}
+	startLine := stage.Location[0].Start.Line
+	line := sm.Line(startLine - 1)
+	idx := strings.Index(line, raw)
+	if idx < 0 {
+		return nil
+	}
+	startCol := idx + 1
+	endCol := startCol + len(raw)
+	return &rules.SuggestedFix{
+		Description: "Bump the Ruby base image to a supported branch (" + target + ")",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(input.File, startLine, startCol, startLine, endCol),
+			NewText:  newRaw,
+		}},
+	}
+}
+
+func init() {
+	rules.Register(NewEOLRubyVersionRule())
+}

--- a/internal/rules/tally/ruby/eol_ruby_version_test.go
+++ b/internal/rules/tally/ruby/eol_ruby_version_test.go
@@ -1,0 +1,191 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestEOLRubyVersionRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewEOLRubyVersionRule().Metadata()
+	if meta.Code != EOLRubyVersionRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, EOLRubyVersionRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityWarning {
+		t.Errorf("DefaultSeverity = %v, want Warning", meta.DefaultSeverity)
+	}
+	if meta.Category != "security" {
+		t.Errorf("Category = %q, want %q", meta.Category, "security")
+	}
+}
+
+func TestEOLRubyVersionRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewEOLRubyVersionRule(), []testutil.RuleTestCase{
+		// --- Violations: EOL Ruby branches ---
+		{
+			Name: "ruby:2.7-slim (EOL) triggers",
+			Content: `FROM ruby:2.7-slim
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ruby:3.0 (EOL) triggers",
+			Content: `FROM ruby:3.0
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ruby:3.1.6 (EOL with patch) triggers",
+			Content: `FROM ruby:3.1.6
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: supported Ruby branches ---
+		{
+			Name: "ruby:3.3-slim (supported) does NOT trigger",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ruby:3.4 (supported) does NOT trigger",
+			Content: `FROM ruby:3.4
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Suppressions ---
+		{
+			Name: "non-Ruby base does NOT trigger",
+			Content: `FROM debian:bookworm-slim
+RUN apt-get install -y ruby
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "Ruby derivative (jruby) does NOT trigger",
+			Content: `FROM jruby:9.4
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ruby:latest (no parseable major.minor) does NOT trigger",
+			Content: `FROM ruby:latest
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestEOLRubyVersionRule_FixRewritesBranch(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM ruby:3.0-slim
+RUN bundle install
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEOLRubyVersionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
+	}
+	got := v.SuggestedFix.Edits[0].NewText
+	want := supportedRubyBranches[0] + "-slim"
+	if !strings.Contains(got, want) {
+		t.Errorf("fix should contain %q (latest supported branch + variant); got: %q",
+			want, got)
+	}
+}
+
+func TestEOLRubyVersionRule_NoFixForArgTemplated(t *testing.T) {
+	t.Parallel()
+
+	content := `ARG RUBY_VERSION=2.7
+FROM ruby:${RUBY_VERSION}-slim
+RUN bundle install
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEOLRubyVersionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	// ARG-templated FROM lines need user judgment about whether to bump
+	// the ARG default vs rewriting the FROM, so we leave a violation
+	// without an auto-fix attached.
+	if v.SuggestedFix != nil && len(v.SuggestedFix.Edits) > 0 {
+		t.Errorf("ARG-templated FROM should not auto-rewrite; got %d edits",
+			len(v.SuggestedFix.Edits))
+	}
+}
+
+func TestParseRubyImageBranch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		image    string
+		want     string
+		wantRuby bool
+	}{
+		{name: "ruby:3.3-slim", image: "ruby:3.3-slim", want: "3.3", wantRuby: true},
+		{name: "ruby:2.7", image: "ruby:2.7", want: "2.7", wantRuby: true},
+		{name: "ruby:3.0.6-bookworm", image: "ruby:3.0.6-bookworm", want: "3.0", wantRuby: true},
+		{name: "ruby:latest", image: "ruby:latest", want: "", wantRuby: true},
+		{name: "ruby (no tag)", image: "ruby", want: "", wantRuby: true},
+		{name: "jruby:9.4", image: "jruby:9.4", want: "", wantRuby: false},
+		{name: "debian:bookworm", image: "debian:bookworm", want: "", wantRuby: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotBranch, gotRuby := parseRubyImageBranch(tt.image)
+			if gotBranch != tt.want {
+				t.Errorf("branch = %q, want %q", gotBranch, tt.want)
+			}
+			if gotRuby != tt.wantRuby {
+				t.Errorf("isRuby = %v, want %v", gotRuby, tt.wantRuby)
+			}
+		})
+	}
+}
+
+func TestMajorMinorFromVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in, want string
+	}{
+		{"3.3.5", "3.3"},
+		{"3.3.5p100", "3.3"},
+		{"2.7.0", "2.7"},
+		{"  3.4  ", "3.4"}, // trims whitespace; only major.minor needed
+		{"abc.def", ""},
+		{"3", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := majorMinorFromVersion(tt.in)
+		if got != tt.want {
+			t.Errorf("majorMinorFromVersion(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/rules/tally/ruby/eol_ruby_version_test.go
+++ b/internal/rules/tally/ruby/eol_ruby_version_test.go
@@ -1,7 +1,6 @@
 package ruby
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/wharflab/tally/internal/rules"
@@ -108,10 +107,63 @@ RUN bundle install
 		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
 	}
 	got := v.SuggestedFix.Edits[0].NewText
-	want := supportedRubyBranches[0] + "-slim"
-	if !strings.Contains(got, want) {
-		t.Errorf("fix should contain %q (latest supported branch + variant); got: %q",
-			want, got)
+	want := "ruby:" + supportedRubyBranches[0] + "-slim"
+	if got != want {
+		t.Errorf("fix NewText = %q, want %q", got, want)
+	}
+}
+
+func TestEOLRubyVersionRule_FixDropsPatchLevel(t *testing.T) {
+	t.Parallel()
+
+	// Regression for codex P2 / greptile P1 / gemini medium: rewriting
+	// `ruby:3.1.6` → `ruby:3.4.6` would carry the old branch's patch
+	// number into the new branch and produce a tag that may not exist
+	// on Docker Hub. The fix must drop the patch level.
+	content := `FROM ruby:3.1.6
+RUN bundle install
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewEOLRubyVersionRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	got := v.SuggestedFix.Edits[0].NewText
+	want := "ruby:" + supportedRubyBranches[0]
+	if got != want {
+		t.Errorf("fix NewText = %q, want %q (must drop patch level)", got, want)
+	}
+}
+
+func TestEOLRubyVersionRule_FixPreservesVariant(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		from string
+		want string
+	}{
+		{"FROM ruby:3.0-slim\n", "ruby:" + supportedRubyBranches[0] + "-slim"},
+		{"FROM ruby:3.0-bookworm\n", "ruby:" + supportedRubyBranches[0] + "-bookworm"},
+		{"FROM ruby:3.0-alpine3.19\n", "ruby:" + supportedRubyBranches[0] + "-alpine3.19"},
+		{"FROM ruby:2.7.0-alpine\n", "ruby:" + supportedRubyBranches[0] + "-alpine"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.from, func(t *testing.T) {
+			t.Parallel()
+			input := testutil.MakeLintInput(t, "Dockerfile", tt.from)
+			violations := NewEOLRubyVersionRule().Check(input)
+			if len(violations) != 1 {
+				t.Fatalf("got %d violations, want 1", len(violations))
+			}
+			got := violations[0].SuggestedFix.Edits[0].NewText
+			if got != tt.want {
+				t.Errorf("fix NewText = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/eol-ruby-version`](https://tally.wharflab.com/rules/tally/ruby/eol-ruby-version/) — Section 4.2 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

Production images on end-of-life Ruby branches accumulate unfixed CVEs over time. The corpus shows 48 of 196 Dockerfiles still pinned to Ruby 2.x and 15 more pinned to 3.0/3.1. This rule maintains a curated EOL table sourced from [Ruby's maintenance branches page](https://www.ruby-lang.org/en/downloads/branches/) and emits an `error` for fully retired branches.

- **Coverage:** Ruby 2.4–3.1 (all retired) → error severity. Ruby 3.2/3.3/3.4 → no violation.
- **Suppressions:** Ruby derivatives (`jruby`, `truffleruby`, `phusion/passenger-ruby`) follow different release cadences and aren't covered by the upstream Ruby EOL table. Windows stages are also skipped.
- **Context-aware:** when the FROM line is ARG-templated (`FROM ruby:${RUBY_VERSION}`) and the literal value is unparsable, the rule falls back to `.ruby-version` / `.tool-versions` / `Gemfile.lock`'s `RUBY VERSION` block via `RubyFacts.RubyVersion`.
- **Auto-fix:** `FixSuggestion`. Rewrites `FROM ruby:X.Y[-variant]` to use the most recent supported branch, preserving the variant suffix. Suppressed for ARG-templated bases.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint and fix fixtures: `internal/integration/fixtures/{lint,fix}/ruby-eol-ruby-version/`