### PR TITLE
feat(rules): add tally/ruby/state-paths-not-writable-as-non-root

### DIFF
--- a/_docs/rules/tally/ruby/state-paths-not-writable-as-non-root.mdx
+++ b/_docs/rules/tally/ruby/state-paths-not-writable-as-non-root.mdx
@@ -1,0 +1,90 @@
+---
+title: "tally/ruby/state-paths-not-writable-as-non-root"
+description: "Rails app COPY without `--chown` leaves state dirs (tmp, log, storage, db) root-owned at runtime."
+---
+
+A Rails app stage that switches to a non-root `USER` but `COPY`s application content without `--chown` (or a
+matching runtime `chown -R`) leaves Rails state directories root-owned. The app crashes on first request
+when ActionView, ActiveStorage, ActiveRecord, or `bin/rails db:prepare` tries to write to them.
+
+| Property | Value |
+|----------|-------|
+| Severity | Warning |
+| Category | Correctness |
+| Default | Enabled |
+| Auto-fix | Yes (`FixSuggestion`) |
+
+## Description
+
+Rails maintains four canonical state directories that need to be writable by the runtime user: `tmp/`,
+`log/`, `storage/`, and `db/`. The Rails generator template handles ownership in its final-stage COPY:
+
+```dockerfile
+COPY --chown=rails:rails --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+COPY --chown=rails:rails --from=build /rails /rails
+USER rails:rails
+```
+
+Forks of that template that drop `--chown` (or that introduce a non-root `USER` independent of the generator
+pattern) end up with root-owned `tmp/cache` directories. ActionView writes there on first render;
+ActiveStorage on first upload; `bin/rails db:prepare` on schema load. The result is a 500 on first request,
+or worse: a permission-denied that gets logged but doesn't crash the app, leaving the user staring at
+mysteriously broken behavior.
+
+This rule fires when:
+
+- The stage explicitly sets `USER` to a non-root identity.
+- The stage `COPY`s application content (canonical shapes: `COPY . .`, `COPY /rails /rails`, `COPY --from=build /rails /rails`).
+- Neither the COPY carries `--chown=<user>...` matching the runtime user, nor a subsequent `RUN chown -R <user>...` covers all four state directories.
+- The base image is plausibly a Rails app (Ruby base + WORKDIR /rails or /app, or ENTRYPOINT/CMD references rails).
+
+CLI-only gem images (no `WORKDIR /rails`/`/app`, no `bin/rails`, no `RAILS_ENV` env binding) are skipped —
+they don't ship Rails state directories.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails:rails
+COPY . .
+CMD ["bin/rails", "server"]
+```
+
+### After
+
+The Rails-generator-style fix adds `--chown` to the offending COPY:
+
+```dockerfile
+FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails:rails
+COPY --chown=rails:rails . .
+CMD ["bin/rails", "server"]
+```
+
+A runtime `chown -R` covering all four directories is also accepted (matches `basecamp/writebook`'s pattern):
+
+```dockerfile
+FROM ruby:3.3-slim
+WORKDIR /rails
+COPY . .
+RUN chown -R rails:rails db log storage tmp
+USER rails:rails
+CMD ["bin/rails", "server"]
+```
+
+## Auto-fix
+
+`FixSuggestion`. Inserts `--chown=<user>:<user>` immediately after the `COPY` keyword on the offending
+instruction. The fix is `FixSuggestion` (not `FixSafe`) because the user/group name may need adjustment in
+unusual setups (group not matching user, numeric uid/gid, etc.).
+
+## References
+
+- [Rails Dockerfile generator template](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt) —
+  uses `COPY --chown=rails:rails` for both the bundle and app trees.
+- [`basecamp/writebook` Dockerfile](https://github.com/basecamp/writebook/blob/main/Dockerfile) —
+  the runtime-`chown` pattern.

--- a/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/.tally.toml
+++ b/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/.tally.toml
@@ -1,0 +1,11 @@
+unsafe-fixes = true
+
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/state-paths-not-writable-as-non-root"]
+exclude = ["*"]
+
+[output]
+fail-level = "none"

--- a/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails:rails
+COPY . .
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/fixed_1.snap.Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails:rails
+COPY .--chown=rails:rails  .
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/fixed_1.snap.Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.3-slim
 WORKDIR /rails
 USER rails:rails
-COPY .--chown=rails:rails  .
+COPY --chown=rails:rails . .
 CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-state-paths-not-writable-as-non-root/report_1.snap.md
@@ -1,0 +1,2 @@
+Fixed 1 issues
+**No issues found**

--- a/internal/integration/fixtures/lint/ruby-state-paths-not-writable-as-non-root/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-state-paths-not-writable-as-non-root/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/state-paths-not-writable-as-non-root"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-state-paths-not-writable-as-non-root/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-state-paths-not-writable-as-non-root/Dockerfile
@@ -1,0 +1,28 @@
+# Canonical violation: COPY . . without --chown after non-root USER.
+FROM ruby:3.3-slim AS app-violation
+WORKDIR /rails
+USER rails:rails
+COPY . .
+CMD ["bin/rails", "server"]
+
+# Compliant: --chown on the COPY.
+FROM ruby:3.3-slim AS app-chown
+WORKDIR /rails
+USER rails:rails
+COPY --chown=rails:rails . .
+CMD ["bin/rails", "server"]
+
+# Compliant: runtime chown -R covering all four state dirs before USER.
+FROM ruby:3.3-slim AS app-runtime-chown
+WORKDIR /rails
+COPY . .
+RUN chown -R rails:rails db log storage tmp
+USER rails:rails
+CMD ["bin/rails", "server"]
+
+# Suppressed: root USER (tells us the stage isn't dropping privileges).
+FROM ruby:3.3-slim AS app-root
+WORKDIR /rails
+USER root
+COPY . .
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/lint/ruby-state-paths-not-writable-as-non-root/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-state-paths-not-writable-as-non-root/result_1.snap.json
@@ -27,12 +27,12 @@
               {
                 "location": {
                   "end": {
-                    "column": 6,
+                    "column": 5,
                     "line": 5
                   },
                   "file": "fixtures/lint/ruby-state-paths-not-writable-as-non-root/Dockerfile",
                   "start": {
-                    "column": 6,
+                    "column": 5,
                     "line": 5
                   }
                 },

--- a/internal/integration/fixtures/lint/ruby-state-paths-not-writable-as-non-root/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-state-paths-not-writable-as-non-root/result_1.snap.json
@@ -1,0 +1,60 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-state-paths-not-writable-as-non-root/Dockerfile",
+      "violations": [
+        {
+          "detail": "When the runtime stage runs as `rails`, copying application content without `--chown=rails:rails` leaves the Rails state directories (tmp, log, storage, db) root-owned. Rails crashes on first request when ActionView, ActiveStorage, ActiveRecord, or `bin/rails db:prepare` tries to write to them. Add `--chown=rails:rails` to the offending COPY (the Rails generator template's exact pattern) or perform an explicit `chown -R rails:rails` on the state directories before switching to USER.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/state-paths-not-writable-as-non-root/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 5
+            },
+            "file": "fixtures/lint/ruby-state-paths-not-writable-as-non-root/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 5
+            }
+          },
+          "message": "Rails app COPY without --chown leaves state dirs (tmp, log, storage, db) root-owned at runtime",
+          "rule": "tally/ruby/state-paths-not-writable-as-non-root",
+          "severity": "warning",
+          "sourceCode": "COPY . .",
+          "suggestedFix": {
+            "description": "Add --chown=rails:rails so Rails state dirs are writable at runtime",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 6,
+                    "line": 5
+                  },
+                  "file": "fixtures/lint/ruby-state-paths-not-writable-as-non-root/Dockerfile",
+                  "start": {
+                    "column": 6,
+                    "line": 5
+                  }
+                },
+                "newText": "--chown=rails:rails "
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 1,
+    "warnings": 1
+  }
+}

--- a/internal/rules/tally/ruby/state_paths_not_writable_as_non_root.go
+++ b/internal/rules/tally/ruby/state_paths_not_writable_as_non_root.go
@@ -1,0 +1,349 @@
+package ruby
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+)
+
+// StatePathsNotWritableAsNonRootRuleCode is the full rule code.
+const StatePathsNotWritableAsNonRootRuleCode = rules.TallyRulePrefix + "ruby/state-paths-not-writable-as-non-root"
+
+// statePathsNotWritableAsNonRootFixPriority keeps this rule's edits ordered
+// alongside the other Ruby rules.
+const statePathsNotWritableAsNonRootFixPriority = 88
+
+// railsStateDirs are the canonical Rails directories that need to be
+// writable by the non-root runtime user. These are Rails convention,
+// not generic Docker.
+var railsStateDirs = []string{"tmp", "log", "storage", "db"}
+
+// railsServerCommand is the Rails CLI binary basename used to detect
+// Rails-app-shaped runtime stages.
+const railsServerCommand = "rails"
+
+// StatePathsNotWritableAsNonRootRule flags Rails app stages that switch
+// to a non-root USER but `COPY` application content without `--chown` (or
+// a subsequent `chown -R`), leaving Rails state directories root-owned
+// and unwritable to the runtime user.
+type StatePathsNotWritableAsNonRootRule struct{}
+
+// NewStatePathsNotWritableAsNonRootRule creates the rule.
+func NewStatePathsNotWritableAsNonRootRule() *StatePathsNotWritableAsNonRootRule {
+	return &StatePathsNotWritableAsNonRootRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *StatePathsNotWritableAsNonRootRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            StatePathsNotWritableAsNonRootRuleCode,
+		Name:            "Rails state directories must be writable as the non-root runtime user",
+		Description:     "Rails app COPY without --chown leaves state dirs (tmp, log, storage, db) root-owned at runtime",
+		DocURL:          rules.TallyDocURL(StatePathsNotWritableAsNonRootRuleCode),
+		DefaultSeverity: rules.SeverityWarning,
+		Category:        "correctness",
+		FixPriority:     statePathsNotWritableAsNonRootFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *StatePathsNotWritableAsNonRootRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		// Only fire on Ruby/Rails-shaped stages.
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+		// Require an explicit non-root USER to be set in this stage.
+		if sf.EffectiveUser == "" || facts.IsRootUser(sf.EffectiveUser) {
+			continue
+		}
+		// CLI-only gem images (no WORKDIR /rails, no bin/rails references)
+		// are out of scope.
+		if !stageLooksLikeRailsApp(stage, sf) {
+			continue
+		}
+		violations = append(violations, r.checkStage(input, stage, sf, meta)...)
+	}
+	return violations
+}
+
+func (r *StatePathsNotWritableAsNonRootRule) checkStage(
+	input rules.LintInput,
+	stage instructions.Stage,
+	sf *facts.StageFacts,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	user := stripUserGroup(sf.EffectiveUser)
+
+	// Find the offending COPY: any COPY of application content (not
+	// stage-to-stage with --chown, not a single-file COPY of a known
+	// vendor artifact) that lacks --chown to the non-root user. The
+	// canonical violation shape is `COPY . .` (or `COPY /rails /rails`)
+	// without --chown.
+	var violations []rules.Violation
+	for _, cmd := range stage.Commands {
+		copyCmd, ok := cmd.(*instructions.CopyCommand)
+		if !ok {
+			continue
+		}
+		if !copyLooksLikeAppContent(copyCmd) {
+			continue
+		}
+		if copyHasChownToUser(copyCmd, user) {
+			continue
+		}
+		// If a later RUN performs `chown -R user dir(s)` covering all
+		// observed state dirs, the COPY is acceptable.
+		if stageHasRuntimeChown(sf, user) {
+			continue
+		}
+
+		loc := copyInstructionLocation(input.File, copyCmd)
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(statePathsDetail(user))
+		if fix := buildStatePathsFix(input.File, copyCmd, user, meta.FixPriority); fix != nil {
+			v = v.WithSuggestedFix(fix)
+		}
+		violations = append(violations, v)
+	}
+	return violations
+}
+
+func statePathsDetail(user string) string {
+	dirs := strings.Join(railsStateDirs, ", ")
+	return "When the runtime stage runs as `" + user + "`, copying application content without " +
+		"`--chown=" + user + ":" + user + "` leaves the Rails state directories (" + dirs + ") " +
+		"root-owned. Rails crashes on first request when ActionView, ActiveStorage, ActiveRecord, or " +
+		"`bin/rails db:prepare` tries to write to them. Add `--chown=" + user + ":" + user + "` to the " +
+		"offending COPY (the Rails generator template's exact pattern) or perform an explicit " +
+		"`chown -R " + user + ":" + user + "` on the state directories before switching to USER."
+}
+
+// stageLooksLikeRailsApp reports whether the stage looks like a Rails app
+// runtime image — has a WORKDIR /rails (or similar) and references
+// `bin/rails`, `bundle exec rails`, or `rails server` somewhere. CLI-only
+// gem images (no Rails) are out of scope.
+func stageLooksLikeRailsApp(stage instructions.Stage, sf *facts.StageFacts) bool {
+	// Quick wins: WORKDIR pointing at a typical Rails app directory.
+	if sf.FinalWorkdir == "/rails" || sf.FinalWorkdir == "/app" ||
+		strings.HasSuffix(sf.FinalWorkdir, "/rails") ||
+		strings.HasSuffix(sf.FinalWorkdir, "/app") {
+		return true
+	}
+	// ENTRYPOINT/CMD references rails-style binaries.
+	for _, name := range stageRuntimeCommandBasenames(stage) {
+		if name == railsServerCommand || name == "thrust" || name == "puma" || name == "rackup" {
+			return true
+		}
+	}
+	// Effective env explicitly declares Rails.
+	if value, ok := sf.EffectiveEnv.Bindings["RAILS_ENV"]; ok && value.Value != "" {
+		return true
+	}
+	return false
+}
+
+// stripUserGroup returns the user portion of a `user[:group]` string.
+func stripUserGroup(s string) string {
+	if user, _, ok := strings.Cut(s, ":"); ok {
+		return user
+	}
+	return s
+}
+
+// copyLooksLikeAppContent reports whether a COPY is copying application
+// content (a directory tree like `.`, `./`, `/rails`, or `--from=builder
+// /rails`) rather than a single file or vendor artifact.
+func copyLooksLikeAppContent(cmd *instructions.CopyCommand) bool {
+	if cmd == nil {
+		return false
+	}
+	// Heredoc COPYs aren't application-content COPYs; skip.
+	if len(cmd.SourceContents) > 0 {
+		return false
+	}
+	for _, src := range cmd.SourcePaths {
+		if src == "." || src == "./" || src == "/rails" || src == "/app" {
+			return true
+		}
+		// Deep paths into the project that imply directory content.
+		if strings.HasSuffix(src, "/.") {
+			return true
+		}
+	}
+	return false
+}
+
+// copyHasChownToUser reports whether the COPY's --chown flag's value
+// matches the supplied user (left side of any user:group). A bare user
+// without group also counts.
+func copyHasChownToUser(cmd *instructions.CopyCommand, user string) bool {
+	if cmd == nil || cmd.Chown == "" {
+		return false
+	}
+	chown := cmd.Chown
+	if idx := strings.Index(chown, ":"); idx >= 0 {
+		chown = chown[:idx]
+	}
+	return strings.EqualFold(strings.TrimSpace(chown), user)
+}
+
+// stageHasRuntimeChown reports whether any RUN in the stage performs
+// `chown -R user[:group] <state-dirs>` covering all four canonical Rails
+// state directories. A partial chown (e.g. only `tmp log`) is not
+// sufficient — Rails crashes on whichever directory is missing.
+func stageHasRuntimeChown(sf *facts.StageFacts, user string) bool {
+	if sf == nil {
+		return false
+	}
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		for _, ci := range runFacts.CommandInfos {
+			if !strings.EqualFold(ci.Name, "chown") {
+				continue
+			}
+			if !chownTargetsUser(ci.Args, user) {
+				continue
+			}
+			if !chownIsRecursive(ci.Args) {
+				continue
+			}
+			if chownCoversAllStateDirs(ci.Args) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func chownTargetsUser(args []string, user string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		// First non-flag arg is the user/group spec.
+		owner := a
+		if idx := strings.Index(owner, ":"); idx >= 0 {
+			owner = owner[:idx]
+		}
+		return strings.EqualFold(strings.TrimSpace(owner), user)
+	}
+	return false
+}
+
+func chownIsRecursive(args []string) bool {
+	for _, a := range args {
+		if a == "-R" || a == "--recursive" {
+			return true
+		}
+		// Combined short flags (-Rh, -fR, etc.) — scan letters.
+		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") {
+			for _, c := range a[1:] {
+				if c == 'R' {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func chownCoversAllStateDirs(args []string) bool {
+	covered := make(map[string]bool, len(railsStateDirs))
+	sawUserSpec := false
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		if !sawUserSpec {
+			// Skip the first non-flag arg (the user[:group] spec).
+			sawUserSpec = true
+			continue
+		}
+		// Strip leading ./ or trailing /
+		path := strings.TrimPrefix(a, "./")
+		path = strings.TrimSuffix(path, "/")
+		// Match against state dir basenames.
+		for _, d := range railsStateDirs {
+			if path == d || strings.HasSuffix(path, "/"+d) {
+				covered[d] = true
+			}
+		}
+	}
+	for _, d := range railsStateDirs {
+		if !covered[d] {
+			return false
+		}
+	}
+	return true
+}
+
+// copyInstructionLocation returns the COPY instruction's source location.
+func copyInstructionLocation(file string, cmd *instructions.CopyCommand) rules.Location {
+	if cmd == nil {
+		return rules.NewFileLocation(file)
+	}
+	loc := cmd.Location()
+	if len(loc) == 0 {
+		return rules.NewFileLocation(file)
+	}
+	return rules.NewLocationFromRanges(file, loc)
+}
+
+// buildStatePathsFix proposes adding `--chown=user:user` to the offending
+// COPY. The fix is FixSuggestion because the user/group may need
+// adjustment in unusual setups (group not matching user, numeric uid/gid,
+// etc.).
+func buildStatePathsFix(
+	file string,
+	cmd *instructions.CopyCommand,
+	user string,
+	priority int,
+) *rules.SuggestedFix {
+	if cmd == nil {
+		return nil
+	}
+	loc := cmd.Location()
+	if len(loc) == 0 {
+		return nil
+	}
+	startLine := loc[0].Start.Line
+	// Position.Character is the 0-based column; rules.NewRangeLocation
+	// expects 1-based columns.
+	startCol := loc[0].Start.Character + 1
+	// Insert the --chown flag immediately after `COPY` (4 chars + space = 5).
+	const copyKeywordLen = len("COPY ")
+	insertCol := startCol + copyKeywordLen
+	chownFlag := "--chown=" + user + ":" + user + " "
+	return &rules.SuggestedFix{
+		Description: "Add --chown=" + user + ":" + user + " so Rails state dirs are writable at runtime",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(file, startLine, insertCol, startLine, insertCol),
+			NewText:  chownFlag,
+		}},
+	}
+}
+
+func init() {
+	rules.Register(NewStatePathsNotWritableAsNonRootRule())
+}

--- a/internal/rules/tally/ruby/state_paths_not_writable_as_non_root.go
+++ b/internal/rules/tally/ruby/state_paths_not_writable_as_non_root.go
@@ -1,6 +1,7 @@
 package ruby
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
@@ -25,6 +26,11 @@ var railsStateDirs = []string{"tmp", "log", "storage", "db"}
 // railsServerCommand is the Rails CLI binary basename used to detect
 // Rails-app-shaped runtime stages.
 const railsServerCommand = "rails"
+
+// railsAppWorkdirs are the canonical WORKDIR values for a Rails app,
+// used to detect Rails-shaped runtime stages and to recognize
+// `chown -R user <dir>` as covering all state dirs under that root.
+var railsAppWorkdirs = []string{"/rails", "/app"}
 
 // StatePathsNotWritableAsNonRootRule flags Rails app stages that switch
 // to a non-root USER but `COPY` application content without `--chown` (or
@@ -106,9 +112,12 @@ func (r *StatePathsNotWritableAsNonRootRule) checkStage(
 		if copyHasChownToUser(copyCmd, user) {
 			continue
 		}
-		// If a later RUN performs `chown -R user dir(s)` covering all
-		// observed state dirs, the COPY is acceptable.
-		if stageHasRuntimeChown(sf, user) {
+		// If a RUN chown -R covering all canonical state dirs runs
+		// AFTER the COPY (in source order), the chown corrects the
+		// COPY's ownership and the rule is satisfied. A chown that
+		// runs BEFORE the COPY does not — the COPY would re-introduce
+		// root-owned files.
+		if stageHasRuntimeChownAfter(sf, user, copyStartLine(copyCmd)) {
 			continue
 		}
 
@@ -140,10 +149,10 @@ func statePathsDetail(user string) string {
 // gem images (no Rails) are out of scope.
 func stageLooksLikeRailsApp(stage instructions.Stage, sf *facts.StageFacts) bool {
 	// Quick wins: WORKDIR pointing at a typical Rails app directory.
-	if sf.FinalWorkdir == "/rails" || sf.FinalWorkdir == "/app" ||
-		strings.HasSuffix(sf.FinalWorkdir, "/rails") ||
-		strings.HasSuffix(sf.FinalWorkdir, "/app") {
-		return true
+	for _, workdir := range railsAppWorkdirs {
+		if sf.FinalWorkdir == workdir || strings.HasSuffix(sf.FinalWorkdir, workdir) {
+			return true
+		}
 	}
 	// ENTRYPOINT/CMD references rails-style binaries.
 	for _, name := range stageRuntimeCommandBasenames(stage) {
@@ -203,16 +212,32 @@ func copyHasChownToUser(cmd *instructions.CopyCommand, user string) bool {
 	return strings.EqualFold(strings.TrimSpace(chown), user)
 }
 
-// stageHasRuntimeChown reports whether any RUN in the stage performs
-// `chown -R user[:group] <state-dirs>` covering all four canonical Rails
-// state directories. A partial chown (e.g. only `tmp log`) is not
-// sufficient — Rails crashes on whichever directory is missing.
-func stageHasRuntimeChown(sf *facts.StageFacts, user string) bool {
+// stageHasRuntimeChownAfter reports whether any RUN at-or-after the
+// supplied source line performs `chown -R user[:group] <state-dirs>`
+// covering all four canonical Rails state directories. A chown BEFORE
+// the line does not count: it would be undone by the COPY at `line`
+// re-introducing root-owned files.
+//
+// `chown -R user .` or `chown -R user /rails` (the WORKDIR root) also
+// count as covering all state dirs because Rails state lives under
+// the WORKDIR.
+//
+// Partial chowns (e.g. only `tmp log`) are not sufficient — Rails
+// crashes on whichever directory is missing.
+func stageHasRuntimeChownAfter(sf *facts.StageFacts, user string, line int) bool {
 	if sf == nil {
 		return false
 	}
 	for _, runFacts := range sf.Runs {
-		if runFacts == nil {
+		if runFacts == nil || runFacts.Run == nil {
+			continue
+		}
+		runRanges := runFacts.Run.Location()
+		if len(runRanges) == 0 {
+			continue
+		}
+		runLine := runRanges[0].Start.Line
+		if runLine < line {
 			continue
 		}
 		for _, ci := range runFacts.CommandInfos {
@@ -231,6 +256,19 @@ func stageHasRuntimeChown(sf *facts.StageFacts, user string) bool {
 		}
 	}
 	return false
+}
+
+// copyStartLine returns the 1-based line of the COPY instruction's
+// first character, or 0 when the location is missing.
+func copyStartLine(cmd *instructions.CopyCommand) int {
+	if cmd == nil {
+		return 0
+	}
+	loc := cmd.Location()
+	if len(loc) == 0 {
+		return 0
+	}
+	return loc[0].Start.Line
 }
 
 func chownTargetsUser(args []string, user string) bool {
@@ -277,9 +315,17 @@ func chownCoversAllStateDirs(args []string) bool {
 			sawUserSpec = true
 			continue
 		}
-		// Strip leading ./ or trailing /
-		path := strings.TrimPrefix(a, "./")
-		path = strings.TrimSuffix(path, "/")
+		// A chown -R on the project root or workdir covers everything
+		// inside it, including all four state dirs.
+		path := strings.TrimSuffix(a, "/")
+		if path == "." || path == "./" {
+			return true
+		}
+		if slices.Contains(railsAppWorkdirs, path) {
+			return true
+		}
+		// Strip leading ./
+		path = strings.TrimPrefix(path, "./")
 		// Match against state dir basenames.
 		for _, d := range railsStateDirs {
 			if path == d || strings.HasSuffix(path, "/"+d) {
@@ -325,12 +371,11 @@ func buildStatePathsFix(
 		return nil
 	}
 	startLine := loc[0].Start.Line
-	// Position.Character is the 0-based column; rules.NewRangeLocation
-	// expects 1-based columns.
-	startCol := loc[0].Start.Character + 1
-	// Insert the --chown flag immediately after `COPY` (4 chars + space = 5).
+	// rules.NewRangeLocation columns are 0-based; Position.Character is
+	// also 0-based. Insert `--chown=...` immediately after `COPY ` (5
+	// chars) on the same line.
 	const copyKeywordLen = len("COPY ")
-	insertCol := startCol + copyKeywordLen
+	insertCol := loc[0].Start.Character + copyKeywordLen
 	chownFlag := "--chown=" + user + ":" + user + " "
 	return &rules.SuggestedFix{
 		Description: "Add --chown=" + user + ":" + user + " so Rails state dirs are writable at runtime",

--- a/internal/rules/tally/ruby/state_paths_not_writable_as_non_root_test.go
+++ b/internal/rules/tally/ruby/state_paths_not_writable_as_non_root_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wharflab/tally/internal/fix"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/testutil"
 )
@@ -132,6 +133,41 @@ COPY . .
 `,
 			WantViolations: 0,
 		},
+		// --- Regression: chown BEFORE COPY does NOT count ---
+		{
+			Name: "chown -R before COPY does NOT suppress (COPY would re-introduce root-owned files)",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+RUN chown -R rails:rails db log storage tmp
+COPY . .
+USER rails:rails
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: chown -R . (project root) covers everything ---
+		{
+			Name: "chown -R rails . after COPY suppresses (covers all dirs under WORKDIR)",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+COPY . .
+RUN chown -R rails:rails .
+USER rails:rails
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "chown -R rails:rails /rails after COPY suppresses (covers all dirs under WORKDIR)",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+COPY . .
+RUN chown -R rails:rails /rails
+USER rails:rails
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
 	})
 }
 
@@ -156,9 +192,15 @@ CMD ["bin/rails", "server"]
 	if v.SuggestedFix.Safety != rules.FixSuggestion {
 		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
 	}
-	got := v.SuggestedFix.Edits[0].NewText
-	want := "--chown=rails:rails "
-	if !strings.Contains(got, want) {
-		t.Errorf("fix should contain %q; got: %q", want, got)
+	if len(v.SuggestedFix.Edits) == 0 {
+		t.Fatalf("expected at least one edit; got %d", len(v.SuggestedFix.Edits))
+	}
+
+	// Apply the fix to verify the output is a syntactically correct
+	// Dockerfile (regression test for the off-by-one column bug that
+	// produced `COPY .--chown=...`).
+	got := string(fix.ApplyFix([]byte(content), v.SuggestedFix))
+	if !strings.Contains(got, "COPY --chown=rails:rails . .") {
+		t.Errorf("applied fix should produce `COPY --chown=rails:rails . .`; got:\n%s", got)
 	}
 }

--- a/internal/rules/tally/ruby/state_paths_not_writable_as_non_root_test.go
+++ b/internal/rules/tally/ruby/state_paths_not_writable_as_non_root_test.go
@@ -1,0 +1,164 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestStatePathsNotWritableAsNonRootRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewStatePathsNotWritableAsNonRootRule().Metadata()
+	if meta.Code != StatePathsNotWritableAsNonRootRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, StatePathsNotWritableAsNonRootRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityWarning {
+		t.Errorf("DefaultSeverity = %v, want Warning", meta.DefaultSeverity)
+	}
+	if meta.Category != "correctness" {
+		t.Errorf("Category = %q, want %q", meta.Category, "correctness")
+	}
+}
+
+func TestStatePathsNotWritableAsNonRootRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewStatePathsNotWritableAsNonRootRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "non-root USER + COPY . . without --chown triggers",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails:rails
+COPY . .
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "USER set as numeric uid + COPY without --chown still triggers",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+USER 1000:1000
+COPY . .
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "COPY --from=builder /rails /rails without --chown triggers",
+			Content: `FROM ruby:3.3-slim AS builder
+WORKDIR /rails
+COPY . .
+
+FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails:rails
+COPY --from=builder /rails /rails
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: --chown on the COPY ---
+		{
+			Name: "COPY --chown=rails:rails . . suppresses",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails:rails
+COPY --chown=rails:rails . .
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "COPY --chown=rails . . (bare user, no group) suppresses",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails
+COPY --chown=rails . .
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: chown -R covering all state dirs ---
+		{
+			Name: "chown -R rails:rails db log storage tmp before USER suppresses",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+COPY . .
+RUN chown -R rails:rails db log storage tmp
+USER rails:rails
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		// --- Suppressions ---
+		{
+			Name: "root USER skipped",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+USER root
+COPY . .
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "no USER instruction skipped",
+			Content: `FROM ruby:3.3-slim
+WORKDIR /rails
+COPY . .
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Rails image (CLI gem) skipped",
+			Content: `FROM ruby:3.3-slim
+USER ruby:ruby
+COPY mygem.gemspec /
+CMD ["mygem"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Ruby base skipped",
+			Content: `FROM debian:bookworm-slim
+USER nonroot:nonroot
+COPY . .
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestStatePathsNotWritableAsNonRootRule_FixAddsChownFlag(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM ruby:3.3-slim
+WORKDIR /rails
+USER rails:rails
+COPY . .
+CMD ["bin/rails", "server"]
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewStatePathsNotWritableAsNonRootRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
+	}
+	got := v.SuggestedFix.Edits[0].NewText
+	want := "--chown=rails:rails "
+	if !strings.Contains(got, want) {
+		t.Errorf("fix should contain %q; got: %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/state-paths-not-writable-as-non-root`](https://tally.wharflab.com/rules/tally/ruby/state-paths-not-writable-as-non-root/) — Section 4.2 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

A Rails app stage that switches to a non-root `USER` but `COPY`s application content without `--chown` leaves the Rails state directories (`tmp`, `log`, `storage`, `db`) root-owned. Rails crashes on first request when ActionView, ActiveStorage, ActiveRecord, or `bin/rails db:prepare` tries to write to them. The Rails generator template handles this via `COPY --chown=rails:rails ... /rails /rails`; forks that drop the flag ship runtime-broken images.

- **Compliance:** `--chown=<user>...` on the COPY (with bare-user form `--chown=rails` accepted), or a runtime `chown -R <user> tmp log storage db` covering all four canonical state directories.
- **Suppressions:** stages without an explicit USER, root USER, non-Ruby stages, non-Rails-shaped images (no `WORKDIR /rails`/`/app`, no rails-style ENTRYPOINT, no `RAILS_ENV`).
- **Auto-fix:** `FixSuggestion`. Inserts `--chown=<user>:<user>` after the `COPY` keyword. Marked suggestion (not safe) because user/group names may need adjustment for unusual setups.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint and fix fixtures: `internal/integration/fixtures/{lint,fix}/ruby-state-paths-not-writable-as-non-root/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a linting rule to detect Rails/Ruby containers that switch to non-root users without ensuring critical state directories remain writable after copying application code.

* **Documentation**
  * Added documentation for the new rule with Dockerfile examples, fix suggestions, and guidance on proper ownership configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wharflab/tally/pull/675)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->