### PR TITLE
feat(rules): add tally/ruby/prefer-bundler-cache-mount

### DIFF
--- a/_docs/rules/tally/ruby/prefer-bundler-cache-mount.mdx
+++ b/_docs/rules/tally/ruby/prefer-bundler-cache-mount.mdx
@@ -1,0 +1,79 @@
+---
+title: "tally/ruby/prefer-bundler-cache-mount"
+description: "`bundle install` doesn't use a BuildKit cache mount; native-extension gems will recompile on every build."
+---
+
+`bundle install` doesn't use a BuildKit cache mount on `${BUNDLE_PATH}/cache`.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info (default) / Warning (project has native-extension gems) |
+| Category | Performance |
+| Default | Enabled |
+| Auto-fix | Yes (`FixSuggestion`, no-edit) |
+
+## Description
+
+BuildKit's `RUN --mount=type=cache,target=${BUNDLE_PATH}/cache` keeps the gem-extraction cache across
+builds. Without it, every cache-busted `bundle install` re-fetches and (for native-extension gems)
+recompiles every gem from scratch — typically 30s+ on a non-trivial Rails project, and minutes for
+nokogiri-heavy or grpc-heavy projects.
+
+The corpus shows only **7 of 196** Dockerfiles use cache mounts at all.
+
+This rule fires when:
+
+- The Dockerfile carries the `# syntax=docker/dockerfile:1` (or higher) pragma — without it,
+  `--mount=type=cache` errors at build time.
+- A Ruby-shaped stage runs `bundle install`.
+- That `RUN` doesn't carry a `--mount=type=cache,target=...` whose target matches the Bundler cache
+  directory.
+
+Recognized cache-target paths:
+
+- `${BUNDLE_PATH}/cache` (variable form, what the Rails generator template uses).
+- `/usr/local/bundle/cache` (Rails generator's default `BUNDLE_PATH`).
+- `/bundle/cache`, `/bundle-cache`, `/cache` (other commonly-seen layouts).
+
+### Context-aware refinement
+
+When tally is invoked with `--context` and `Gemfile.lock` is observable, severity escalates from `info` to
+`warning` for projects with at least one native-extension gem (`nokogiri`, `pg`, `mysql2`, `sqlite3`,
+`grpc`, `ffi`, `oj`, `bcrypt`, `nio4r`, `puma`, `rugged`, `protobuf`, `sassc`, `eventmachine`, `unf_ext`,
+`racc`, `bigdecimal`). The rebuild-from-scratch cost of these gems is exactly what the cache mount fixes.
+
+## Examples
+
+### Before
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+```
+
+### After
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN --mount=type=cache,id=bundler,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle install
+```
+
+The `id=bundler` makes the cache reusable across Dockerfiles. The `sharing=locked` prevents corruption
+when concurrent builds touch the same cache.
+
+## Auto-fix
+
+`FixSuggestion`. The rule emits a non-edit suggestion: rewriting `--mount=type=cache` onto multi-line `RUN`
+chains is too easy to get wrong (continuation backslashes, existing `--mount` flags, heredoc bodies). The
+user applies the suggestion manually.
+
+## References
+
+- [Docker BuildKit `RUN --mount=type=cache` documentation](https://docs.docker.com/build/cache/optimize/#use-cache-mounts).
+- [Bundler cache layout](https://bundler.io/v2.5/man/bundle-cache.1.html) — describes
+  `${BUNDLE_PATH}/cache` semantics.

--- a/internal/integration/fixtures/lint/ruby-prefer-bundler-cache-mount/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-prefer-bundler-cache-mount/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/prefer-bundler-cache-mount"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-prefer-bundler-cache-mount/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-prefer-bundler-cache-mount/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+# Canonical violation: bundle install without cache mount.
+FROM ruby:3.3-slim AS app-violation
+RUN bundle install
+CMD ["bin/rails", "server"]
+
+# Compliant: cache mount on the Rails-generator default path.
+FROM ruby:3.3-slim AS app-compliant
+RUN --mount=type=cache,id=bundler,target=/usr/local/bundle/cache,sharing=locked \
+    bundle install
+
+# Compliant: variable-form target path.
+FROM ruby:3.3-slim AS app-variable
+RUN --mount=type=cache,target=${BUNDLE_PATH}/cache \
+    bundle install
+
+# Suppressed: dev stage.
+FROM ruby:3.3-slim AS dev
+RUN bundle install

--- a/internal/integration/fixtures/lint/ruby-prefer-bundler-cache-mount/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-prefer-bundler-cache-mount/result_1.snap.json
@@ -1,0 +1,43 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-prefer-bundler-cache-mount/Dockerfile",
+      "violations": [
+        {
+          "detail": "BuildKit's `RUN --mount=type=cache,target=${BUNDLE_PATH}/cache` is the documented way to keep the gem-extraction cache across builds. Without it, every cache-busted `bundle install` re-fetches and (for native-extension gems) recompiles every gem from scratch — typically 30s+ on a non-trivial Rails project.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-bundler-cache-mount/",
+          "location": {
+            "end": {
+              "column": 18,
+              "line": 4
+            },
+            "file": "fixtures/lint/ruby-prefer-bundler-cache-mount/Dockerfile",
+            "start": {
+              "column": 11,
+              "line": 4
+            }
+          },
+          "message": "`bundle install` doesn't use a BuildKit cache mount; native-extension gems will recompile on every cache-busted build",
+          "rule": "tally/ruby/prefer-bundler-cache-mount",
+          "severity": "info",
+          "sourceCode": "RUN bundle install",
+          "suggestedFix": {
+            "description": "Add `--mount=type=cache,id=bundler,target=${BUNDLE_PATH}/cache,sharing=locked` to the bundle install RUN",
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/rules/tally/ruby/prefer_bundler_cache_mount.go
+++ b/internal/rules/tally/ruby/prefer_bundler_cache_mount.go
@@ -1,0 +1,225 @@
+package ruby
+
+import (
+	"slices"
+	"strings"
+
+	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/runmount"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// PreferBundlerCacheMountRuleCode is the full rule code.
+const PreferBundlerCacheMountRuleCode = rules.TallyRulePrefix + "ruby/prefer-bundler-cache-mount"
+
+// preferBundlerCacheMountFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const preferBundlerCacheMountFixPriority = 88
+
+// PreferBundlerCacheMountRule flags `bundle install` invocations that don't
+// use a BuildKit cache mount on `${BUNDLE_PATH}/cache`. Native-extension
+// gems benefit most from the cache mount because they recompile from
+// source on every cache-busted build.
+type PreferBundlerCacheMountRule struct{}
+
+// NewPreferBundlerCacheMountRule creates the rule.
+func NewPreferBundlerCacheMountRule() *PreferBundlerCacheMountRule {
+	return &PreferBundlerCacheMountRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *PreferBundlerCacheMountRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            PreferBundlerCacheMountRuleCode,
+		Name:            "Prefer BuildKit cache mount for `bundle install`",
+		Description:     "`bundle install` doesn't use a BuildKit cache mount; native-extension gems will recompile on every cache-busted build",
+		DocURL:          rules.TallyDocURL(PreferBundlerCacheMountRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "performance",
+		FixPriority:     preferBundlerCacheMountFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *PreferBundlerCacheMountRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	// BuildKit cache mounts require the `# syntax=docker/dockerfile:1`
+	// pragma. Without it, `--mount=type=cache` would error at build
+	// time, so we don't recommend the rewrite.
+	if !hasBuildKitDockerfileSyntax(input) {
+		return nil
+	}
+
+	rubyFacts := input.Facts.RubyFacts()
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+		violations = append(violations, r.checkStage(input, sf, rubyFacts, meta)...)
+	}
+	return violations
+}
+
+func (r *PreferBundlerCacheMountRule) checkStage(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	rubyFacts *rubyfacts.RubyFacts,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	var violations []rules.Violation
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil || runFacts.Run == nil {
+			continue
+		}
+		install := findFirstBundleInstall(runFacts)
+		if install == nil {
+			continue
+		}
+		if runHasBundlerCacheMount(runFacts) {
+			continue
+		}
+
+		severity := meta.DefaultSeverity
+		if rubyFacts != nil && rubyFacts.Lockfile != nil &&
+			len(rubyFacts.Lockfile.NativeExtGems) > 0 {
+			severity = rules.SeverityWarning
+		}
+
+		loc := bundleInstallViolationLocation(input.File, runFacts, *install, input.SourceMap())
+		v := rules.NewViolation(loc, meta.Code, meta.Description, severity).
+			WithDocURL(meta.DocURL).
+			WithDetail(preferBundlerCacheMountDetail(rubyFacts))
+		// FixSuggestion that doesn't auto-edit: rewriting --mount=type=cache
+		// onto a multi-line RUN is too easy to get wrong (continuation
+		// lines, existing --mount flags, heredoc bodies). The user
+		// applies this manually.
+		v = v.WithSuggestedFix(&rules.SuggestedFix{
+			Description: "Add `--mount=type=cache,id=bundler,target=${BUNDLE_PATH}/cache,sharing=locked` to the bundle install RUN",
+			Safety:      rules.FixSuggestion,
+			Priority:    meta.FixPriority,
+			IsPreferred: false,
+		})
+		violations = append(violations, v)
+		// Report once per stage — multiple `bundle install` invocations
+		// in a single stage almost always benefit from the same cache
+		// mount, and the user only needs the recommendation once.
+		return violations
+	}
+	return violations
+}
+
+func preferBundlerCacheMountDetail(rubyFacts *rubyfacts.RubyFacts) string {
+	base := "BuildKit's `RUN --mount=type=cache,target=${BUNDLE_PATH}/cache` is the documented way to keep " +
+		"the gem-extraction cache across builds. Without it, every cache-busted `bundle install` " +
+		"re-fetches and (for native-extension gems) recompiles every gem from scratch — typically 30s+ on " +
+		"a non-trivial Rails project."
+	if rubyFacts != nil && rubyFacts.Lockfile != nil &&
+		len(rubyFacts.Lockfile.NativeExtGems) > 0 {
+		base += " This project resolves at least one native-extension gem (e.g. " +
+			rubyFacts.Lockfile.NativeExtGems[0] +
+			") whose recompile cost matters most."
+	}
+	return base
+}
+
+// runHasBundlerCacheMount reports whether the RUN has a
+// `--mount=type=cache,target=${BUNDLE_PATH}/cache` flag (or a literal
+// path equivalent).
+func runHasBundlerCacheMount(runFacts *facts.RunFacts) bool {
+	if runFacts == nil || runFacts.Run == nil {
+		return false
+	}
+	mounts := runmount.GetMounts(runFacts.Run)
+	for _, mount := range mounts {
+		if mount == nil || mount.Type != "cache" {
+			continue
+		}
+		if cacheTargetMatchesBundlerCache(mount.Target) {
+			return true
+		}
+	}
+	return false
+}
+
+// cacheTargetMatchesBundlerCache reports whether a cache-mount target
+// path looks like a Bundler cache directory.
+//
+// Recognized shapes:
+//
+//	${BUNDLE_PATH}/cache
+//	$BUNDLE_PATH/cache
+//	/usr/local/bundle/cache       (Rails generator default)
+//	/bundle/cache
+//	/bundle-cache                  (commonly used name)
+//	/cache                         (also seen)
+//
+// Other targets (e.g. /tmp) don't actually back Bundler's cache.
+func cacheTargetMatchesBundlerCache(target string) bool {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return false
+	}
+	// Variable-expanded forms.
+	if strings.Contains(target, "BUNDLE_PATH") && strings.HasSuffix(target, "/cache") {
+		return true
+	}
+	// Exact-path forms commonly seen in the corpus.
+	knownTargets := []string{
+		"/usr/local/bundle/cache",
+		"/bundle/cache",
+		"/bundle-cache",
+	}
+	if slices.Contains(knownTargets, target) {
+		return true
+	}
+	// `/cache` alone is too generic; require it to be the only target,
+	// which is unlikely to be a false positive — but keep this loose.
+	return target == "/cache"
+}
+
+// hasBuildKitDockerfileSyntax reports whether the Dockerfile's source
+// carries the `# syntax=docker/dockerfile:1` (or higher) pragma. Cache
+// mounts require BuildKit, which is enabled per-Dockerfile via this
+// pragma.
+func hasBuildKitDockerfileSyntax(input rules.LintInput) bool {
+	if input.AST == nil {
+		return false
+	}
+	// The pragma appears in the AST's directives.
+	src := string(input.Source)
+	for line := range strings.SplitSeq(src, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "#") {
+			// Stop at the first non-directive line.
+			break
+		}
+		// Accept any `syntax=` directive that mentions dockerfile/labs;
+		// we don't gate on a specific version because cache mounts
+		// have been stable since the dockerfile/1 frontend.
+		if strings.Contains(line, "syntax=") &&
+			(strings.Contains(line, "docker/dockerfile") || strings.Contains(line, "dockerfile/labs")) {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	rules.Register(NewPreferBundlerCacheMountRule())
+}

--- a/internal/rules/tally/ruby/prefer_bundler_cache_mount_test.go
+++ b/internal/rules/tally/ruby/prefer_bundler_cache_mount_test.go
@@ -1,0 +1,138 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestPreferBundlerCacheMountRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewPreferBundlerCacheMountRule().Metadata()
+	if meta.Code != PreferBundlerCacheMountRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, PreferBundlerCacheMountRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "performance" {
+		t.Errorf("Category = %q, want %q", meta.Category, "performance")
+	}
+}
+
+func TestPreferBundlerCacheMountRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewPreferBundlerCacheMountRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "bundle install without cache mount triggers (with syntax pragma)",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: cache mount on ${BUNDLE_PATH}/cache ---
+		{
+			Name: "bundle install with cache mount on BUNDLE_PATH suppresses",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --mount=type=cache,id=bundler,target=/usr/local/bundle/cache,sharing=locked \
+    bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bundle install with cache mount on /bundle/cache suppresses",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --mount=type=cache,target=/bundle/cache \
+    bundle install
+`,
+			WantViolations: 0,
+		},
+		// --- Suppressions ---
+		{
+			Name: "no syntax pragma → suppress (cache mounts unsupported)",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev stage skipped",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim AS dev
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Ruby stage skipped",
+			Content: `# syntax=docker/dockerfile:1
+FROM debian:bookworm-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestPreferBundlerCacheMountRule_FixSafety(t *testing.T) {
+	t.Parallel()
+
+	content := `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN bundle install
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewPreferBundlerCacheMountRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
+	}
+	// No-edit suggestion: rewriting --mount onto multi-line RUNs is too
+	// risky. The user applies the suggestion manually.
+	if len(v.SuggestedFix.Edits) != 0 {
+		t.Errorf("expected no edits (manual fix); got %d", len(v.SuggestedFix.Edits))
+	}
+	if !strings.Contains(v.SuggestedFix.Description, "cache") {
+		t.Errorf("description should mention cache mount; got: %q",
+			v.SuggestedFix.Description)
+	}
+}
+
+func TestCacheTargetMatchesBundlerCache(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{"/usr/local/bundle/cache", true},
+		{"/bundle/cache", true},
+		{"/bundle-cache", true},
+		{"/cache", true},
+		{"${BUNDLE_PATH}/cache", true},
+		{"$BUNDLE_PATH/cache", true},
+		{"/tmp", false},
+		{"/var/cache", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := cacheTargetMatchesBundlerCache(tt.target)
+		if got != tt.want {
+			t.Errorf("cacheTargetMatchesBundlerCache(%q) = %v, want %v", tt.target, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/prefer-bundler-cache-mount`](https://tally.wharflab.com/rules/tally/ruby/prefer-bundler-cache-mount/) — Section 4.2 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

BuildKit's `RUN --mount=type=cache,target=${BUNDLE_PATH}/cache` keeps the gem-extraction cache across builds. Without it, every cache-busted `bundle install` re-fetches and (for native-extension gems) recompiles every gem from scratch. The corpus shows only 7 of 196 Dockerfiles use cache mounts.

- **Suppressions:** Dockerfiles without `# syntax=docker/dockerfile:1` (cache mounts unsupported), dev/test/ci stages, non-Ruby stages.
- **Recognized cache-target paths:** `${BUNDLE_PATH}/cache`, `/usr/local/bundle/cache`, `/bundle/cache`, `/bundle-cache`, `/cache`.
- **Context-aware:** when `Gemfile.lock` lists at least one native-extension gem, severity escalates from `info` to `warning` — those gems' rebuild-from-scratch cost is exactly what the cache mount fixes.
- **Auto-fix:** `FixSuggestion` (no-edit). Rewriting `--mount` onto multi-line RUN chains is too risky to auto-apply; the user applies it manually.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint fixture: `internal/integration/fixtures/lint/ruby-prefer-bundler-cache-mount/`