### PR TITLE
feat(rules): add tally/ruby/yjit-not-enabled-on-supported-runtime

### DIFF
--- a/_docs/rules/tally/ruby/yjit-not-enabled-on-supported-runtime.mdx
+++ b/_docs/rules/tally/ruby/yjit-not-enabled-on-supported-runtime.mdx
@@ -1,0 +1,87 @@
+---
+title: "tally/ruby/yjit-not-enabled-on-supported-runtime"
+description: "Ruby 3.3+ runtime image doesn't enable YJIT, missing a near-free 15-30% CPU win."
+---
+
+The final Ruby 3.3+ runtime stage doesn't enable YJIT — Ruby's bundled JIT compiler.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info |
+| Category | Performance |
+| Default | Enabled |
+| Auto-fix | Yes (`FixSuggestion`) |
+
+## Description
+
+YJIT is Ruby's bundled JIT compiler. As of Ruby 3.3, it's production-ready and delivers a 15–30% CPU win on
+most Rails workloads at near-zero cost. But it's opt-in: you have to set `RUBY_YJIT_ENABLE=1`, pass `--yjit`
+to the Ruby/Rails binary, or include `--yjit` in `RUBYOPT`.
+
+The corpus shows only **3 of 196** Rails Dockerfiles enable YJIT. For projects on Ruby 3.3+ this is a
+near-free performance gain that's missing from almost every production deployment.
+
+This rule fires when:
+
+- The final stage's effective Ruby version is 3.3 or later (resolved from the base image tag, or from
+  `.ruby-version` / `.tool-versions` / `Gemfile.lock`'s `RUBY VERSION` block when the base is ARG-templated).
+- The stage looks like a long-running Ruby server (ENTRYPOINT/CMD references `rails`, `puma`, `unicorn`,
+  `thrust`, `rackup`, `sidekiq`, `falcon`, `thin`, `passenger`, or `iodine`).
+- None of these YJIT signals is present:
+  - `ENV RUBY_YJIT_ENABLE=...` (any truthy value).
+  - `ENV RUBYOPT="--yjit"` (or contains `--yjit`).
+  - ENTRYPOINT/CMD passes `--yjit` to the binary.
+
+### Suppressions
+
+The rule skips:
+
+- Ruby `< 3.3` — YJIT existed but was experimental and had Rails-specific regressions.
+- Non-final stages (only the production runtime image matters for YJIT).
+- CLI-only Ruby images (no rails/puma/sidekiq/etc. ENTRYPOINT) — JIT warmup dominates short-lived processes.
+- Stages explicitly named `dev`, `development`, `test`, `testing`, `ci`, or `debug`.
+- Non-Ruby and Windows stages.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY . .
+CMD ["bin/rails", "server"]
+```
+
+### After
+
+```dockerfile
+FROM ruby:3.3-slim
+ENV RUBY_YJIT_ENABLE="1"
+COPY . .
+CMD ["bin/rails", "server"]
+```
+
+Equivalent forms also satisfy the rule:
+
+```dockerfile
+ENV RUBYOPT="--yjit"
+```
+
+```dockerfile
+CMD ["bin/rails", "server", "--yjit"]
+```
+
+## Auto-fix
+
+`FixSuggestion`. Inserts `ENV RUBY_YJIT_ENABLE="1"` on the line immediately after the final stage's `FROM`.
+The fix is suggestion-level because performance changes — even good ones — are best applied with the user's
+explicit consent.
+
+## References
+
+- [Ruby 3.3 release notes](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) —
+  declares YJIT production-ready.
+- [YJIT documentation](https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md) — opt-in environment
+  variable and CLI flag.
+- [Mastodon Dockerfile](https://github.com/mastodon/mastodon/blob/main/Dockerfile) — production-grade
+  example that enables YJIT.

--- a/internal/integration/fixtures/fix/ruby-yjit-not-enabled/.tally.toml
+++ b/internal/integration/fixtures/fix/ruby-yjit-not-enabled/.tally.toml
@@ -1,0 +1,11 @@
+unsafe-fixes = true
+
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/yjit-not-enabled-on-supported-runtime"]
+exclude = ["*"]
+
+[output]
+fail-level = "none"

--- a/internal/integration/fixtures/fix/ruby-yjit-not-enabled/Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-yjit-not-enabled/Dockerfile
@@ -1,0 +1,3 @@
+FROM ruby:3.3-slim
+COPY . .
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-yjit-not-enabled/fixed_1.snap.Dockerfile
+++ b/internal/integration/fixtures/fix/ruby-yjit-not-enabled/fixed_1.snap.Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.3-slim
+ENV RUBY_YJIT_ENABLE="1"
+COPY . .
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/fix/ruby-yjit-not-enabled/report_1.snap.md
+++ b/internal/integration/fixtures/fix/ruby-yjit-not-enabled/report_1.snap.md
@@ -1,0 +1,2 @@
+Fixed 1 issues
+**No issues found**

--- a/internal/integration/fixtures/lint/ruby-yjit-not-enabled/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-yjit-not-enabled/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/yjit-not-enabled-on-supported-runtime"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-yjit-not-enabled/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-yjit-not-enabled/Dockerfile
@@ -1,0 +1,4 @@
+# Final stage on Ruby 3.3+ without YJIT — canonical violation.
+FROM ruby:3.3-slim
+COPY . .
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/lint/ruby-yjit-not-enabled/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-yjit-not-enabled/result_1.snap.json
@@ -1,0 +1,60 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-yjit-not-enabled/Dockerfile",
+      "violations": [
+        {
+          "detail": "YJIT is Ruby 3.3+'s production-ready JIT compiler. On most Rails workloads it delivers a 15–30% CPU win at near-zero cost — but it is opt-in. Enable it via `ENV RUBY_YJIT_ENABLE=\"1\"` or by passing `--yjit` to the server entrypoint. The corpus shows only 3 of 196 Rails Dockerfiles do this; for projects on Ruby 3.3+ this is a near-free performance gain.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/yjit-not-enabled-on-supported-runtime/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 2
+            },
+            "file": "fixtures/lint/ruby-yjit-not-enabled/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 2
+            }
+          },
+          "message": "Ruby 3.3+ runtime does not enable YJIT (RUBY_YJIT_ENABLE=1)",
+          "rule": "tally/ruby/yjit-not-enabled-on-supported-runtime",
+          "severity": "info",
+          "sourceCode": "FROM ruby:3.3-slim",
+          "suggestedFix": {
+            "description": "Add ENV RUBY_YJIT_ENABLE=\"1\" to enable YJIT on this Ruby 3.3+ runtime",
+            "edits": [
+              {
+                "location": {
+                  "end": {
+                    "column": 0,
+                    "line": 3
+                  },
+                  "file": "fixtures/lint/ruby-yjit-not-enabled/Dockerfile",
+                  "start": {
+                    "column": 0,
+                    "line": 3
+                  }
+                },
+                "newText": "ENV RUBY_YJIT_ENABLE=\"1\"\n"
+              }
+            ],
+            "isPreferred": true,
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/rules/tally/ruby/yjit_not_enabled.go
+++ b/internal/rules/tally/ruby/yjit_not_enabled.go
@@ -1,0 +1,285 @@
+package ruby
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/distribution/reference"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// rubyImageVersionRE extracts X.Y from a ruby:* image tag like
+// "3.3-slim", "3.0.6-bookworm", "2.7.0p100-alpine3.18".
+var rubyImageVersionRE = regexp.MustCompile(`^(\d+)\.(\d+)`)
+
+// longRunningRubyServerCommands is the set of ENTRYPOINT/CMD basenames
+// that mark a stage as a long-running Ruby server (web app or worker).
+// YJIT delivers its 15-30% speedup on these workloads.
+var longRunningRubyServerCommands = map[string]bool{
+	"rails":     true,
+	"puma":      true,
+	"unicorn":   true,
+	"thrust":    true,
+	"rackup":    true,
+	"sidekiq":   true,
+	"falcon":    true,
+	"thin":      true,
+	"passenger": true,
+	"iodine":    true,
+}
+
+// YJITNotEnabledOnSupportedRuntimeRuleCode is the full rule code.
+const YJITNotEnabledOnSupportedRuntimeRuleCode = rules.TallyRulePrefix + "ruby/yjit-not-enabled-on-supported-runtime"
+
+// yjitNotEnabledFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const yjitNotEnabledFixPriority = 88
+
+// minYJITSupportedMajor and minYJITSupportedMinor define the minimum Ruby
+// branch where YJIT is production-ready (3.3 per upstream release notes).
+// Earlier branches (3.0/3.1) had YJIT but it was experimental and had
+// Rails-specific regressions, so the rule should not fire there.
+const (
+	minYJITSupportedMajor = 3
+	minYJITSupportedMinor = 3
+)
+
+// YJITNotEnabledOnSupportedRuntimeRule flags final Ruby/Rails runtime
+// stages on Ruby 3.3+ that don't enable YJIT — a near-free 15-30% CPU
+// win on most Rails workloads.
+type YJITNotEnabledOnSupportedRuntimeRule struct{}
+
+// NewYJITNotEnabledOnSupportedRuntimeRule creates the rule.
+func NewYJITNotEnabledOnSupportedRuntimeRule() *YJITNotEnabledOnSupportedRuntimeRule {
+	return &YJITNotEnabledOnSupportedRuntimeRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *YJITNotEnabledOnSupportedRuntimeRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            YJITNotEnabledOnSupportedRuntimeRuleCode,
+		Name:            "Enable YJIT on Ruby 3.3+ runtime",
+		Description:     "Ruby 3.3+ runtime does not enable YJIT (RUBY_YJIT_ENABLE=1)",
+		DocURL:          rules.TallyDocURL(YJITNotEnabledOnSupportedRuntimeRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "performance",
+		FixPriority:     yjitNotEnabledFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *YJITNotEnabledOnSupportedRuntimeRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+	rubyFacts := input.Facts.RubyFacts()
+
+	finalIdx := input.FinalStageIndex()
+	if finalIdx < 0 || finalIdx >= len(input.Stages) {
+		return nil
+	}
+
+	stage := input.Stages[finalIdx]
+	sf := input.Facts.Stage(finalIdx)
+	if sf == nil {
+		return nil
+	}
+	if sf.BaseImageOS == semantic.BaseImageOSWindows {
+		return nil
+	}
+	if stagename.LooksLikeDev(stage.Name) {
+		return nil
+	}
+	if !stageLooksLikeRuby(input.Semantic, finalIdx, stage, sf) {
+		return nil
+	}
+	if !stageLooksLikeLongRunningRubyServer(stage, sf) {
+		// CLI-only Ruby images don't benefit from YJIT — JIT warmup
+		// dominates short-lived processes.
+		return nil
+	}
+	if !rubyVersionSupportsYJIT(input, finalIdx, rubyFacts) {
+		return nil
+	}
+	if stageEnablesYJIT(sf, stage) {
+		return nil
+	}
+
+	loc := finalStageFromLocation(input, finalIdx)
+	v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+		WithDocURL(meta.DocURL).
+		WithDetail(yjitNotEnabledDetail()).
+		WithSuggestedFix(buildYJITFix(input, finalIdx, meta.FixPriority))
+	return []rules.Violation{v}
+}
+
+func yjitNotEnabledDetail() string {
+	return "YJIT is Ruby 3.3+'s production-ready JIT compiler. On most Rails workloads it delivers a " +
+		"15–30% CPU win at near-zero cost — but it is opt-in. Enable it via `ENV RUBY_YJIT_ENABLE=\"1\"` " +
+		"or by passing `--yjit` to the server entrypoint. The corpus shows only 3 of 196 Rails " +
+		"Dockerfiles do this; for projects on Ruby 3.3+ this is a near-free performance gain."
+}
+
+// rubyVersionSupportsYJIT reports whether the Ruby version associated
+// with the stage is 3.3 or later. Resolves via:
+//
+//  1. Stage's external base image tag (`ruby:3.3-slim` etc.).
+//  2. RubyFacts.RubyVersion (.ruby-version / .tool-versions / lockfile).
+//
+// Returns false for unparsable versions, ARG-templated FROMs without a
+// resolvable version, or branches < 3.3.
+func rubyVersionSupportsYJIT(input rules.LintInput, stageIdx int, rubyFacts *rubyfacts.RubyFacts) bool {
+	// Try the stage's base image first.
+	if base := input.Semantic.ExternalBase(stageIdx); base != nil {
+		raw := base.Effective
+		if raw == "" {
+			raw = base.Raw
+		}
+		if branch := extractRubyBranchFromImageRef(raw); branch != "" {
+			if major, minor, ok := parseMajorMinor(branch); ok {
+				return majorMinorAtLeast(major, minor, minYJITSupportedMajor, minYJITSupportedMinor)
+			}
+		}
+	}
+	// Fall back to RubyFacts.RubyVersion (e.g. "3.3.5" or "3.3.5p100").
+	if rubyFacts != nil && rubyFacts.RubyVersion != "" {
+		if major, minor, ok := parseMajorMinor(rubyFacts.RubyVersion); ok {
+			return majorMinorAtLeast(major, minor, minYJITSupportedMajor, minYJITSupportedMinor)
+		}
+	}
+	return false
+}
+
+// stageEnablesYJIT reports whether the stage's effective state already
+// enables YJIT. Recognized signals:
+//
+//  1. ENV RUBY_YJIT_ENABLE=1 (any truthy value).
+//  2. ENV RUBYOPT contains --yjit.
+//  3. ENTRYPOINT/CMD passes --yjit to the Ruby/Rails binary.
+//  4. ENTRYPOINT/CMD sets RUBYOPT inline before invoking Ruby.
+func stageEnablesYJIT(sf *facts.StageFacts, stage instructions.Stage) bool {
+	if envBoundValue(sf, "RUBY_YJIT_ENABLE") != "" {
+		return true
+	}
+	if rubyopt := envBoundValue(sf, "RUBYOPT"); strings.Contains(rubyopt, "--yjit") {
+		return true
+	}
+	for _, cmd := range stage.Commands {
+		switch c := cmd.(type) {
+		case *instructions.EntrypointCommand:
+			if cmdLineHasYJIT(c.CmdLine) {
+				return true
+			}
+		case *instructions.CmdCommand:
+			if cmdLineHasYJIT(c.CmdLine) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func cmdLineHasYJIT(cmdLine []string) bool {
+	for _, a := range cmdLine {
+		if strings.Contains(a, "--yjit") {
+			return true
+		}
+		if strings.Contains(a, "RUBY_YJIT_ENABLE") {
+			return true
+		}
+	}
+	return false
+}
+
+// stageLooksLikeLongRunningRubyServer reports whether the stage has the
+// shape of a long-running Ruby server (web app or worker process), which
+// is where YJIT delivers its 15-30% speedup. Short-lived CLI images are
+// out of scope — JIT warmup dominates.
+func stageLooksLikeLongRunningRubyServer(stage instructions.Stage, sf *facts.StageFacts) bool {
+	for _, name := range stageRuntimeCommandBasenames(stage) {
+		if longRunningRubyServerCommands[name] {
+			return true
+		}
+	}
+	// sf reserved for future EXPOSE/HEALTHCHECK heuristics.
+	_ = sf
+	return false
+}
+
+// finalStageFromLocation returns the source location of the final stage's
+// FROM line.
+func finalStageFromLocation(input rules.LintInput, stageIdx int) rules.Location {
+	if stageIdx < 0 || stageIdx >= len(input.Stages) {
+		return rules.NewFileLocation(input.File)
+	}
+	stage := input.Stages[stageIdx]
+	if len(stage.Location) == 0 {
+		return rules.NewFileLocation(input.File)
+	}
+	return rules.NewLocationFromRanges(input.File, stage.Location)
+}
+
+// extractRubyBranchFromImageRef parses a ruby:* image reference and
+// returns the X.Y branch from its tag. Returns "" for non-Ruby images
+// or unparsable tags.
+func extractRubyBranchFromImageRef(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	named, err := reference.ParseNormalizedNamed(strings.ToLower(raw))
+	if err != nil {
+		return ""
+	}
+	if reference.FamiliarName(named) != "ruby" {
+		return ""
+	}
+	tagged, ok := named.(reference.Tagged)
+	if !ok {
+		return ""
+	}
+	m := rubyImageVersionRE.FindStringSubmatch(tagged.Tag())
+	if m == nil {
+		return ""
+	}
+	return m[1] + "." + m[2]
+}
+
+func majorMinorAtLeast(haveMajor, haveMinor, wantMajor, wantMinor int) bool {
+	if haveMajor != wantMajor {
+		return haveMajor > wantMajor
+	}
+	return haveMinor >= wantMinor
+}
+
+// buildYJITFix proposes inserting `ENV RUBY_YJIT_ENABLE="1"` at the top
+// of the final stage. Insertion is zero-width at column 0 of the line
+// after the stage's `FROM`.
+func buildYJITFix(input rules.LintInput, stageIdx, priority int) *rules.SuggestedFix {
+	if stageIdx < 0 || stageIdx >= len(input.Stages) {
+		return nil
+	}
+	stage := input.Stages[stageIdx]
+	if len(stage.Location) == 0 {
+		return nil
+	}
+	insertLine := stage.Location[len(stage.Location)-1].End.Line + 1
+	return &rules.SuggestedFix{
+		Description: `Add ENV RUBY_YJIT_ENABLE="1" to enable YJIT on this Ruby 3.3+ runtime`,
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: true,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
+			NewText:  "ENV RUBY_YJIT_ENABLE=\"1\"\n",
+		}},
+	}
+}
+
+func init() {
+	rules.Register(NewYJITNotEnabledOnSupportedRuntimeRule())
+}

--- a/internal/rules/tally/ruby/yjit_not_enabled.go
+++ b/internal/rules/tally/ruby/yjit_not_enabled.go
@@ -19,6 +19,12 @@ import (
 // "3.3-slim", "3.0.6-bookworm", "2.7.0p100-alpine3.18".
 var rubyImageVersionRE = regexp.MustCompile(`^(\d+)\.(\d+)`)
 
+// officialRubyImageFamiliarName is the familiar name returned by
+// `reference.FamiliarName` for the official `ruby:*` image. Pulled into
+// a named constant to avoid the string literal living next to other
+// `"ruby"` mentions in this file.
+const officialRubyImageFamiliarName = "ruby"
+
 // longRunningRubyServerCommands is the set of ENTRYPOINT/CMD basenames
 // that mark a stage as a long-running Ruby server (web app or worker).
 // YJIT delivers its 15-30% speedup on these workloads.
@@ -163,7 +169,7 @@ func rubyVersionSupportsYJIT(input rules.LintInput, stageIdx int, rubyFacts *rub
 //  3. ENTRYPOINT/CMD passes --yjit to the Ruby/Rails binary.
 //  4. ENTRYPOINT/CMD sets RUBYOPT inline before invoking Ruby.
 func stageEnablesYJIT(sf *facts.StageFacts, stage instructions.Stage) bool {
-	if envBoundValue(sf, "RUBY_YJIT_ENABLE") != "" {
+	if isYJITEnableTruthy(envBoundValue(sf, "RUBY_YJIT_ENABLE")) {
 		return true
 	}
 	if rubyopt := envBoundValue(sf, "RUBYOPT"); strings.Contains(rubyopt, "--yjit") {
@@ -184,14 +190,69 @@ func stageEnablesYJIT(sf *facts.StageFacts, stage instructions.Stage) bool {
 	return false
 }
 
+// isYJITEnableTruthy reports whether a RUBY_YJIT_ENABLE value would
+// actually turn YJIT on at Ruby startup. Ruby's YJIT init checks the
+// env var via `getenv` and treats only the documented truthy values
+// (case-insensitive) as enabling the JIT — anything else (including
+// `0`, `false`, `no`, empty, missing) leaves YJIT off.
+func isYJITEnableTruthy(value string) bool {
+	v := strings.ToLower(strings.TrimSpace(strings.Trim(value, `"'`)))
+	switch v {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// cmdLineHasYJIT reports whether an ENTRYPOINT/CMD argv-like sequence
+// enables YJIT. Recognized shapes:
+//
+//	["ruby", "--yjit", ...]                    (any token == --yjit or contains --yjit=...)
+//	["sh", "-c", "RUBY_YJIT_ENABLE=1 bin/rails server"]   (truthy inline assignment)
+//	["sh", "-c", "RUBY_YJIT_ENABLE=true bundle exec puma"]
+//
+// `RUBY_YJIT_ENABLE=0` (or any falsey value) is correctly NOT treated
+// as enabling YJIT.
 func cmdLineHasYJIT(cmdLine []string) bool {
 	for _, a := range cmdLine {
 		if strings.Contains(a, "--yjit") {
 			return true
 		}
-		if strings.Contains(a, "RUBY_YJIT_ENABLE") {
+		if cmdTokenSetsYJITTruthy(a) {
 			return true
 		}
+	}
+	return false
+}
+
+// cmdTokenSetsYJITTruthy reports whether a single argv token contains
+// a `RUBY_YJIT_ENABLE=<truthy>` assignment. The token may be a plain
+// `RUBY_YJIT_ENABLE=1` env-prefix or embedded inside a longer shell
+// string passed to `sh -c`.
+func cmdTokenSetsYJITTruthy(token string) bool {
+	idx := 0
+	for idx < len(token) {
+		next := strings.Index(token[idx:], "RUBY_YJIT_ENABLE=")
+		if next < 0 {
+			return false
+		}
+		valStart := idx + next + len("RUBY_YJIT_ENABLE=")
+		valEnd := valStart
+		for valEnd < len(token) && !isShellTokenBoundary(token[valEnd]) {
+			valEnd++
+		}
+		if isYJITEnableTruthy(token[valStart:valEnd]) {
+			return true
+		}
+		idx = valEnd
+	}
+	return false
+}
+
+func isShellTokenBoundary(c byte) bool {
+	switch c {
+	case ' ', '\t', '\n', ';', '&', '|':
+		return true
 	}
 	return false
 }
@@ -200,14 +261,52 @@ func cmdLineHasYJIT(cmdLine []string) bool {
 // shape of a long-running Ruby server (web app or worker process), which
 // is where YJIT delivers its 15-30% speedup. Short-lived CLI images are
 // out of scope — JIT warmup dominates.
+//
+// Recognized argv shapes (we walk the full ENTRYPOINT/CMD argv, not just
+// the first token, because `bundle exec puma` is the canonical Rails
+// production form and the first token there is `bundle`):
+//
+//	["puma"]                          → puma
+//	["bin/rails", "server"]           → rails
+//	["bundle", "exec", "puma"]        → puma (via wrapper)
+//	["bundle", "exec", "rails", ...]  → rails
+//	["sh", "-c", "exec puma"]         → puma (best-effort scan of the script body)
 func stageLooksLikeLongRunningRubyServer(stage instructions.Stage, sf *facts.StageFacts) bool {
-	for _, name := range stageRuntimeCommandBasenames(stage) {
-		if longRunningRubyServerCommands[name] {
-			return true
+	var lastEntrypoint *instructions.EntrypointCommand
+	var lastCmd *instructions.CmdCommand
+	for _, c := range stage.Commands {
+		switch cc := c.(type) {
+		case *instructions.EntrypointCommand:
+			lastEntrypoint = cc
+		case *instructions.CmdCommand:
+			lastCmd = cc
 		}
+	}
+	if lastEntrypoint != nil && argvIncludesRubyServer(lastEntrypoint.CmdLine) {
+		return true
+	}
+	if lastCmd != nil && argvIncludesRubyServer(lastCmd.CmdLine) {
+		return true
 	}
 	// sf reserved for future EXPOSE/HEALTHCHECK heuristics.
 	_ = sf
+	return false
+}
+
+// argvIncludesRubyServer reports whether any argv token's basename
+// matches a long-running Ruby server name. Token splitting handles both
+// list-form ENTRYPOINT/CMD (each arg is a separate token) and
+// string-form (a single token containing `puma --bind ...` etc.).
+func argvIncludesRubyServer(argv []string) bool {
+	for _, token := range argv {
+		// Split on whitespace so string-form CMD/ENTRYPOINT (e.g.
+		// `CMD bundle exec puma`) is handled the same as list-form.
+		for word := range strings.FieldsSeq(token) {
+			if longRunningRubyServerCommands[strings.ToLower(commandBasename(word))] {
+				return true
+			}
+		}
+	}
 	return false
 }
 
@@ -235,7 +334,7 @@ func extractRubyBranchFromImageRef(raw string) string {
 	if err != nil {
 		return ""
 	}
-	if reference.FamiliarName(named) != "ruby" {
+	if reference.FamiliarName(named) != officialRubyImageFamiliarName {
 		return ""
 	}
 	tagged, ok := named.(reference.Tagged)

--- a/internal/rules/tally/ruby/yjit_not_enabled_test.go
+++ b/internal/rules/tally/ruby/yjit_not_enabled_test.go
@@ -1,0 +1,138 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestYJITNotEnabledOnSupportedRuntimeRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewYJITNotEnabledOnSupportedRuntimeRule().Metadata()
+	if meta.Code != YJITNotEnabledOnSupportedRuntimeRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, YJITNotEnabledOnSupportedRuntimeRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "performance" {
+		t.Errorf("Category = %q, want %q", meta.Category, "performance")
+	}
+}
+
+func TestYJITNotEnabledOnSupportedRuntimeRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewYJITNotEnabledOnSupportedRuntimeRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "ruby:3.3-slim runtime without YJIT triggers",
+			Content: `FROM ruby:3.3-slim
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ruby:3.4 runtime without YJIT triggers",
+			Content: `FROM ruby:3.4
+CMD ["puma"]
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: ENV RUBY_YJIT_ENABLE=1 ---
+		{
+			Name: "ENV RUBY_YJIT_ENABLE=1 suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV RUBY_YJIT_ENABLE="1"
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: RUBYOPT contains --yjit ---
+		{
+			Name: "ENV RUBYOPT containing --yjit suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV RUBYOPT="--yjit"
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: --yjit on the entrypoint ---
+		{
+			Name: "CMD passing --yjit to bin/rails suppresses",
+			Content: `FROM ruby:3.3-slim
+CMD ["bin/rails", "server", "--yjit"]
+`,
+			WantViolations: 0,
+		},
+		// --- Suppressions ---
+		{
+			Name: "ruby:3.2 (pre-3.3) does NOT trigger (YJIT was experimental)",
+			Content: `FROM ruby:3.2-slim
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "ruby:3.0 does NOT trigger",
+			Content: `FROM ruby:3.0-slim
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Ruby runtime does NOT trigger",
+			Content: `FROM debian:bookworm-slim
+CMD ["bash"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "Ruby CLI image (no rails/puma/etc.) does NOT trigger",
+			Content: `FROM ruby:3.3-slim
+ENTRYPOINT ["mygem"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev stage skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		// --- Multi-stage: only final stage matters ---
+		{
+			Name: "non-final ruby:3.3 stage does NOT trigger (rule scopes to final)",
+			Content: `FROM ruby:3.3-slim AS builder
+CMD ["bin/rails", "server"]
+
+FROM ruby:3.2-slim
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestYJITNotEnabledOnSupportedRuntimeRule_FixSafety(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM ruby:3.3-slim
+CMD ["bin/rails", "server"]
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewYJITNotEnabledOnSupportedRuntimeRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if v.SuggestedFix.Safety != rules.FixSuggestion {
+		t.Errorf("Safety = %v, want FixSuggestion", v.SuggestedFix.Safety)
+	}
+}

--- a/internal/rules/tally/ruby/yjit_not_enabled_test.go
+++ b/internal/rules/tally/ruby/yjit_not_enabled_test.go
@@ -114,6 +114,61 @@ CMD ["bin/rails", "server"]
 `,
 			WantViolations: 0,
 		},
+		// --- Regression: bundle exec X recognized as long-running ---
+		{
+			Name: `CMD bundle exec puma triggers (bundle exec server is long-running)`,
+			Content: `FROM ruby:3.3-slim
+CMD ["bundle", "exec", "puma"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: `ENTRYPOINT bundle exec rails server triggers`,
+			Content: `FROM ruby:3.3-slim
+ENTRYPOINT ["bundle", "exec", "rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		// --- Regression: ENTRYPOINT with --yjit suppresses ---
+		{
+			Name: `ENTRYPOINT bundle exec puma --yjit suppresses`,
+			Content: `FROM ruby:3.3-slim
+ENTRYPOINT ["bundle", "exec", "puma", "--yjit"]
+`,
+			WantViolations: 0,
+		},
+		// --- Regression: falsy RUBY_YJIT_ENABLE values still trigger ---
+		{
+			Name: `ENV RUBY_YJIT_ENABLE=0 still triggers (falsy value doesn't enable YJIT)`,
+			Content: `FROM ruby:3.3-slim
+ENV RUBY_YJIT_ENABLE="0"
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: `ENV RUBY_YJIT_ENABLE=false still triggers`,
+			Content: `FROM ruby:3.3-slim
+ENV RUBY_YJIT_ENABLE="false"
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		// --- Regression: shell-form CMD/ENTRYPOINT scan ---
+		{
+			Name: `CMD sh -c RUBY_YJIT_ENABLE=0 bin/rails server triggers (falsy inline)`,
+			Content: `FROM ruby:3.3-slim
+CMD ["sh", "-c", "RUBY_YJIT_ENABLE=0 bin/rails server"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: `CMD sh -c RUBY_YJIT_ENABLE=1 bin/rails server suppresses (truthy inline)`,
+			Content: `FROM ruby:3.3-slim
+CMD ["sh", "-c", "RUBY_YJIT_ENABLE=1 bin/rails server"]
+`,
+			WantViolations: 0,
+		},
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/yjit-not-enabled-on-supported-runtime`](https://tally.wharflab.com/rules/tally/ruby/yjit-not-enabled-on-supported-runtime/) — Section 4.3 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

YJIT is Ruby 3.3+'s production-ready JIT compiler. On most Rails workloads it delivers a 15-30% CPU win at near-zero cost — but it's opt-in. The corpus shows only 3 of 196 Rails Dockerfiles enable it.

- **Recognized YJIT signals:** `ENV RUBY_YJIT_ENABLE=<truthy>`, `ENV RUBYOPT` containing `--yjit`, ENTRYPOINT/CMD passing `--yjit`.
- **Suppressions:** Ruby `< 3.3` (was experimental), non-final stages, CLI-only Ruby images (no rails/puma/sidekiq/etc.), dev/test/ci stages.
- **Context-aware:** when the FROM is ARG-templated, fall back to `RubyFacts.RubyVersion` (`.ruby-version` / `.tool-versions` / `Gemfile.lock` `RUBY VERSION` block).
- **Auto-fix:** `FixSuggestion`. Inserts `ENV RUBY_YJIT_ENABLE="1"` after the final stage's `FROM`.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint and fix fixtures: `internal/integration/fixtures/{lint,fix}/ruby-yjit-not-enabled/`