### PR TITLE
feat(rules): add tally/ruby/secrets-in-arg-or-env

### DIFF
--- a/_docs/rules/tally/ruby/secrets-in-arg-or-env.mdx
+++ b/_docs/rules/tally/ruby/secrets-in-arg-or-env.mdx
@@ -1,0 +1,103 @@
+---
+title: "tally/ruby/secrets-in-arg-or-env"
+description: "Rails secret declared via ARG/ENV bakes the secret into image history."
+---
+
+A Rails secret name (`SECRET_KEY_BASE`, `RAILS_MASTER_KEY`, `DEVISE_SECRET_KEY`, etc.) is declared via `ARG`
+or `ENV` with a non-placeholder value, baking the secret into image history.
+
+| Property | Value |
+|----------|-------|
+| Severity | Error |
+| Category | Security |
+| Default | Enabled |
+| Auto-fix | No edit (suggestion only) |
+
+## Description
+
+Rails secrets declared via `ARG` or `ENV` end up in image history. `docker history --no-trunc <image>` and any
+registry that proxies image manifests will leak them. Anyone who can pull the image can recover the secret.
+
+This rule fires on the following env-var names — the Rails core canonical secrets plus Devise's:
+
+- `SECRET_KEY_BASE`
+- `RAILS_MASTER_KEY`
+- `SECRET_TOKEN` (legacy Rails 4.x)
+- `DEVISE_SECRET_KEY`
+- `DEVISE_PEPPER`
+- `RAILS_KEY` (alternate alias seen in some apps)
+
+The rule fires for both `ARG` and `ENV`, including:
+
+- `ENV SECRET_KEY_BASE="abc123"` — value baked into image layer history.
+- `ARG SECRET_KEY_BASE=value` — value baked into both layer history (when consumed via `RUN`) and the build
+  cache key data.
+- `ARG SECRET_KEY_BASE` (no default) — still flagged. The user is meant to pass `--build-arg SECRET_KEY_BASE=...`,
+  which adds the secret to build cache key data and (when consumed via `RUN`/`ENV`) leaks it into image
+  history.
+- Meta-`ARG` (before any `FROM`).
+
+### Compliance
+
+The rule treats `=1`, `="1"`, `="dummy"`, and `="SECRET_KEY_BASE_DUMMY"` (case-insensitive) as compliant
+placeholder values — these match Rails 7.1+'s build-time placeholder contract for asset compilation.
+`SECRET_KEY_BASE_DUMMY=1` is the supported way to run `bin/rails assets:precompile` without a real key.
+
+Stages explicitly named `dev`/`development`/`test`/`testing`/`ci`/`debug` are skipped.
+
+### Recommended replacement
+
+Use BuildKit's secret-mount syntax: secrets exist for the duration of one `RUN`, never appear in image
+content, and are not part of the cache key.
+
+```dockerfile
+RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY \
+    bundle exec rails db:schema:load
+```
+
+For asset compilation specifically, `SECRET_KEY_BASE_DUMMY=1` (Rails 7.1+) avoids needing the real key at
+build time entirely:
+
+```dockerfile
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+```
+
+This is also caught by [`tally/ruby/asset-precompile-without-dummy-key`](/rules/tally/ruby/asset-precompile-without-dummy-key/),
+which is the structural fix for build-time `SECRET_KEY_BASE`.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+ARG RAILS_MASTER_KEY
+ENV RAILS_MASTER_KEY=$RAILS_MASTER_KEY
+RUN bundle exec rails db:schema:load
+```
+
+### After
+
+```dockerfile
+FROM ruby:3.3-slim
+RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY \
+    bundle exec rails db:schema:load
+```
+
+Pass the secret at build time with:
+
+```bash
+docker buildx build --secret id=rails_master_key,src=$HOME/.ssh/rails_master_key .
+```
+
+## Auto-fix
+
+The rule emits a no-edit `FixUnsafe` suggestion: the description points the user at the BuildKit secret-mount
+pattern. The actual rewrite depends on the user's CI / vault / secret-injection setup, so the rule cannot
+auto-rewrite.
+
+## References
+
+- [Rails security guide — environmental security](https://guides.rubyonrails.org/security.html#environmental-security).
+- [BuildKit `RUN --mount=type=secret` documentation](https://docs.docker.com/build/building/secrets/).
+- [Rails 7.1 release notes — `SECRET_KEY_BASE_DUMMY`](https://guides.rubyonrails.org/7_1_release_notes.html#assets-precompile-no-longer-requires-credentials).

--- a/internal/integration/fixtures/lint/ruby-secrets-in-arg-or-env/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-secrets-in-arg-or-env/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/secrets-in-arg-or-env"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-secrets-in-arg-or-env/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-secrets-in-arg-or-env/Dockerfile
@@ -1,0 +1,23 @@
+# Meta-ARG with literal RAILS_MASTER_KEY: violation.
+ARG RAILS_MASTER_KEY=abc123def
+
+# Stage with ENV SECRET_KEY_BASE: violation.
+FROM ruby:3.3-slim AS app-with-secrets
+ENV SECRET_KEY_BASE="literal-secret-here"
+ENV DEVISE_SECRET_KEY="some-pepper"
+RUN echo "this leaks the keys to image history"
+
+# Compliant: SECRET_KEY_BASE=1 is the Rails-accepted placeholder.
+FROM ruby:3.3-slim AS app-placeholder
+ENV SECRET_KEY_BASE=1
+RUN bin/rails assets:precompile
+
+# Compliant: SECRET_KEY_BASE_DUMMY=1 (the canonical Rails 7.1+ build-time form).
+FROM ruby:3.3-slim AS app-dummy
+ENV SECRET_KEY_BASE_DUMMY=1
+RUN bin/rails assets:precompile
+
+# Compliant via BuildKit secret mount: secret never enters image history.
+FROM ruby:3.3-slim AS app-secret-mount
+RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY \
+    bundle exec rails db:schema:load

--- a/internal/integration/fixtures/lint/ruby-secrets-in-arg-or-env/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-secrets-in-arg-or-env/result_1.snap.json
@@ -1,0 +1,91 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-secrets-in-arg-or-env/Dockerfile",
+      "violations": [
+        {
+          "detail": "Setting `RAILS_MASTER_KEY` via ARG bakes the value into the image's per-layer history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Anyone who can pull the image can recover the secret. Use BuildKit secret mounts (`RUN --mount=type=secret,id=rails_master_key,env=RAILS_MASTER_KEY`) for build-time access; for asset compilation specifically, use `SECRET_KEY_BASE_DUMMY=1` so the build doesn't need the real key at all (Rails 7.1+).",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/secrets-in-arg-or-env/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 2
+            },
+            "file": "fixtures/lint/ruby-secrets-in-arg-or-env/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 2
+            }
+          },
+          "message": "Rails secret declared via ARG/ENV bakes the secret into image history",
+          "rule": "tally/ruby/secrets-in-arg-or-env",
+          "severity": "error",
+          "sourceCode": "ARG RAILS_MASTER_KEY=abc123def",
+          "suggestedFix": {
+            "description": "Pass the secret via `RUN --mount=type=secret,id=...,env=...` instead of ARG/ENV. For asset compilation use SECRET_KEY_BASE_DUMMY=1 (Rails 7.1+) to avoid needing the real key at build time entirely.",
+            "priority": 88,
+            "safety": 2
+          }
+        },
+        {
+          "detail": "Setting `SECRET_KEY_BASE` via ENV bakes the value into the image's per-layer history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Anyone who can pull the image can recover the secret. Use BuildKit secret mounts (`RUN --mount=type=secret,id=secret_key_base,env=SECRET_KEY_BASE`) for build-time access; for asset compilation specifically, use `SECRET_KEY_BASE_DUMMY=1` so the build doesn't need the real key at all (Rails 7.1+).",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/secrets-in-arg-or-env/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 6
+            },
+            "file": "fixtures/lint/ruby-secrets-in-arg-or-env/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 6
+            }
+          },
+          "message": "Rails secret declared via ARG/ENV bakes the secret into image history",
+          "rule": "tally/ruby/secrets-in-arg-or-env",
+          "severity": "error",
+          "sourceCode": "ENV SECRET_KEY_BASE=\"literal-secret-here\"",
+          "suggestedFix": {
+            "description": "Pass the secret via `RUN --mount=type=secret,id=...,env=...` instead of ARG/ENV. For asset compilation use SECRET_KEY_BASE_DUMMY=1 (Rails 7.1+) to avoid needing the real key at build time entirely.",
+            "priority": 88,
+            "safety": 2
+          }
+        },
+        {
+          "detail": "Setting `DEVISE_SECRET_KEY` via ENV bakes the value into the image's per-layer history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Anyone who can pull the image can recover the secret. Use BuildKit secret mounts (`RUN --mount=type=secret,id=devise_secret_key,env=DEVISE_SECRET_KEY`) for build-time access; for asset compilation specifically, use `SECRET_KEY_BASE_DUMMY=1` so the build doesn't need the real key at all (Rails 7.1+).",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/secrets-in-arg-or-env/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 7
+            },
+            "file": "fixtures/lint/ruby-secrets-in-arg-or-env/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 7
+            }
+          },
+          "message": "Rails secret declared via ARG/ENV bakes the secret into image history",
+          "rule": "tally/ruby/secrets-in-arg-or-env",
+          "severity": "error",
+          "sourceCode": "ENV DEVISE_SECRET_KEY=\"some-pepper\"",
+          "suggestedFix": {
+            "description": "Pass the secret via `RUN --mount=type=secret,id=...,env=...` instead of ARG/ENV. For asset compilation use SECRET_KEY_BASE_DUMMY=1 (Rails 7.1+) to avoid needing the real key at build time entirely.",
+            "priority": 88,
+            "safety": 2
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 3,
+    "files": 1,
+    "info": 0,
+    "style": 0,
+    "total": 3,
+    "warnings": 0
+  }
+}

--- a/internal/rules/tally/ruby/secrets_in_arg_or_env.go
+++ b/internal/rules/tally/ruby/secrets_in_arg_or_env.go
@@ -1,0 +1,209 @@
+package ruby
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/command"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// SecretsInArgOrEnvRuleCode is the full rule code.
+const SecretsInArgOrEnvRuleCode = rules.TallyRulePrefix + "ruby/secrets-in-arg-or-env"
+
+// secretsInArgOrEnvFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const secretsInArgOrEnvFixPriority = 88
+
+// railsSecretEnvKeys are the env-var names known to carry Rails-app secrets.
+// Setting them via ARG/ENV at build time bakes the secret into image
+// history (visible via `docker history --no-trunc`).
+var railsSecretEnvKeys = map[string]bool{
+	"SECRET_KEY_BASE":   true,
+	"RAILS_MASTER_KEY":  true,
+	"SECRET_TOKEN":      true, // legacy Rails 4.x
+	"DEVISE_SECRET_KEY": true,
+	"DEVISE_PEPPER":     true,
+	"RAILS_KEY":         true, // some apps use this name as an alias
+}
+
+// SecretsInArgOrEnvRule flags ARG/ENV instructions that declare known
+// Rails-app secret env vars with non-placeholder values.
+type SecretsInArgOrEnvRule struct{}
+
+// NewSecretsInArgOrEnvRule creates the rule.
+func NewSecretsInArgOrEnvRule() *SecretsInArgOrEnvRule {
+	return &SecretsInArgOrEnvRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *SecretsInArgOrEnvRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            SecretsInArgOrEnvRuleCode,
+		Name:            "Rails secrets must not be passed via ARG or ENV",
+		Description:     "Rails secret declared via ARG/ENV bakes the secret into image history",
+		DocURL:          rules.TallyDocURL(SecretsInArgOrEnvRuleCode),
+		DefaultSeverity: rules.SeverityError,
+		Category:        "security",
+		FixPriority:     secretsInArgOrEnvFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *SecretsInArgOrEnvRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	var violations []rules.Violation
+
+	// Check meta-ARGs (those before any FROM).
+	for _, arg := range input.MetaArgs {
+		if v := r.checkArgValue(input, &arg, meta); v != nil {
+			violations = append(violations, *v)
+		}
+	}
+
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		// Walk all ARG and ENV commands in the stage.
+		for _, cmd := range stage.Commands {
+			switch c := cmd.(type) {
+			case *instructions.ArgCommand:
+				if v := r.checkArgValue(input, c, meta); v != nil {
+					violations = append(violations, *v)
+				}
+			case *instructions.EnvCommand:
+				violations = append(violations, r.checkEnvValues(input, c, meta)...)
+			}
+		}
+	}
+	return violations
+}
+
+func (r *SecretsInArgOrEnvRule) checkArgValue(
+	input rules.LintInput,
+	cmd *instructions.ArgCommand,
+	meta rules.RuleMetadata,
+) *rules.Violation {
+	if cmd == nil {
+		return nil
+	}
+	for _, arg := range cmd.Args {
+		if !railsSecretEnvKeys[arg.Key] {
+			continue
+		}
+		// ARG with no default value is still suspicious — it becomes
+		// part of build cache key data and the user is meant to pass a
+		// real secret via --build-arg, which would then leak into image
+		// history once an ENV/RUN consumes it.
+		var value string
+		if arg.Value != nil {
+			value = strings.TrimSpace(*arg.Value)
+		}
+		if isPlaceholderSecretValue(value) {
+			continue
+		}
+		loc := rules.NewLocationFromRanges(input.File, cmd.Location())
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(secretsInArgOrEnvDetail(arg.Key, strings.ToUpper(command.Arg)))
+		v = v.WithSuggestedFix(buildSecretsFix(meta.FixPriority))
+		return &v
+	}
+	return nil
+}
+
+func (r *SecretsInArgOrEnvRule) checkEnvValues(
+	input rules.LintInput,
+	cmd *instructions.EnvCommand,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	if cmd == nil {
+		return nil
+	}
+	var violations []rules.Violation
+	for _, kv := range cmd.Env {
+		if !railsSecretEnvKeys[kv.Key] {
+			continue
+		}
+		value := strings.TrimSpace(kv.Value)
+		// Strip surrounding quotes for placeholder check.
+		unquoted := value
+		if len(unquoted) >= 2 &&
+			((unquoted[0] == '"' && unquoted[len(unquoted)-1] == '"') ||
+				(unquoted[0] == '\'' && unquoted[len(unquoted)-1] == '\'')) {
+			unquoted = unquoted[1 : len(unquoted)-1]
+		}
+		if isPlaceholderSecretValue(unquoted) {
+			continue
+		}
+		loc := rules.NewLocationFromRanges(input.File, cmd.Location())
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(secretsInArgOrEnvDetail(kv.Key, strings.ToUpper(command.Env)))
+		v = v.WithSuggestedFix(buildSecretsFix(meta.FixPriority))
+		violations = append(violations, v)
+	}
+	return violations
+}
+
+// isPlaceholderSecretValue reports whether a value is a known Rails
+// placeholder constant (the dummy/build-time form Rails accepts).
+func isPlaceholderSecretValue(value string) bool {
+	v := strings.ToLower(strings.TrimSpace(value))
+	switch v {
+	case "":
+		// Empty value (e.g. `ARG SECRET_KEY_BASE` with no default) is
+		// flagged below — the user is passing the value via --build-arg
+		// which would then leak into image cache key data. Don't treat
+		// empty as a placeholder.
+		return false
+	case "1", "dummy", "secret_key_base_dummy":
+		return true
+	}
+	// Bash-style placeholder patterns Rails accepts.
+	return false
+}
+
+func secretsInArgOrEnvDetail(key, instruction string) string {
+	return "Setting `" + key + "` via " + instruction + " bakes the value into the image's per-layer history " +
+		"(`docker history --no-trunc <image>`) and into the build cache key data. Anyone who can pull the " +
+		"image can recover the secret. Use BuildKit secret mounts " +
+		"(`RUN --mount=type=secret,id=" + canonicalSecretID(key) + ",env=" + key + "`) for build-time " +
+		"access; for asset compilation specifically, use `SECRET_KEY_BASE_DUMMY=1` so the build doesn't " +
+		"need the real key at all (Rails 7.1+)."
+}
+
+// canonicalSecretID returns a conventional secret-mount ID for a given env var.
+func canonicalSecretID(key string) string {
+	return strings.ToLower(key)
+}
+
+// buildSecretsFix emits a non-edit suggestion. The fix can't auto-rewrite
+// (the user's CI/secret-injection mechanism is repo-specific), but the
+// description points at the supported alternative.
+func buildSecretsFix(priority int) *rules.SuggestedFix {
+	return &rules.SuggestedFix{
+		Description: "Pass the secret via `RUN --mount=type=secret,id=...,env=...` instead of ARG/ENV. For " +
+			"asset compilation use SECRET_KEY_BASE_DUMMY=1 (Rails 7.1+) to avoid needing the real key at " +
+			"build time entirely.",
+		Safety:      rules.FixUnsafe,
+		Priority:    priority,
+		IsPreferred: false,
+	}
+}
+
+func init() {
+	rules.Register(NewSecretsInArgOrEnvRule())
+}

--- a/internal/rules/tally/ruby/secrets_in_arg_or_env.go
+++ b/internal/rules/tally/ruby/secrets_in_arg_or_env.go
@@ -111,6 +111,11 @@ func (r *SecretsInArgOrEnvRule) checkArgValue(
 		if arg.Value != nil {
 			value = strings.TrimSpace(*arg.Value)
 		}
+		// BuildKit preserves quote characters in arg.Value, so a
+		// quoted placeholder like `ARG SECRET_KEY_BASE="dummy"`
+		// arrives as `"dummy"` (with literal quote bytes). Strip
+		// surrounding quotes before the placeholder check.
+		value = stripSurroundingQuotes(value)
 		if isPlaceholderSecretValue(value) {
 			continue
 		}
@@ -138,13 +143,7 @@ func (r *SecretsInArgOrEnvRule) checkEnvValues(
 			continue
 		}
 		value := strings.TrimSpace(kv.Value)
-		// Strip surrounding quotes for placeholder check.
-		unquoted := value
-		if len(unquoted) >= 2 &&
-			((unquoted[0] == '"' && unquoted[len(unquoted)-1] == '"') ||
-				(unquoted[0] == '\'' && unquoted[len(unquoted)-1] == '\'')) {
-			unquoted = unquoted[1 : len(unquoted)-1]
-		}
+		unquoted := stripSurroundingQuotes(value)
 		if isPlaceholderSecretValue(unquoted) {
 			continue
 		}
@@ -156,6 +155,18 @@ func (r *SecretsInArgOrEnvRule) checkEnvValues(
 		violations = append(violations, v)
 	}
 	return violations
+}
+
+// stripSurroundingQuotes removes a single layer of matching `"` or `'`
+// quotes. Used because BuildKit preserves the literal quote characters
+// in ENV/ARG values.
+func stripSurroundingQuotes(s string) string {
+	if len(s) >= 2 &&
+		((s[0] == '"' && s[len(s)-1] == '"') ||
+			(s[0] == '\'' && s[len(s)-1] == '\'')) {
+		return s[1 : len(s)-1]
+	}
+	return s
 }
 
 // isPlaceholderSecretValue reports whether a value is a known Rails

--- a/internal/rules/tally/ruby/secrets_in_arg_or_env_test.go
+++ b/internal/rules/tally/ruby/secrets_in_arg_or_env_test.go
@@ -1,0 +1,107 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestSecretsInArgOrEnvRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewSecretsInArgOrEnvRule().Metadata()
+	if meta.Code != SecretsInArgOrEnvRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, SecretsInArgOrEnvRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityError {
+		t.Errorf("DefaultSeverity = %v, want Error", meta.DefaultSeverity)
+	}
+	if meta.Category != "security" {
+		t.Errorf("Category = %q, want %q", meta.Category, "security")
+	}
+}
+
+func TestSecretsInArgOrEnvRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewSecretsInArgOrEnvRule(), []testutil.RuleTestCase{
+		// --- Violations: ENV with non-placeholder values ---
+		{
+			Name: "ENV SECRET_KEY_BASE with literal value triggers",
+			Content: `FROM ruby:3.3-slim
+ENV SECRET_KEY_BASE="abc123"
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ENV RAILS_MASTER_KEY triggers",
+			Content: `FROM ruby:3.3-slim
+ENV RAILS_MASTER_KEY="secret_key_value"
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ENV DEVISE_SECRET_KEY triggers",
+			Content: `FROM ruby:3.3-slim
+ENV DEVISE_SECRET_KEY="some-pepper"
+`,
+			WantViolations: 1,
+		},
+		// --- Violations: ARG with non-placeholder value ---
+		{
+			Name: "ARG SECRET_KEY_BASE=value triggers",
+			Content: `FROM ruby:3.3-slim
+ARG SECRET_KEY_BASE=abc123
+`,
+			WantViolations: 1,
+		},
+		// --- Violations: meta-ARG (before any FROM) ---
+		{
+			Name: "meta-ARG RAILS_MASTER_KEY triggers",
+			Content: `ARG RAILS_MASTER_KEY=defabc
+FROM ruby:3.3-slim
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: placeholder values ---
+		{
+			Name: "ENV SECRET_KEY_BASE=1 (Rails-accepted placeholder) suppresses",
+			Content: `FROM ruby:3.3-slim
+ENV SECRET_KEY_BASE=1
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: `ENV SECRET_KEY_BASE="dummy" (placeholder) suppresses`,
+			Content: `FROM ruby:3.3-slim
+ENV SECRET_KEY_BASE="dummy"
+`,
+			WantViolations: 0,
+		},
+		// --- Compliance: no value (empty default ARG is suspicious but
+		// we still flag it because --build-arg substitution would leak)
+		{
+			Name: "ARG SECRET_KEY_BASE without default still triggers",
+			Content: `FROM ruby:3.3-slim
+ARG SECRET_KEY_BASE
+`,
+			WantViolations: 1,
+		},
+		// --- Suppressions ---
+		{
+			Name: "non-secret ENV (RAILS_ENV) does not trigger",
+			Content: `FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev stage skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+ENV SECRET_KEY_BASE="abc123"
+`,
+			WantViolations: 0,
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/secrets-in-arg-or-env`](https://tally.wharflab.com/rules/tally/ruby/secrets-in-arg-or-env/) — Section 4.3 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

Rails-app secret env vars declared via `ARG` or `ENV` end up in image history (`docker history --no-trunc`) and build cache key data. Anyone who can pull the image can recover the secret.

- **Coverage:** `SECRET_KEY_BASE`, `RAILS_MASTER_KEY`, `SECRET_TOKEN`, `DEVISE_SECRET_KEY`, `DEVISE_PEPPER`, `RAILS_KEY`.
- **Placeholders accepted (compliant):** `1`, `dummy`, `secret_key_base_dummy` (case-insensitive) — matches Rails 7.1+'s build-time placeholder contract.
- **Also fires on:** meta-ARG (before any FROM) and ARG without default (user passes `--build-arg`, which adds the secret to build cache key data).
- **Suppressions:** dev/test/ci/debug stages, Windows.
- **Severity:** `error`.
- **Auto-fix:** `FixUnsafe` no-edit suggestion. Description points at BuildKit secret mounts (`RUN --mount=type=secret,id=...,env=...`) and the `SECRET_KEY_BASE_DUMMY=1` alternative for asset precompile.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint fixture: `internal/integration/fixtures/lint/ruby-secrets-in-arg-or-env/`