### PR TITLE
feat(rules): add tally/ruby/prefer-gemfile-bind-mounts

### DIFF
--- a/_docs/rules/tally/ruby/prefer-gemfile-bind-mounts.mdx
+++ b/_docs/rules/tally/ruby/prefer-gemfile-bind-mounts.mdx
@@ -1,0 +1,78 @@
+---
+title: "tally/ruby/prefer-gemfile-bind-mounts"
+description: "`COPY Gemfile Gemfile.lock` + `RUN bundle install` can become a BuildKit bind mount."
+---
+
+`COPY Gemfile Gemfile.lock` followed by `RUN bundle install` can be replaced by a BuildKit bind-mount on the
+manifests, eliminating the layer that just carries the manifest files.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info |
+| Category | Performance |
+| Default | Enabled (advisory) |
+| Auto-fix | `FixSuggestion` (no-edit) |
+
+## Description
+
+The dominant pattern in the corpus is:
+
+```dockerfile
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+```
+
+That bakes the manifest files into an image layer that is later overwritten by `COPY . .` and rewritten by
+every `assets:precompile` and `bootsnap precompile` invocation. With BuildKit, the manifests can be
+bind-mounted directly into the `RUN`, never appearing as layer content at all.
+
+The corpus shows **94 of 196** Rails Dockerfiles `COPY Gemfile Gemfile.lock` (plus standalone files), and
+**0 of 196** use a BuildKit bind mount. This rule's job is to surface the pattern at the moment a user
+reaches for the older one.
+
+The rule fires only when:
+
+- The Dockerfile carries `# syntax=docker/dockerfile:1` (or compatible) — bind mounts require BuildKit.
+- A Ruby-shaped stage has a `COPY Gemfile Gemfile.lock ...` (or `COPY Gemfile* ./`) instruction.
+- The same stage runs `bundle install`.
+
+`COPY . .` (wholesale tree copy) doesn't trigger the rule — that's a different pattern with different
+trade-offs.
+
+Stages explicitly named `dev`/`development`/`test`/`testing`/`ci`/`debug` are skipped.
+
+## Examples
+
+### Before
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+```
+
+### After
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle install
+```
+
+The manifests are visible to `bundle install` for the duration of the RUN but never become layer content.
+Combined with the cache mount on `${BUNDLE_PATH}/cache`, this is the modern shape of a Ruby dependency stage.
+
+## Auto-fix
+
+`FixSuggestion` (no-edit). The rule emits a description-only suggestion: rewriting `COPY` + `RUN` into a
+single `RUN --mount=type=bind` block is too easy to get wrong on multi-line `RUN` chains. The user applies
+the rewrite manually.
+
+## References
+
+- [Docker BuildKit `RUN --mount=type=bind` documentation](https://docs.docker.com/build/cache/optimize/#use-bind-mounts).
+- [Bundler `bundle install` documentation](https://bundler.io/v2.5/man/bundle-install.1.html).

--- a/internal/integration/fixtures/lint/ruby-prefer-gemfile-bind-mounts/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-prefer-gemfile-bind-mounts/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/prefer-gemfile-bind-mounts"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-prefer-gemfile-bind-mounts/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-prefer-gemfile-bind-mounts/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+# Canonical violation.
+FROM ruby:3.3-slim AS app
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# Compliant: bind mount + cache mount.
+FROM ruby:3.3-slim AS app-bind
+RUN --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle install
+
+# Suppressed: dev stage.
+FROM ruby:3.3-slim AS dev
+COPY Gemfile Gemfile.lock ./
+RUN bundle install

--- a/internal/integration/fixtures/lint/ruby-prefer-gemfile-bind-mounts/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-prefer-gemfile-bind-mounts/result_1.snap.json
@@ -1,0 +1,43 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-prefer-gemfile-bind-mounts/Dockerfile",
+      "violations": [
+        {
+          "detail": "94 of 196 Rails Dockerfiles in the corpus `COPY Gemfile Gemfile.lock`; 0 use a BuildKit bind mount. With `# syntax=docker/dockerfile:1`, the manifests can be bind-mounted directly into the `bundle install` RUN — they never appear as layer content. Combined with `--mount=type=cache` for `${BUNDLE_PATH}/cache`, this is the modern shape of a Ruby dependency stage.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-gemfile-bind-mounts/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 4
+            },
+            "file": "fixtures/lint/ruby-prefer-gemfile-bind-mounts/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 4
+            }
+          },
+          "message": "`COPY Gemfile Gemfile.lock` followed by `bundle install` can be replaced by a BuildKit bind mount",
+          "rule": "tally/ruby/prefer-gemfile-bind-mounts",
+          "severity": "info",
+          "sourceCode": "COPY Gemfile Gemfile.lock ./",
+          "suggestedFix": {
+            "description": "Replace COPY Gemfile Gemfile.lock + RUN bundle install with `RUN --mount=type=bind,source=Gemfile,target=Gemfile --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked bundle install`",
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go
+++ b/internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go
@@ -1,0 +1,190 @@
+package ruby
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// dockerfileSyntaxBuildKitMarkers identifies BuildKit-frontend syntax
+// pragmas. Cache and bind mounts require one of these.
+var dockerfileSyntaxBuildKitMarkers = []string{"docker/dockerfile", "dockerfile/labs"}
+
+// hasBuildKitSyntaxPragma reports whether the Dockerfile carries a
+// `# syntax=docker/dockerfile:1` (or compatible) directive at its top.
+func hasBuildKitSyntaxPragma(input rules.LintInput) bool {
+	for line := range strings.SplitSeq(string(input.Source), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") {
+			break
+		}
+		if strings.Contains(trimmed, "syntax=") {
+			for _, m := range dockerfileSyntaxBuildKitMarkers {
+				if strings.Contains(trimmed, m) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// PreferGemfileBindMountsRuleCode is the full rule code.
+const PreferGemfileBindMountsRuleCode = rules.TallyRulePrefix + "ruby/prefer-gemfile-bind-mounts"
+
+// preferGemfileBindMountsFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const preferGemfileBindMountsFixPriority = 88
+
+// PreferGemfileBindMountsRule flags `COPY Gemfile Gemfile.lock` patterns
+// that are followed by `bundle install`, suggesting the BuildKit
+// `--mount=type=bind` form instead.
+type PreferGemfileBindMountsRule struct{}
+
+// NewPreferGemfileBindMountsRule creates the rule.
+func NewPreferGemfileBindMountsRule() *PreferGemfileBindMountsRule {
+	return &PreferGemfileBindMountsRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *PreferGemfileBindMountsRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            PreferGemfileBindMountsRuleCode,
+		Name:            "Prefer BuildKit bind mounts for Gemfile/Gemfile.lock",
+		Description:     "`COPY Gemfile Gemfile.lock` followed by `bundle install` can be replaced by a BuildKit bind mount",
+		DocURL:          rules.TallyDocURL(PreferGemfileBindMountsRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "performance",
+		FixPriority:     preferGemfileBindMountsFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *PreferGemfileBindMountsRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	// Only suggest the bind-mount form on Dockerfiles that already opt
+	// into BuildKit syntax — `--mount=type=bind` requires it.
+	if !hasBuildKitSyntaxPragma(input) {
+		return nil
+	}
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+
+		// Find a `COPY Gemfile Gemfile.lock ...` instruction followed
+		// later in the same stage by `bundle install`.
+		copyCmd := findGemfileCopy(stage)
+		if copyCmd == nil {
+			continue
+		}
+		if !stageHasBundleInstall(sf) {
+			continue
+		}
+
+		loc := copyInstructionLocation(input.File, copyCmd)
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(preferGemfileBindMountsDetail()).
+			WithSuggestedFix(&rules.SuggestedFix{
+				Description: "Replace COPY Gemfile Gemfile.lock + RUN bundle install with " +
+					"`RUN --mount=type=bind,source=Gemfile,target=Gemfile " +
+					"--mount=type=bind,source=Gemfile.lock,target=Gemfile.lock " +
+					"--mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked bundle install`",
+				Safety:      rules.FixSuggestion,
+				Priority:    meta.FixPriority,
+				IsPreferred: false,
+			})
+		violations = append(violations, v)
+		// Report once per stage.
+		break
+	}
+	return violations
+}
+
+func preferGemfileBindMountsDetail() string {
+	return "94 of 196 Rails Dockerfiles in the corpus `COPY Gemfile Gemfile.lock`; 0 use a BuildKit bind " +
+		"mount. With `# syntax=docker/dockerfile:1`, the manifests can be bind-mounted directly into the " +
+		"`bundle install` RUN — they never appear as layer content. Combined with `--mount=type=cache` " +
+		"for `${BUNDLE_PATH}/cache`, this is the modern shape of a Ruby dependency stage."
+}
+
+// findGemfileCopy returns the first COPY in the stage that copies
+// Gemfile and Gemfile.lock as standalone files (not as part of a
+// catch-all `COPY . .`).
+func findGemfileCopy(stage instructions.Stage) *instructions.CopyCommand {
+	for _, cmd := range stage.Commands {
+		copyCmd, ok := cmd.(*instructions.CopyCommand)
+		if !ok {
+			continue
+		}
+		if copyMatchesGemfileManifests(copyCmd) {
+			return copyCmd
+		}
+	}
+	return nil
+}
+
+// copyMatchesGemfileManifests reports whether a COPY explicitly copies
+// Gemfile and Gemfile.lock (in some order). `COPY . .` doesn't count —
+// that's a wholesale tree copy, not the bind-mount pattern.
+func copyMatchesGemfileManifests(cmd *instructions.CopyCommand) bool {
+	if cmd == nil || len(cmd.SourceContents) > 0 {
+		return false
+	}
+	hasGemfile := false
+	hasLock := false
+	for _, src := range cmd.SourcePaths {
+		switch src {
+		case "Gemfile":
+			hasGemfile = true
+		case "Gemfile.lock":
+			hasLock = true
+		case "Gemfile*", "Gemfile.*":
+			// Glob form covers both.
+			return true
+		}
+		// Wholesale source — `.` and `./` and `/rails` don't count.
+		if src == "." || src == "./" || strings.HasPrefix(src, "/") {
+			return false
+		}
+	}
+	return hasGemfile && hasLock
+}
+
+// stageHasBundleInstall reports whether any RUN in the stage runs
+// `bundle install`.
+func stageHasBundleInstall(sf *facts.StageFacts) bool {
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		if slices.ContainsFunc(runFacts.CommandInfos, isBundleInstall) {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	rules.Register(NewPreferGemfileBindMountsRule())
+}

--- a/internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go
+++ b/internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go
@@ -97,7 +97,12 @@ func (r *PreferGemfileBindMountsRule) Check(input rules.LintInput) []rules.Viola
 		if copyCmd == nil {
 			continue
 		}
-		if !stageHasBundleInstall(sf) {
+		// Only fire when bundle install runs AFTER the COPY in source
+		// order. A `bundle install` before any Gemfile COPY (or a COPY
+		// that exists for another purpose, e.g. shipping Gemfile into
+		// a final-stage runtime that doesn't run install) is not the
+		// pattern this rule targets.
+		if !stageHasBundleInstallAfter(sf, copyStartLine(copyCmd)) {
 			continue
 		}
 
@@ -115,10 +120,34 @@ func (r *PreferGemfileBindMountsRule) Check(input rules.LintInput) []rules.Viola
 				IsPreferred: false,
 			})
 		violations = append(violations, v)
-		// Report once per stage.
-		break
+		// Report once per stage; continue scanning subsequent stages
+		// in case a multi-stage Dockerfile has multiple Ruby stages
+		// with the same pattern.
 	}
 	return violations
+}
+
+// stageHasBundleInstallAfter reports whether any RUN at-or-after the
+// supplied source line contains `bundle install`. Used to enforce the
+// ordering: the COPY must precede the install.
+func stageHasBundleInstallAfter(sf *facts.StageFacts, line int) bool {
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil || runFacts.Run == nil {
+			continue
+		}
+		runRanges := runFacts.Run.Location()
+		if len(runRanges) == 0 {
+			continue
+		}
+		runLine := runRanges[0].Start.Line
+		if runLine < line {
+			continue
+		}
+		if slices.ContainsFunc(runFacts.CommandInfos, isBundleInstall) {
+			return true
+		}
+	}
+	return false
 }
 
 func preferGemfileBindMountsDetail() string {
@@ -169,20 +198,6 @@ func copyMatchesGemfileManifests(cmd *instructions.CopyCommand) bool {
 		}
 	}
 	return hasGemfile && hasLock
-}
-
-// stageHasBundleInstall reports whether any RUN in the stage runs
-// `bundle install`.
-func stageHasBundleInstall(sf *facts.StageFacts) bool {
-	for _, runFacts := range sf.Runs {
-		if runFacts == nil {
-			continue
-		}
-		if slices.ContainsFunc(runFacts.CommandInfos, isBundleInstall) {
-			return true
-		}
-	}
-	return false
 }
 
 func init() {

--- a/internal/rules/tally/ruby/prefer_gemfile_bind_mounts_test.go
+++ b/internal/rules/tally/ruby/prefer_gemfile_bind_mounts_test.go
@@ -1,0 +1,84 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestPreferGemfileBindMountsRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewPreferGemfileBindMountsRule().Metadata()
+	if meta.Code != PreferGemfileBindMountsRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, PreferGemfileBindMountsRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "performance" {
+		t.Errorf("Category = %q, want %q", meta.Category, "performance")
+	}
+}
+
+func TestPreferGemfileBindMountsRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewPreferGemfileBindMountsRule(), []testutil.RuleTestCase{
+		// --- Violations ---
+		{
+			Name: "COPY Gemfile Gemfile.lock + RUN bundle install triggers (with syntax pragma)",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Suppressions ---
+		{
+			Name: "no syntax pragma → suppress (bind mounts unsupported)",
+			Content: `FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "COPY . . (catch-all) does NOT trigger",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+COPY . .
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "COPY without bundle install does NOT trigger",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Ruby stage skipped",
+			Content: `# syntax=docker/dockerfile:1
+FROM debian:bookworm-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev stage skipped",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim AS dev
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/prefer-gemfile-bind-mounts`](https://tally.wharflab.com/rules/tally/ruby/prefer-gemfile-bind-mounts/) — Section 4.4 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

Educational/advisory rule. The dominant corpus pattern (`COPY Gemfile Gemfile.lock` + `RUN bundle install`) bakes manifest files into a layer that's later overwritten. With BuildKit, the manifests can be bind-mounted into the RUN — no layer content. Corpus: 94/196 use the COPY pattern, 0/196 use bind mounts.

- **Trigger:** Dockerfile carries `# syntax=docker/dockerfile:1` AND a Ruby-shaped stage has `COPY Gemfile Gemfile.lock` (or `Gemfile*`) AND the same stage runs `bundle install`.
- **Suppressions:** `COPY . .` (different pattern), no syntax pragma, dev/test/ci stages, non-Ruby, Windows.
- **Auto-fix:** `FixSuggestion` (no-edit, info severity). Description points at the canonical bind-mount + cache-mount shape.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint fixture: `internal/integration/fixtures/lint/ruby-prefer-gemfile-bind-mounts/`