### PR TITLE
feat(rules): add tally/ruby/prefer-network-none-install

### DIFF
--- a/_docs/rules/tally/ruby/prefer-network-none-install.mdx
+++ b/_docs/rules/tally/ruby/prefer-network-none-install.mdx
@@ -1,0 +1,90 @@
+---
+title: "tally/ruby/prefer-network-none-install"
+description: "Once on BuildKit bind+cache mounts, prefer the `bundle cache` + `RUN --network=none` two-phase install."
+---
+
+Educational rule: once `bundle install` runs with `--mount=type=bind` for the manifests and
+`--mount=type=cache` for the gem cache, the next-best step is to split the install into two RUNs — one
+that fetches with the network on, one that installs with the network off.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info |
+| Category | Security |
+| Default | Enabled (advisory) |
+| Auto-fix | `FixSuggestion` (no-edit) |
+
+## Description
+
+Bundler can split the dependency lifecycle into two halves:
+
+- `bundle cache --no-install --all-platforms` — downloads `.gem` files into a cache directory. Network
+  required.
+- `bundle install --local` — installs from the cache only. Network not required.
+
+With BuildKit, the install half can be wrapped in `RUN --network=none`, which guarantees that nothing in the
+install path — including post-install C-extension build scripts — is making outbound network calls. The
+result is a strictly reproducible install step and a real defense-in-depth boundary against malicious gems
+exfiltrating data at build time.
+
+The corpus shows **0 of 196** Rails Dockerfiles using this pattern. This rule is intentionally niche — it
+fires only when the user has *already* opted into BuildKit cache and bind mounts, surfacing the further
+upgrade at the moment of relevance.
+
+This rule fires when:
+
+- The Dockerfile carries `# syntax=docker/dockerfile:1` (or compatible).
+- A Ruby-shaped stage's `bundle install` RUN already has `--mount=type=bind` on the Gemfile/Gemfile.lock
+  AND `--mount=type=cache` on `${BUNDLE_PATH}/cache`.
+- The same RUN does NOT have `--network=none`.
+
+If the user is still on the `COPY Gemfile + RUN bundle install` shape, the
+[`tally/ruby/prefer-gemfile-bind-mounts`](/rules/tally/ruby/prefer-gemfile-bind-mounts/) rule covers that
+step first; this rule stays silent until the user gets there.
+
+## Examples
+
+### Before
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle install
+```
+
+### After
+
+Split into two RUNs:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle config set --local cache_path "${BUNDLE_PATH}/cache" && \
+    bundle cache --no-install --all-platforms
+
+RUN --network=none \
+    --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle config set --local cache_path "${BUNDLE_PATH}/cache" && \
+    bundle install --local
+```
+
+## Auto-fix
+
+`FixSuggestion` (no-edit). The split is structural — the user keeps the bind/cache mount setup, copies it to
+a second RUN, and adds `--network=none` plus `--local`. Description points at the canonical shape.
+
+## References
+
+- [Bundler `bundle cache` documentation](https://bundler.io/v2.5/man/bundle-cache.1.html) — describes the
+  cache-only install path.
+- [Docker BuildKit `RUN --network=none`](https://docs.docker.com/reference/dockerfile/#run---network).
+- [`xz` upstream supply-chain compromise](https://access.redhat.com/security/cve/cve-2024-3094) — context for
+  why offline install matters as defense-in-depth.

--- a/internal/integration/fixtures/lint/ruby-prefer-network-none-install/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-prefer-network-none-install/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/prefer-network-none-install"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-prefer-network-none-install/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-prefer-network-none-install/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+# Already on BuildKit bind+cache, but missing --network=none — triggers.
+FROM ruby:3.3-slim AS app
+RUN --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle install
+
+# Compliant: --network=none added.
+FROM ruby:3.3-slim AS app-network-none
+RUN --network=none \
+    --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle install --local
+
+# Suppressed: bare bundle install (no bind/cache yet) — other rules
+# cover that step.
+FROM ruby:3.3-slim AS app-bare
+COPY Gemfile Gemfile.lock ./
+RUN bundle install

--- a/internal/integration/fixtures/lint/ruby-prefer-network-none-install/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-prefer-network-none-install/result_1.snap.json
@@ -1,0 +1,43 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-prefer-network-none-install/Dockerfile",
+      "violations": [
+        {
+          "detail": "Once `bundle install` runs with `--mount=type=bind` for the manifests and `--mount=type=cache` for the gem cache, the next-best step is to split the install into two RUNs: `bundle cache --no-install --all-platforms` (network required) and `RUN --network=none bundle install --local` (network disabled). The result is a strictly reproducible install step and a defense-in-depth boundary against malicious gems exfiltrating data at build time. Corpus uptake: 0/196 — this is a niche but well-documented BuildKit feature worth surfacing.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-network-none-install/",
+          "location": {
+            "end": {
+              "column": 66,
+              "line": 4
+            },
+            "file": "fixtures/lint/ruby-prefer-network-none-install/Dockerfile",
+            "start": {
+              "column": 59,
+              "line": 4
+            }
+          },
+          "message": "BuildKit `RUN --network=none` enables a strictly reproducible offline install phase",
+          "rule": "tally/ruby/prefer-network-none-install",
+          "severity": "info",
+          "sourceCode": "RUN --mount=type=bind,source=Gemfile,target=Gemfile \\",
+          "suggestedFix": {
+            "description": "Split bundle install into two phases: `RUN bundle cache --no-install --all-platforms` (network required), then `RUN --network=none bundle install --local` (network disabled, strictly reproducible)",
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/rules/tally/ruby/prefer_network_none_install.go
+++ b/internal/rules/tally/ruby/prefer_network_none_install.go
@@ -1,0 +1,204 @@
+package ruby
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/runmount"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// dockerfileSyntaxBuildKitMarkers identifies BuildKit-frontend syntax
+// pragmas. Cache and bind mounts require one of these.
+var dockerfileSyntaxBuildKitMarkers = []string{"docker/dockerfile", "dockerfile/labs"}
+
+// hasBuildKitSyntaxPragma reports whether the Dockerfile carries a
+// `# syntax=docker/dockerfile:1` (or compatible) directive at its top.
+func hasBuildKitSyntaxPragma(input rules.LintInput) bool {
+	for line := range strings.SplitSeq(string(input.Source), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") {
+			break
+		}
+		if strings.Contains(trimmed, "syntax=") {
+			for _, m := range dockerfileSyntaxBuildKitMarkers {
+				if strings.Contains(trimmed, m) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// PreferNetworkNoneInstallRuleCode is the full rule code.
+const PreferNetworkNoneInstallRuleCode = rules.TallyRulePrefix + "ruby/prefer-network-none-install"
+
+// preferNetworkNoneInstallFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const preferNetworkNoneInstallFixPriority = 88
+
+// PreferNetworkNoneInstallRule flags `bundle install` invocations on
+// modern BuildKit Dockerfiles that don't use `RUN --network=none` for
+// the install phase. The pattern is:
+//
+//  1. RUN bundle cache --no-install --all-platforms  (network required)
+//  2. RUN --network=none bundle install --local       (network disabled)
+//
+// This is an advisory rule that surfaces the pattern at moments when
+// the user is already on BuildKit syntax. It never fires unless the
+// pattern would actually work.
+type PreferNetworkNoneInstallRule struct{}
+
+// NewPreferNetworkNoneInstallRule creates the rule.
+func NewPreferNetworkNoneInstallRule() *PreferNetworkNoneInstallRule {
+	return &PreferNetworkNoneInstallRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *PreferNetworkNoneInstallRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            PreferNetworkNoneInstallRuleCode,
+		Name:            "Consider `bundle cache` + `RUN --network=none bundle install --local`",
+		Description:     "BuildKit `RUN --network=none` enables a strictly reproducible offline install phase",
+		DocURL:          rules.TallyDocURL(PreferNetworkNoneInstallRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "security",
+		FixPriority:     preferNetworkNoneInstallFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *PreferNetworkNoneInstallRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	// `--network=none` is BuildKit-only. Suppress when there's no
+	// syntax pragma.
+	if !hasBuildKitSyntaxPragma(input) {
+		return nil
+	}
+
+	var violations []rules.Violation
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+
+		// Find a `bundle install` RUN that doesn't already use both
+		// the bind-mount + cache-mount pattern. The advisory only
+		// fires when the user is already on BuildKit AND is using
+		// the modern manifest pattern — surfacing the further upgrade.
+		runFacts := findBundleInstallRun(sf)
+		if runFacts == nil {
+			continue
+		}
+		if !runUsesBundleManifestBindAndCache(runFacts) {
+			// The user hasn't even adopted the bind-mount + cache-mount
+			// pattern yet. The prefer-gemfile-bind-mounts and
+			// prefer-bundler-cache-mount rules cover that step.
+			// Don't pile on with a second educational suggestion.
+			continue
+		}
+		if runHasNetworkNoneFlag(runFacts) {
+			continue
+		}
+
+		loc := bundleInstallViolationLocation(input.File, runFacts, *findFirstBundleInstall(runFacts), input.SourceMap())
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(preferNetworkNoneInstallDetail()).
+			WithSuggestedFix(&rules.SuggestedFix{
+				Description: "Split bundle install into two phases: " +
+					"`RUN bundle cache --no-install --all-platforms` (network required), " +
+					"then `RUN --network=none bundle install --local` (network disabled, " +
+					"strictly reproducible)",
+				Safety:      rules.FixSuggestion,
+				Priority:    meta.FixPriority,
+				IsPreferred: false,
+			})
+		violations = append(violations, v)
+	}
+	return violations
+}
+
+func preferNetworkNoneInstallDetail() string {
+	return "Once `bundle install` runs with `--mount=type=bind` for the manifests and `--mount=type=cache` " +
+		"for the gem cache, the next-best step is to split the install into two RUNs: `bundle cache " +
+		"--no-install --all-platforms` (network required) and `RUN --network=none bundle install --local` " +
+		"(network disabled). The result is a strictly reproducible install step and a defense-in-depth " +
+		"boundary against malicious gems exfiltrating data at build time. Corpus uptake: 0/196 — " +
+		"this is a niche but well-documented BuildKit feature worth surfacing."
+}
+
+// findBundleInstallRun returns the first RUN in the stage that runs
+// `bundle install`, or nil when none exists.
+func findBundleInstallRun(sf *facts.StageFacts) *facts.RunFacts {
+	for _, runFacts := range sf.Runs {
+		if runFacts == nil {
+			continue
+		}
+		if findFirstBundleInstall(runFacts) != nil {
+			return runFacts
+		}
+	}
+	return nil
+}
+
+// runUsesBundleManifestBindAndCache reports whether a RUN already uses
+// both `--mount=type=bind` for Gemfile/Gemfile.lock AND
+// `--mount=type=cache` for the Bundler cache target.
+func runUsesBundleManifestBindAndCache(runFacts *facts.RunFacts) bool {
+	if runFacts == nil || runFacts.Run == nil {
+		return false
+	}
+	hasBindGemfile := false
+	hasCache := false
+	for _, mount := range runmount.GetMounts(runFacts.Run) {
+		if mount == nil {
+			continue
+		}
+		switch mount.Type {
+		case instructions.MountTypeBind:
+			if mount.Source == "Gemfile" || mount.Source == "Gemfile.lock" {
+				hasBindGemfile = true
+			}
+		case instructions.MountTypeCache:
+			if cacheTargetMatchesBundlerCache(mount.Target) {
+				hasCache = true
+			}
+		case instructions.MountTypeTmpfs,
+			instructions.MountTypeSecret,
+			instructions.MountTypeSSH:
+			// Other mount types are unrelated to this rule's
+			// bind+cache check. Ignore.
+		}
+	}
+	return hasBindGemfile && hasCache
+}
+
+// runHasNetworkNoneFlag reports whether the RUN carries
+// `--network=none`.
+func runHasNetworkNoneFlag(runFacts *facts.RunFacts) bool {
+	if runFacts == nil || runFacts.Run == nil {
+		return false
+	}
+	return instructions.GetNetwork(runFacts.Run) == instructions.NetworkNone
+}
+
+func init() {
+	rules.Register(NewPreferNetworkNoneInstallRule())
+}

--- a/internal/rules/tally/ruby/prefer_network_none_install_test.go
+++ b/internal/rules/tally/ruby/prefer_network_none_install_test.go
@@ -1,0 +1,88 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestPreferNetworkNoneInstallRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewPreferNetworkNoneInstallRule().Metadata()
+	if meta.Code != PreferNetworkNoneInstallRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, PreferNetworkNoneInstallRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "security" {
+		t.Errorf("Category = %q, want %q", meta.Category, "security")
+	}
+}
+
+func TestPreferNetworkNoneInstallRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewPreferNetworkNoneInstallRule(), []testutil.RuleTestCase{
+		// --- Violation ---
+		{
+			Name: "bundle install with bind+cache mounts but no --network=none triggers",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle install
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: --network=none present ---
+		{
+			Name: "bundle install with --network=none suppresses",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+RUN --network=none \
+    --mount=type=bind,source=Gemfile,target=Gemfile \
+    --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
+    --mount=type=cache,target=${BUNDLE_PATH}/cache,sharing=locked \
+    bundle install --local
+`,
+			WantViolations: 0,
+		},
+		// --- Suppressions ---
+		{
+			Name: "no syntax pragma → suppress",
+			Content: `FROM ruby:3.3-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "bare bundle install (no bind/cache mounts) does NOT trigger (other rules cover those)",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Ruby stage skipped",
+			Content: `# syntax=docker/dockerfile:1
+FROM debian:bookworm-slim
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev stage skipped",
+			Content: `# syntax=docker/dockerfile:1
+FROM ruby:3.3-slim AS dev
+RUN bundle install
+`,
+			WantViolations: 0,
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/prefer-network-none-install`](https://tally.wharflab.com/rules/tally/ruby/prefer-network-none-install/) — Section 4.4 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

Educational/advisory rule. Once `bundle install` runs with `--mount=type=bind` for the manifests and `--mount=type=cache` for the gem cache, the next-best step is to split the install into two RUNs — one fetches with the network on (`bundle cache --no-install --all-platforms`), one installs with the network off (`RUN --network=none bundle install --local`). Result: strictly reproducible install + defense-in-depth boundary against malicious gems exfiltrating data at build time.

- **Trigger:** Dockerfile carries `# syntax=docker/dockerfile:1`, AND a Ruby-shaped stage's `bundle install` RUN already has bind+cache mounts AND no `--network=none`.
- **Stays silent** when the user is still on the older `COPY Gemfile + RUN bundle install` shape (other rules cover that step first).
- **Auto-fix:** `FixSuggestion` (no-edit). Structural rewrite — description points at the canonical two-RUN shape.

Corpus uptake: 0 of 196 — this is intentionally niche and surfaces the modern feature at the moment of relevance.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint fixture: `internal/integration/fixtures/lint/ruby-prefer-network-none-install/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tally/ruby/prefer-network-none-install` linting rule that recommends splitting Ruby `bundle install` into two phases—one for downloading gems with network access, then one with `--network=none` for offline installation.

* **Documentation**
  * Added rule guidance with before/after examples for secure, cache-optimized Ruby Docker builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wharflab/tally/pull/683)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->