### PR TITLE
feat(rules): add tally/ruby/prefer-secret-mounts-for-build-credentials

### DIFF
--- a/_docs/rules/tally/ruby/prefer-secret-mounts-for-build-credentials.mdx
+++ b/_docs/rules/tally/ruby/prefer-secret-mounts-for-build-credentials.mdx
@@ -41,6 +41,10 @@ specifically:
 The corpus shows only 1 of 196 Dockerfiles using `RUN --mount=type=secret`. This rule's job is to surface
 the supported alternative at the moment a user reaches for ARG/ENV.
 
+The rule only fires on Ruby-shaped Dockerfiles — non-Ruby Dockerfiles that happen to use one of these env-var
+names (e.g. a Node.js Dockerfile with `NPM_TOKEN`) are ignored. A meta-`ARG` (declared before any `FROM`)
+also requires at least one Ruby stage somewhere in the file.
+
 Stages explicitly named `dev`/`development`/`test`/`testing`/`ci`/`debug` are skipped.
 
 ## Examples

--- a/_docs/rules/tally/ruby/prefer-secret-mounts-for-build-credentials.mdx
+++ b/_docs/rules/tally/ruby/prefer-secret-mounts-for-build-credentials.mdx
@@ -34,6 +34,9 @@ specifically:
 
 - `BUNDLE_GITHUB__COM`, `BUNDLE_BITBUCKET__ORG`, `BUNDLE_GITLAB__COM` — Bundler host tokens.
 - `BUNDLE_<HOST>__<TLD>` — the generic Bundler host-credential pattern (host names use `__` for `.`).
+  Compound TLDs are supported (`BUNDLE_GEMS__ACME__CO__UK`). Bundler's non-host config namespaces
+  (`BUNDLE_LOCAL__<gem>`, `BUNDLE_BUILD__<gem>`) are excluded because they encode gem identity rather
+  than a hostname.
 - `GEM_HOST_API_KEY` — RubyGems push key.
 - `NPM_TOKEN`, `YARN_AUTH_TOKEN` — npm/yarn auth tokens, commonly used during `bin/rails assets:precompile`
   to fetch private packages.

--- a/_docs/rules/tally/ruby/prefer-secret-mounts-for-build-credentials.mdx
+++ b/_docs/rules/tally/ruby/prefer-secret-mounts-for-build-credentials.mdx
@@ -1,0 +1,84 @@
+---
+title: "tally/ruby/prefer-secret-mounts-for-build-credentials"
+description: "Build-time credential declared via ARG/ENV; prefer `RUN --mount=type=secret,...`."
+---
+
+A Ruby-shaped Dockerfile declares a build-time credential (Bundler host token, NPM/Yarn auth, RubyGems API
+key) via `ARG` or `ENV`. The credential ends up in image cache key data and image history. BuildKit's
+secret-mount syntax is the supported alternative.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info |
+| Category | Security |
+| Default | Enabled (advisory) |
+| Auto-fix | `FixSuggestion` (no-edit) |
+
+## Description
+
+Build-time credentials passed via `ARG` or `ENV` end up in two places that the user generally doesn't want:
+
+- **Image cache key data.** `ARG`s become part of the cache key BuildKit uses to deduplicate build steps.
+  Different secret values produce different cache keys, leaking the credential into anyone with read access
+  to the cache.
+- **Image history.** Once the credential is consumed via `RUN` or referenced from `ENV`, it ends up in
+  `docker history --no-trunc <image>` for anyone who can pull the image.
+
+BuildKit's `RUN --mount=type=secret,id=<id>,env=<VAR>` is the documented production pattern: the secret is
+exposed only inside the one `RUN` and never reaches the image cache key or layer content.
+
+This is the **constructive companion** to
+[`tally/ruby/secrets-in-arg-or-env`](/rules/tally/ruby/secrets-in-arg-or-env/), which catches the same class
+of issue for Rails-app secrets at error severity. This rule covers Ruby-ecosystem build-time credentials
+specifically:
+
+- `BUNDLE_GITHUB__COM`, `BUNDLE_BITBUCKET__ORG`, `BUNDLE_GITLAB__COM` — Bundler host tokens.
+- `BUNDLE_<HOST>__<TLD>` — the generic Bundler host-credential pattern (host names use `__` for `.`).
+- `GEM_HOST_API_KEY` — RubyGems push key.
+- `NPM_TOKEN`, `YARN_AUTH_TOKEN` — npm/yarn auth tokens, commonly used during `bin/rails assets:precompile`
+  to fetch private packages.
+
+The corpus shows only 1 of 196 Dockerfiles using `RUN --mount=type=secret`. This rule's job is to surface
+the supported alternative at the moment a user reaches for ARG/ENV.
+
+Stages explicitly named `dev`/`development`/`test`/`testing`/`ci`/`debug` are skipped.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+ARG BUNDLE_GITHUB__COM
+ENV BUNDLE_GITHUB__COM=$BUNDLE_GITHUB__COM
+RUN bundle install
+```
+
+### After
+
+```dockerfile
+FROM ruby:3.3-slim
+RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM \
+    bundle install
+```
+
+Pass the secret at build time:
+
+```bash
+docker buildx build --secret id=github_token,src=$HOME/.netrc-github .
+```
+
+The secret exists for the duration of that one `RUN` and never reaches image content or cache key data.
+
+## Auto-fix
+
+`FixSuggestion` (no-edit). The exact rewrite depends on the user's CI / vault / secret-injection setup, so
+the rule cannot auto-apply. Description names the canonical form including the `secret_id` it suggests.
+
+## References
+
+- [Bundler `bundle config` documentation](https://bundler.io/v2.5/man/bundle-config.1.html#CREDENTIALS-FOR-GEM-SOURCES) —
+  describes the `BUNDLE_<HOST>__<TLD>` env-var convention.
+- [BuildKit `RUN --mount=type=secret` documentation](https://docs.docker.com/build/building/secrets/).
+- [`basecamp/fizzy/saas` Dockerfile](https://github.com/basecamp/fizzy) — production example using
+  `RUN --mount=type=secret,id=GITHUB_TOKEN ... BUNDLE_GITHUB__COM=...`.

--- a/internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/prefer-secret-mounts-for-build-credentials"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile
@@ -1,0 +1,30 @@
+# Meta-ARG with Bundler host credential: violation.
+ARG BUNDLE_GITHUB__COM
+
+FROM ruby:3.3-slim AS app-bundle-github
+ENV BUNDLE_GITHUB__COM="user:token"
+RUN bundle install
+
+# Generic Bundler host pattern: violation.
+FROM ruby:3.3-slim AS app-private-gems
+ARG BUNDLE_GEMS__MYCOMPANY__COM
+RUN bundle install
+
+# RubyGems push key: violation.
+FROM ruby:3.3-slim AS app-gem-push
+ENV GEM_HOST_API_KEY="abc123"
+
+# NPM token (used during asset:precompile): violation.
+FROM ruby:3.3-slim AS app-yarn
+ENV NPM_TOKEN="ghp_abc"
+RUN yarn install
+
+# Compliant: BuildKit secret mount.
+FROM ruby:3.3-slim AS app-secret-mount
+RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM \
+    bundle install
+
+# Suppressed: BUNDLE_PATH is config, not a credential (no host pattern).
+FROM ruby:3.3-slim AS app-bundle-path
+ENV BUNDLE_PATH="/usr/local/bundle"
+RUN bundle install

--- a/internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/result_1.snap.json
@@ -4,7 +4,7 @@
       "file": "fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile",
       "violations": [
         {
-          "detail": "`BUNDLE_GITHUB__COM` is a build-time credential; declaring it via ARG bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM bundle install`.",
+          "detail": "`BUNDLE_GITHUB__COM` is a build-time credential; declaring it via ARG bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM \u003ccommand\u003e`.",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
           "location": {
             "end": {
@@ -28,7 +28,7 @@
           }
         },
         {
-          "detail": "`BUNDLE_GITHUB__COM` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM bundle install`.",
+          "detail": "`BUNDLE_GITHUB__COM` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM \u003ccommand\u003e`.",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
           "location": {
             "end": {
@@ -52,7 +52,7 @@
           }
         },
         {
-          "detail": "`BUNDLE_GEMS__MYCOMPANY__COM` is a build-time credential; declaring it via ARG bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=bundle_gems__mycompany__com,env=BUNDLE_GEMS__MYCOMPANY__COM bundle install`.",
+          "detail": "`BUNDLE_GEMS__MYCOMPANY__COM` is a build-time credential; declaring it via ARG bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=bundle_gems__mycompany__com,env=BUNDLE_GEMS__MYCOMPANY__COM \u003ccommand\u003e`.",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
           "location": {
             "end": {
@@ -76,7 +76,7 @@
           }
         },
         {
-          "detail": "`GEM_HOST_API_KEY` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=rubygems_api_key,env=GEM_HOST_API_KEY bundle install`.",
+          "detail": "`GEM_HOST_API_KEY` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=rubygems_api_key,env=GEM_HOST_API_KEY \u003ccommand\u003e`.",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
           "location": {
             "end": {
@@ -100,7 +100,7 @@
           }
         },
         {
-          "detail": "`NPM_TOKEN` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=npm_token,env=NPM_TOKEN bundle install`.",
+          "detail": "`NPM_TOKEN` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=npm_token,env=NPM_TOKEN \u003ccommand\u003e`.",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
           "location": {
             "end": {

--- a/internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/result_1.snap.json
@@ -1,0 +1,139 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile",
+      "violations": [
+        {
+          "detail": "`BUNDLE_GITHUB__COM` is a build-time credential; declaring it via ARG bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM bundle install`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 2
+            },
+            "file": "fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 2
+            }
+          },
+          "message": "Build-time credential declared via ARG/ENV; prefer `RUN --mount=type=secret,...`",
+          "rule": "tally/ruby/prefer-secret-mounts-for-build-credentials",
+          "severity": "info",
+          "sourceCode": "ARG BUNDLE_GITHUB__COM",
+          "suggestedFix": {
+            "description": "Replace ARG/ENV BUNDLE_GITHUB__COM with `RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM \u003ccommand\u003e`. Pass the secret value at build time via `docker buildx build --secret id=github_token,src=...`.",
+            "priority": 88,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "`BUNDLE_GITHUB__COM` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM bundle install`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 5
+            },
+            "file": "fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 5
+            }
+          },
+          "message": "Build-time credential declared via ARG/ENV; prefer `RUN --mount=type=secret,...`",
+          "rule": "tally/ruby/prefer-secret-mounts-for-build-credentials",
+          "severity": "info",
+          "sourceCode": "ENV BUNDLE_GITHUB__COM=\"user:token\"",
+          "suggestedFix": {
+            "description": "Replace ARG/ENV BUNDLE_GITHUB__COM with `RUN --mount=type=secret,id=github_token,env=BUNDLE_GITHUB__COM \u003ccommand\u003e`. Pass the secret value at build time via `docker buildx build --secret id=github_token,src=...`.",
+            "priority": 88,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "`BUNDLE_GEMS__MYCOMPANY__COM` is a build-time credential; declaring it via ARG bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=bundle_gems__mycompany__com,env=BUNDLE_GEMS__MYCOMPANY__COM bundle install`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 10
+            },
+            "file": "fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 10
+            }
+          },
+          "message": "Build-time credential declared via ARG/ENV; prefer `RUN --mount=type=secret,...`",
+          "rule": "tally/ruby/prefer-secret-mounts-for-build-credentials",
+          "severity": "info",
+          "sourceCode": "ARG BUNDLE_GEMS__MYCOMPANY__COM",
+          "suggestedFix": {
+            "description": "Replace ARG/ENV BUNDLE_GEMS__MYCOMPANY__COM with `RUN --mount=type=secret,id=bundle_gems__mycompany__com,env=BUNDLE_GEMS__MYCOMPANY__COM \u003ccommand\u003e`. Pass the secret value at build time via `docker buildx build --secret id=bundle_gems__mycompany__com,src=...`.",
+            "priority": 88,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "`GEM_HOST_API_KEY` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=rubygems_api_key,env=GEM_HOST_API_KEY bundle install`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 15
+            },
+            "file": "fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 15
+            }
+          },
+          "message": "Build-time credential declared via ARG/ENV; prefer `RUN --mount=type=secret,...`",
+          "rule": "tally/ruby/prefer-secret-mounts-for-build-credentials",
+          "severity": "info",
+          "sourceCode": "ENV GEM_HOST_API_KEY=\"abc123\"",
+          "suggestedFix": {
+            "description": "Replace ARG/ENV GEM_HOST_API_KEY with `RUN --mount=type=secret,id=rubygems_api_key,env=GEM_HOST_API_KEY \u003ccommand\u003e`. Pass the secret value at build time via `docker buildx build --secret id=rubygems_api_key,src=...`.",
+            "priority": 88,
+            "safety": 1
+          }
+        },
+        {
+          "detail": "`NPM_TOKEN` is a build-time credential; declaring it via ENV bakes the value into image history (`docker history --no-trunc \u003cimage\u003e`) and into the build cache key data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of the RUN it's mounted into and never enters image content or cache key data: `RUN --mount=type=secret,id=npm_token,env=NPM_TOKEN bundle install`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 19
+            },
+            "file": "fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 19
+            }
+          },
+          "message": "Build-time credential declared via ARG/ENV; prefer `RUN --mount=type=secret,...`",
+          "rule": "tally/ruby/prefer-secret-mounts-for-build-credentials",
+          "severity": "info",
+          "sourceCode": "ENV NPM_TOKEN=\"ghp_abc\"",
+          "suggestedFix": {
+            "description": "Replace ARG/ENV NPM_TOKEN with `RUN --mount=type=secret,id=npm_token,env=NPM_TOKEN \u003ccommand\u003e`. Pass the secret value at build time via `docker buildx build --secret id=npm_token,src=...`.",
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 5,
+    "style": 0,
+    "total": 5,
+    "warnings": 0
+  }
+}

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
@@ -1,0 +1,203 @@
+package ruby
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/command"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// PreferSecretMountsForBuildCredentialsRuleCode is the full rule code.
+const PreferSecretMountsForBuildCredentialsRuleCode = rules.TallyRulePrefix + "ruby/prefer-secret-mounts-for-build-credentials"
+
+// preferSecretMountsForBuildCredentialsFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const preferSecretMountsForBuildCredentialsFixPriority = 88
+
+// rubyPrivateGemCredentialEnvKeys maps Ruby/Bundler ecosystem
+// build-credential env-var names to a canonical secret-mount id.
+//
+// `BUNDLE_<HOST>__<TLD>` is Bundler's host-credential pattern (e.g.
+// BUNDLE_GITHUB__COM, BUNDLE_GITLAB__COM, BUNDLE_GEMS__MYCOMPANY__COM).
+// We recognize a few well-known forms explicitly; any ARG/ENV name
+// matching `BUNDLE_*__*` is treated as a Bundler host credential by
+// the trigger logic.
+var rubyPrivateGemCredentialEnvKeys = map[string]string{ //nolint:gosec // env-var names, not credential values
+	"BUNDLE_GITHUB__COM":    "github_token",
+	"BUNDLE_BITBUCKET__ORG": "bitbucket_token",
+	"BUNDLE_GITLAB__COM":    "gitlab_token",
+	"GEM_HOST_API_KEY":      "rubygems_api_key",
+	"NPM_TOKEN":             "npm_token",
+	"YARN_AUTH_TOKEN":       "yarn_auth_token",
+}
+
+// PreferSecretMountsForBuildCredentialsRule is the constructive
+// companion to tally/ruby/secrets-in-arg-or-env: when a Ruby Dockerfile
+// declares a build-credential env var via ARG or ENV, this rule
+// surfaces the BuildKit secret-mount alternative as the supported way
+// to thread the credential through the build without leaking it into
+// image cache key data or layer history.
+type PreferSecretMountsForBuildCredentialsRule struct{}
+
+// NewPreferSecretMountsForBuildCredentialsRule creates the rule.
+func NewPreferSecretMountsForBuildCredentialsRule() *PreferSecretMountsForBuildCredentialsRule {
+	return &PreferSecretMountsForBuildCredentialsRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *PreferSecretMountsForBuildCredentialsRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            PreferSecretMountsForBuildCredentialsRuleCode,
+		Name:            "Prefer BuildKit secret mounts for build-time credentials",
+		Description:     "Build-time credential declared via ARG/ENV; prefer `RUN --mount=type=secret,...`",
+		DocURL:          rules.TallyDocURL(PreferSecretMountsForBuildCredentialsRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "security",
+		FixPriority:     preferSecretMountsForBuildCredentialsFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *PreferSecretMountsForBuildCredentialsRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	var violations []rules.Violation
+
+	for _, arg := range input.MetaArgs {
+		if v := r.checkArg(input, &arg, meta); v != nil {
+			violations = append(violations, *v)
+		}
+	}
+
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		for _, cmd := range stage.Commands {
+			switch c := cmd.(type) {
+			case *instructions.ArgCommand:
+				if v := r.checkArg(input, c, meta); v != nil {
+					violations = append(violations, *v)
+				}
+			case *instructions.EnvCommand:
+				violations = append(violations, r.checkEnv(input, c, meta)...)
+			}
+		}
+	}
+	return violations
+}
+
+func (r *PreferSecretMountsForBuildCredentialsRule) checkArg(
+	input rules.LintInput,
+	cmd *instructions.ArgCommand,
+	meta rules.RuleMetadata,
+) *rules.Violation {
+	if cmd == nil {
+		return nil
+	}
+	for _, arg := range cmd.Args {
+		secretID, ok := matchRubyBuildCredentialKey(arg.Key)
+		if !ok {
+			continue
+		}
+		loc := rules.NewLocationFromRanges(input.File, cmd.Location())
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(preferSecretMountsDetail(arg.Key, secretID, strings.ToUpper(command.Arg))).
+			WithSuggestedFix(buildSecretMountFix(arg.Key, secretID, meta.FixPriority))
+		return &v
+	}
+	return nil
+}
+
+func (r *PreferSecretMountsForBuildCredentialsRule) checkEnv(
+	input rules.LintInput,
+	cmd *instructions.EnvCommand,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	if cmd == nil {
+		return nil
+	}
+	var violations []rules.Violation
+	for _, kv := range cmd.Env {
+		secretID, ok := matchRubyBuildCredentialKey(kv.Key)
+		if !ok {
+			continue
+		}
+		loc := rules.NewLocationFromRanges(input.File, cmd.Location())
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(preferSecretMountsDetail(kv.Key, secretID, strings.ToUpper(command.Env))).
+			WithSuggestedFix(buildSecretMountFix(kv.Key, secretID, meta.FixPriority))
+		violations = append(violations, v)
+	}
+	return violations
+}
+
+// matchRubyBuildCredentialKey reports whether key is a recognized Ruby
+// build-credential env var, returning the canonical secret-mount id.
+//
+// Recognition order:
+//  1. Explicit map (well-known forms).
+//  2. BUNDLE_<HOST>__<TLD> pattern (Bundler's host-credential
+//     convention — host name with dots replaced by `__`).
+func matchRubyBuildCredentialKey(key string) (string, bool) {
+	if id, ok := rubyPrivateGemCredentialEnvKeys[key]; ok {
+		return id, true
+	}
+	if isBundlerHostCredentialKey(key) {
+		return strings.ToLower(key), true
+	}
+	return "", false
+}
+
+// isBundlerHostCredentialKey reports whether a key matches Bundler's
+// `BUNDLE_<HOST>__<TLD>` host-credential convention. Host names use
+// `__` (double underscore) for `.` (dot), so a real Bundler key has at
+// least one `__` separator.
+func isBundlerHostCredentialKey(key string) bool {
+	if !strings.HasPrefix(key, "BUNDLE_") {
+		return false
+	}
+	// Must have at least one `__` after the BUNDLE_ prefix to look like
+	// a host (dot-separated) credential.
+	rest := strings.TrimPrefix(key, "BUNDLE_")
+	return strings.Contains(rest, "__")
+}
+
+func preferSecretMountsDetail(envKey, secretID, instruction string) string {
+	return "`" + envKey + "` is a build-time credential; declaring it via " + instruction + " bakes the " +
+		"value into image history (`docker history --no-trunc <image>`) and into the build cache key " +
+		"data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of " +
+		"the RUN it's mounted into and never enters image content or cache key data: " +
+		"`RUN --mount=type=secret,id=" + secretID + ",env=" + envKey + " bundle install`."
+}
+
+// buildSecretMountFix emits a non-edit suggestion. The exact rewrite
+// depends on the user's CI/secret-injection mechanism, so the rule
+// can't auto-rewrite.
+func buildSecretMountFix(envKey, secretID string, priority int) *rules.SuggestedFix {
+	return &rules.SuggestedFix{
+		Description: "Replace ARG/ENV " + envKey + " with `RUN --mount=type=secret,id=" + secretID +
+			",env=" + envKey + " <command>`. Pass the secret value at build time via " +
+			"`docker buildx build --secret id=" + secretID + ",src=...`.",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: false,
+	}
+}
+
+func init() {
+	rules.Register(NewPreferSecretMountsForBuildCredentialsRule())
+}

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
@@ -112,15 +112,24 @@ func (r *PreferSecretMountsForBuildCredentialsRule) Check(input rules.LintInput)
 }
 
 // dockerfileHasRubyStage reports whether at least one stage in the
-// Dockerfile is Ruby-shaped — used to gate meta-ARG checks (which run
-// before any FROM and so can't be tied to a specific stage).
+// Dockerfile is Ruby-shaped AND would not be filtered out of the
+// per-stage scan — used to gate meta-ARG checks (which run before any
+// FROM and so can't be tied to a specific stage). Without this, a
+// Dockerfile that has only `dev`/`test` Ruby stages would still emit
+// meta-ARG findings even though every per-stage check would skip.
 func dockerfileHasRubyStage(input rules.LintInput) bool {
 	if input.Facts == nil {
 		return false
 	}
 	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
 		sf := input.Facts.Stage(stageIdx)
 		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
 			continue
 		}
 		if stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
@@ -203,18 +212,45 @@ func matchRubyBuildCredentialKey(key string) (string, bool) {
 	return "", false
 }
 
+// bundlerHostCredentialTLDs is the set of TLDs that, when they appear
+// as the trailing `__<TLD>` segment of a `BUNDLE_*` key, signal a
+// host-credential rather than a generic dotted config key.
+//
+// Bundler's `__` is overloaded — it encodes `.` for both
+// `BUNDLE_GITHUB__COM` (a credential) AND `BUNDLE_LOCAL__RACK` (a
+// config key for `local.rack`). Trailing-TLD discrimination is the
+// least bad heuristic without a registry of known config keys. We err
+// on the side of completeness and include the public-suffix TLDs
+// commonly seen on gem-host URLs.
+var bundlerHostCredentialTLDs = map[string]bool{
+	"COM": true,
+	"ORG": true,
+	"NET": true,
+	"IO":  true,
+	"DEV": true,
+	"CO":  true,
+	"AI":  true,
+}
+
 // isBundlerHostCredentialKey reports whether a key matches Bundler's
 // `BUNDLE_<HOST>__<TLD>` host-credential convention. Host names use
 // `__` (double underscore) for `.` (dot), so a real Bundler key has at
-// least one `__` separator.
+// least one `__` separator AND ends with a known TLD segment to
+// distinguish from configuration keys like `BUNDLE_LOCAL__RACK`
+// (Bundler's `local.rack` config).
 func isBundlerHostCredentialKey(key string) bool {
 	if !strings.HasPrefix(key, "BUNDLE_") {
 		return false
 	}
-	// Must have at least one `__` after the BUNDLE_ prefix to look like
-	// a host (dot-separated) credential.
 	rest := strings.TrimPrefix(key, "BUNDLE_")
-	return strings.Contains(rest, "__")
+	if !strings.Contains(rest, "__") {
+		return false
+	}
+	// The trailing `__<TLD>` segment must be a recognized public-suffix
+	// TLD. Take the last `__`-separated token.
+	idx := strings.LastIndex(rest, "__")
+	tld := rest[idx+2:]
+	return bundlerHostCredentialTLDs[tld]
 }
 
 func preferSecretMountsDetail(envKey, secretID, instruction string) string {

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
@@ -212,45 +212,43 @@ func matchRubyBuildCredentialKey(key string) (string, bool) {
 	return "", false
 }
 
-// bundlerHostCredentialTLDs is the set of TLDs that, when they appear
-// as the trailing `__<TLD>` segment of a `BUNDLE_*` key, signal a
-// host-credential rather than a generic dotted config key.
+// bundlerNonHostConfigPrefixes lists the `BUNDLE_<TOPIC>` prefixes
+// where Bundler uses `__` to encode dots in non-host config namespaces
+// (e.g. `BUNDLE_LOCAL__RACK` is the `local.rack` config, not a
+// credential for `local.rack`). Any `BUNDLE_<TOPIC>__*` key with a
+// topic in this list is a config key, not a host credential.
 //
-// Bundler's `__` is overloaded — it encodes `.` for both
-// `BUNDLE_GITHUB__COM` (a credential) AND `BUNDLE_LOCAL__RACK` (a
-// config key for `local.rack`). Trailing-TLD discrimination is the
-// least bad heuristic without a registry of known config keys. We err
-// on the side of completeness and include the public-suffix TLDs
-// commonly seen on gem-host URLs.
-var bundlerHostCredentialTLDs = map[string]bool{
-	"COM": true,
-	"ORG": true,
-	"NET": true,
-	"IO":  true,
-	"DEV": true,
-	"CO":  true,
-	"AI":  true,
+// Source: bundler/bundler config namespaces — the host-credential
+// path uses `BUNDLE_<HOST>__<TLD>` but a few `__`-encoded namespaces
+// describe gem identity rather than a host:
+//   - LOCAL: `local.<gem>` overrides for development paths
+//   - BUILD: `build.<gem>` per-gem build flags
+//
+// We err toward `true` for everything else (any `BUNDLE_*__*` not in
+// this list) — Bundler's host-credential surface is open-ended, so an
+// allowlist would miss valid public-suffix TLDs (`.co.uk`, `.de`,
+// `.com.br`, etc.).
+var bundlerNonHostConfigPrefixes = map[string]bool{
+	"LOCAL": true,
+	"BUILD": true,
 }
 
 // isBundlerHostCredentialKey reports whether a key matches Bundler's
 // `BUNDLE_<HOST>__<TLD>` host-credential convention. Host names use
 // `__` (double underscore) for `.` (dot), so a real Bundler key has at
-// least one `__` separator AND ends with a known TLD segment to
-// distinguish from configuration keys like `BUNDLE_LOCAL__RACK`
-// (Bundler's `local.rack` config).
+// least one `__` separator. We exclude a small denylist of known
+// non-host namespaces (`LOCAL`, `BUILD`) where `__` encodes a gem name
+// rather than a hostname dot.
 func isBundlerHostCredentialKey(key string) bool {
 	if !strings.HasPrefix(key, "BUNDLE_") {
 		return false
 	}
 	rest := strings.TrimPrefix(key, "BUNDLE_")
-	if !strings.Contains(rest, "__") {
+	first, _, hasSep := strings.Cut(rest, "__")
+	if !hasSep {
 		return false
 	}
-	// The trailing `__<TLD>` segment must be a recognized public-suffix
-	// TLD. Take the last `__`-separated token.
-	idx := strings.LastIndex(rest, "__")
-	tld := rest[idx+2:]
-	return bundlerHostCredentialTLDs[tld]
+	return !bundlerNonHostConfigPrefixes[first]
 }
 
 func preferSecretMountsDetail(envKey, secretID, instruction string) string {

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
@@ -219,18 +219,26 @@ func matchRubyBuildCredentialKey(key string) (string, bool) {
 // topic in this list is a config key, not a host credential.
 //
 // Source: bundler/bundler config namespaces — the host-credential
-// path uses `BUNDLE_<HOST>__<TLD>` but a few `__`-encoded namespaces
-// describe gem identity rather than a host:
+// path uses `BUNDLE_<HOST>__<TLD>` but several `__`-encoded namespaces
+// describe gem identity, paths, or other non-secret config:
 //   - LOCAL: `local.<gem>` overrides for development paths
 //   - BUILD: `build.<gem>` per-gem build flags
+//   - PATH:  `path.system` boolean and similar
+//   - GEM:   `gem.coc`/`gem.mit`/`gem.test`/etc. — gem-template flags
+//   - CACHE: `cache.all`/`cache.path` — cache config
+//   - DISABLE: `disable.foo` — feature disable flags
 //
 // We err toward `true` for everything else (any `BUNDLE_*__*` not in
 // this list) — Bundler's host-credential surface is open-ended, so an
 // allowlist would miss valid public-suffix TLDs (`.co.uk`, `.de`,
 // `.com.br`, etc.).
 var bundlerNonHostConfigPrefixes = map[string]bool{
-	"LOCAL": true,
-	"BUILD": true,
+	"LOCAL":   true,
+	"BUILD":   true,
+	"PATH":    true,
+	"GEM":     true,
+	"CACHE":   true,
+	"DISABLE": true,
 }
 
 // isBundlerHostCredentialKey reports whether a key matches Bundler's

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
 
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/semantic"
@@ -67,14 +68,22 @@ func (r *PreferSecretMountsForBuildCredentialsRule) Check(input rules.LintInput)
 
 	var violations []rules.Violation
 
-	for _, arg := range input.MetaArgs {
-		if v := r.checkArg(input, &arg, meta); v != nil {
-			violations = append(violations, *v)
+	// Meta-ARG (before any FROM) only counts when the Dockerfile has at
+	// least one Ruby-shaped stage — otherwise this is a generic
+	// Node.js/Python/etc. Dockerfile that happens to declare an env var
+	// with one of the names we recognize, and the rule's Ruby-specific
+	// recommendation doesn't apply.
+	if dockerfileHasRubyStage(input) {
+		for _, arg := range input.MetaArgs {
+			violations = append(violations, r.checkArg(input, &arg, meta)...)
 		}
 	}
 
 	for stageIdx, stage := range input.Stages {
 		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		if input.Facts == nil {
 			continue
 		}
 		sf := input.Facts.Stage(stageIdx)
@@ -84,12 +93,16 @@ func (r *PreferSecretMountsForBuildCredentialsRule) Check(input rules.LintInput)
 		if sf.BaseImageOS == semantic.BaseImageOSWindows {
 			continue
 		}
+		// Gate per-stage checks on the Ruby-shape signal so this rule's
+		// Ruby-specific recommendation doesn't fire on Node/Python/etc.
+		// Dockerfiles that happen to use one of the env-var names.
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
 		for _, cmd := range stage.Commands {
 			switch c := cmd.(type) {
 			case *instructions.ArgCommand:
-				if v := r.checkArg(input, c, meta); v != nil {
-					violations = append(violations, *v)
-				}
+				violations = append(violations, r.checkArg(input, c, meta)...)
 			case *instructions.EnvCommand:
 				violations = append(violations, r.checkEnv(input, c, meta)...)
 			}
@@ -98,27 +111,38 @@ func (r *PreferSecretMountsForBuildCredentialsRule) Check(input rules.LintInput)
 	return violations
 }
 
+// dockerfileHasRubyStage reports whether at least one stage in the
+// Dockerfile is Ruby-shaped — used to gate meta-ARG checks (which run
+// before any FROM and so can't be tied to a specific stage).
+func dockerfileHasRubyStage(input rules.LintInput) bool {
+	if input.Facts == nil {
+		return false
+	}
+	for stageIdx, stage := range input.Stages {
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *PreferSecretMountsForBuildCredentialsRule) checkArg(
 	input rules.LintInput,
 	cmd *instructions.ArgCommand,
 	meta rules.RuleMetadata,
-) *rules.Violation {
+) []rules.Violation {
 	if cmd == nil {
 		return nil
 	}
+	keys := make([]string, 0, len(cmd.Args))
 	for _, arg := range cmd.Args {
-		secretID, ok := matchRubyBuildCredentialKey(arg.Key)
-		if !ok {
-			continue
-		}
-		loc := rules.NewLocationFromRanges(input.File, cmd.Location())
-		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
-			WithDocURL(meta.DocURL).
-			WithDetail(preferSecretMountsDetail(arg.Key, secretID, strings.ToUpper(command.Arg))).
-			WithSuggestedFix(buildSecretMountFix(arg.Key, secretID, meta.FixPriority))
-		return &v
+		keys = append(keys, arg.Key)
 	}
-	return nil
+	return r.emitViolations(input, cmd.Location(), keys, strings.ToUpper(command.Arg), meta)
 }
 
 func (r *PreferSecretMountsForBuildCredentialsRule) checkEnv(
@@ -129,17 +153,34 @@ func (r *PreferSecretMountsForBuildCredentialsRule) checkEnv(
 	if cmd == nil {
 		return nil
 	}
-	var violations []rules.Violation
+	keys := make([]string, 0, len(cmd.Env))
 	for _, kv := range cmd.Env {
-		secretID, ok := matchRubyBuildCredentialKey(kv.Key)
+		keys = append(keys, kv.Key)
+	}
+	return r.emitViolations(input, cmd.Location(), keys, strings.ToUpper(command.Env), meta)
+}
+
+// emitViolations builds one violation per recognized credential env-var
+// key in keys. Common to both ARG and ENV — the only difference is the
+// instruction label that appears in the user-visible detail message.
+func (r *PreferSecretMountsForBuildCredentialsRule) emitViolations(
+	input rules.LintInput,
+	cmdLoc []parser.Range,
+	keys []string,
+	instruction string,
+	meta rules.RuleMetadata,
+) []rules.Violation {
+	var violations []rules.Violation
+	for _, key := range keys {
+		secretID, ok := matchRubyBuildCredentialKey(key)
 		if !ok {
 			continue
 		}
-		loc := rules.NewLocationFromRanges(input.File, cmd.Location())
+		loc := rules.NewLocationFromRanges(input.File, cmdLoc)
 		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
 			WithDocURL(meta.DocURL).
-			WithDetail(preferSecretMountsDetail(kv.Key, secretID, strings.ToUpper(command.Env))).
-			WithSuggestedFix(buildSecretMountFix(kv.Key, secretID, meta.FixPriority))
+			WithDetail(preferSecretMountsDetail(key, secretID, instruction)).
+			WithSuggestedFix(buildSecretMountFix(key, secretID, meta.FixPriority))
 		violations = append(violations, v)
 	}
 	return violations
@@ -181,7 +222,7 @@ func preferSecretMountsDetail(envKey, secretID, instruction string) string {
 		"value into image history (`docker history --no-trunc <image>`) and into the build cache key " +
 		"data. Pass it through a BuildKit secret mount instead — the secret exists for the duration of " +
 		"the RUN it's mounted into and never enters image content or cache key data: " +
-		"`RUN --mount=type=secret,id=" + secretID + ",env=" + envKey + " bundle install`."
+		"`RUN --mount=type=secret,id=" + secretID + ",env=" + envKey + " <command>`."
 }
 
 // buildSecretMountFix emits a non-edit suggestion. The exact rewrite

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
@@ -212,32 +212,24 @@ func matchRubyBuildCredentialKey(key string) (string, bool) {
 	return "", false
 }
 
-// commonHostCredentialTLDs is the set of TLDs that, when they appear
-// as the trailing `__<TLD>` segment of a `BUNDLE_*` key, signal a
-// host-credential. Bundler's `__` is overloaded: it encodes `.` for
-// both `BUNDLE_GITHUB__COM` (a credential for github.com) and
-// `BUNDLE_LOCAL__RACK` / `BUNDLE_PATH__SYSTEM` /
-// `BUNDLE_IGNORE_MESSAGES__HTTPARTY` (config keys with dotted names
-// where the trailing segment is a gem name, not a TLD).
+// bundlerNonHostConfigPrefixes lists the `BUNDLE_<TOPIC>` prefixes
+// where Bundler uses `__` to encode dots in non-host config namespaces.
+// Any `BUNDLE_<TOPIC>__*` key with a topic in this list is treated as
+// configuration, NOT a host credential — even if the trailing token
+// happens to look like a TLD (e.g. `BUNDLE_LOCAL__AI` for `local.ai`,
+// or `BUNDLE_BUILD__JEMALLOC__CO` for a hypothetical gem).
 //
-// Trailing-TLD discrimination is the most reliable heuristic without
-// hard-coding every Bundler config namespace (which keeps growing).
-// We cover:
-//   - the standard generic TLDs (com/org/net/io/dev/co/ai/edu/gov/info/biz)
-//   - all 2-letter ISO country code TLDs (handled separately by length+alphabetic check)
-var commonHostCredentialTLDs = map[string]bool{
-	"com":  true,
-	"org":  true,
-	"net":  true,
-	"io":   true,
-	"dev":  true,
-	"co":   true,
-	"ai":   true,
-	"edu":  true,
-	"gov":  true,
-	"info": true,
-	"biz":  true,
-	"app":  true,
+// Source: Bundler config reference. Captures every dotted namespace we
+// know of (the matcher is conservative — we'd rather miss a less-common
+// host pattern than emit a false-positive security finding).
+var bundlerNonHostConfigPrefixes = map[string]bool{
+	"LOCAL":           true,
+	"BUILD":           true,
+	"PATH":            true,
+	"GEM":             true,
+	"CACHE":           true,
+	"DISABLE":         true,
+	"IGNORE_MESSAGES": true,
 }
 
 // isBundlerHostCredentialKey reports whether a key matches Bundler's
@@ -246,37 +238,44 @@ var commonHostCredentialTLDs = map[string]bool{
 // least one `__` separator AND the trailing `__<TLD>` segment must
 // look like a TLD.
 //
-// Acceptance: trailing token is in the curated common-TLD list, OR is
-// a 2-letter all-alphabetic token (covers ISO country code TLDs like
-// `de`, `uk`, `jp`, `br`, etc.).
+// Acceptance is the AND of two checks:
 //
-// This positively identifies host credentials and naturally excludes
-// Bundler's many `__`-encoded config namespaces (`local.<gem>`,
-// `build.<gem>`, `path.system`, `gem.<flag>`, `cache.<flag>`,
-// `disable.<flag>`, `ignore_messages.<gem>`, …) without requiring an
-// ever-growing denylist.
+//  1. The leading topic (everything before the first `__`) is NOT one
+//     of Bundler's known dotted-config namespaces.
+//  2. The trailing `__<TLD>` segment is shaped like a TLD: a 2-6 char
+//     all-alphabetic token. This rejects `BUNDLE_<X>__<GEM_NAME>`
+//     (gem names tend to be longer and contain digits/underscores) and
+//     keeps acceptance broad for the long tail of legitimate TLDs
+//     (`de`/`uk`/`xyz`/`museum` aren't all in a curated allowlist).
+//
+// Combining both gates is what protects against false positives like
+// `BUNDLE_LOCAL__AI` (config; topic is `LOCAL`) without losing
+// coverage on legitimate credentials with less common TLDs.
 func isBundlerHostCredentialKey(key string) bool {
 	if !strings.HasPrefix(key, "BUNDLE_") {
 		return false
 	}
 	rest := strings.TrimPrefix(key, "BUNDLE_")
-	if !strings.Contains(rest, "__") {
+	first, _, hasSep := strings.Cut(rest, "__")
+	if !hasSep {
+		return false
+	}
+	if bundlerNonHostConfigPrefixes[first] {
 		return false
 	}
 	idx := strings.LastIndex(rest, "__")
-	tld := strings.ToLower(rest[idx+2:])
-	if commonHostCredentialTLDs[tld] {
-		return true
-	}
-	// 2-letter all-alphabetic ccTLD (e.g. `de`, `uk`, `jp`, `br`).
-	if len(tld) == 2 && isAllAlpha(tld) {
-		return true
-	}
-	return false
+	tld := rest[idx+2:]
+	return looksLikeTLD(tld)
 }
 
-// isAllAlpha reports whether s consists entirely of ASCII letters.
-func isAllAlpha(s string) bool {
+// looksLikeTLD reports whether s is shaped like a TLD: 2-6 chars,
+// all ASCII letters. Real TLDs span `aa`..`museum`; this filter rejects
+// gem names (which are typically longer or contain digits/underscores)
+// while accepting the long tail of legitimate TLDs.
+func looksLikeTLD(s string) bool {
+	if len(s) < 2 || len(s) > 6 {
+		return false
+	}
 	for i := range len(s) {
 		c := s[i]
 		isLower := c >= 'a' && c <= 'z'
@@ -285,7 +284,7 @@ func isAllAlpha(s string) bool {
 			return false
 		}
 	}
-	return s != ""
+	return true
 }
 
 func preferSecretMountsDetail(envKey, secretID, instruction string) string {

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials.go
@@ -212,51 +212,80 @@ func matchRubyBuildCredentialKey(key string) (string, bool) {
 	return "", false
 }
 
-// bundlerNonHostConfigPrefixes lists the `BUNDLE_<TOPIC>` prefixes
-// where Bundler uses `__` to encode dots in non-host config namespaces
-// (e.g. `BUNDLE_LOCAL__RACK` is the `local.rack` config, not a
-// credential for `local.rack`). Any `BUNDLE_<TOPIC>__*` key with a
-// topic in this list is a config key, not a host credential.
+// commonHostCredentialTLDs is the set of TLDs that, when they appear
+// as the trailing `__<TLD>` segment of a `BUNDLE_*` key, signal a
+// host-credential. Bundler's `__` is overloaded: it encodes `.` for
+// both `BUNDLE_GITHUB__COM` (a credential for github.com) and
+// `BUNDLE_LOCAL__RACK` / `BUNDLE_PATH__SYSTEM` /
+// `BUNDLE_IGNORE_MESSAGES__HTTPARTY` (config keys with dotted names
+// where the trailing segment is a gem name, not a TLD).
 //
-// Source: bundler/bundler config namespaces — the host-credential
-// path uses `BUNDLE_<HOST>__<TLD>` but several `__`-encoded namespaces
-// describe gem identity, paths, or other non-secret config:
-//   - LOCAL: `local.<gem>` overrides for development paths
-//   - BUILD: `build.<gem>` per-gem build flags
-//   - PATH:  `path.system` boolean and similar
-//   - GEM:   `gem.coc`/`gem.mit`/`gem.test`/etc. — gem-template flags
-//   - CACHE: `cache.all`/`cache.path` — cache config
-//   - DISABLE: `disable.foo` — feature disable flags
-//
-// We err toward `true` for everything else (any `BUNDLE_*__*` not in
-// this list) — Bundler's host-credential surface is open-ended, so an
-// allowlist would miss valid public-suffix TLDs (`.co.uk`, `.de`,
-// `.com.br`, etc.).
-var bundlerNonHostConfigPrefixes = map[string]bool{
-	"LOCAL":   true,
-	"BUILD":   true,
-	"PATH":    true,
-	"GEM":     true,
-	"CACHE":   true,
-	"DISABLE": true,
+// Trailing-TLD discrimination is the most reliable heuristic without
+// hard-coding every Bundler config namespace (which keeps growing).
+// We cover:
+//   - the standard generic TLDs (com/org/net/io/dev/co/ai/edu/gov/info/biz)
+//   - all 2-letter ISO country code TLDs (handled separately by length+alphabetic check)
+var commonHostCredentialTLDs = map[string]bool{
+	"com":  true,
+	"org":  true,
+	"net":  true,
+	"io":   true,
+	"dev":  true,
+	"co":   true,
+	"ai":   true,
+	"edu":  true,
+	"gov":  true,
+	"info": true,
+	"biz":  true,
+	"app":  true,
 }
 
 // isBundlerHostCredentialKey reports whether a key matches Bundler's
 // `BUNDLE_<HOST>__<TLD>` host-credential convention. Host names use
 // `__` (double underscore) for `.` (dot), so a real Bundler key has at
-// least one `__` separator. We exclude a small denylist of known
-// non-host namespaces (`LOCAL`, `BUILD`) where `__` encodes a gem name
-// rather than a hostname dot.
+// least one `__` separator AND the trailing `__<TLD>` segment must
+// look like a TLD.
+//
+// Acceptance: trailing token is in the curated common-TLD list, OR is
+// a 2-letter all-alphabetic token (covers ISO country code TLDs like
+// `de`, `uk`, `jp`, `br`, etc.).
+//
+// This positively identifies host credentials and naturally excludes
+// Bundler's many `__`-encoded config namespaces (`local.<gem>`,
+// `build.<gem>`, `path.system`, `gem.<flag>`, `cache.<flag>`,
+// `disable.<flag>`, `ignore_messages.<gem>`, …) without requiring an
+// ever-growing denylist.
 func isBundlerHostCredentialKey(key string) bool {
 	if !strings.HasPrefix(key, "BUNDLE_") {
 		return false
 	}
 	rest := strings.TrimPrefix(key, "BUNDLE_")
-	first, _, hasSep := strings.Cut(rest, "__")
-	if !hasSep {
+	if !strings.Contains(rest, "__") {
 		return false
 	}
-	return !bundlerNonHostConfigPrefixes[first]
+	idx := strings.LastIndex(rest, "__")
+	tld := strings.ToLower(rest[idx+2:])
+	if commonHostCredentialTLDs[tld] {
+		return true
+	}
+	// 2-letter all-alphabetic ccTLD (e.g. `de`, `uk`, `jp`, `br`).
+	if len(tld) == 2 && isAllAlpha(tld) {
+		return true
+	}
+	return false
+}
+
+// isAllAlpha reports whether s consists entirely of ASCII letters.
+func isAllAlpha(s string) bool {
+	for i := range len(s) {
+		c := s[i]
+		isLower := c >= 'a' && c <= 'z'
+		isUpper := c >= 'A' && c <= 'Z'
+		if !isLower && !isUpper {
+			return false
+		}
+	}
+	return s != ""
 }
 
 func preferSecretMountsDetail(envKey, secretID, instruction string) string {

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
@@ -188,6 +188,20 @@ ENV BUNDLE_IGNORE_MESSAGES__HTTPARTY=true
 			WantViolations: 0,
 		},
 		{
+			Name: "BUNDLE_LOCAL__AI is config (local.ai), not credential despite TLD-shaped suffix",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_LOCAL__AI=/path/to/ai-gem
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "BUNDLE_GEMS__ACME__MUSEUM triggers (less common TLD)",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_GEMS__ACME__MUSEUM="user:token"
+`,
+			WantViolations: 1,
+		},
+		{
 			Name: "BUNDLE_GEMS__ACME__CO__UK triggers (compound TLD)",
 			Content: `FROM ruby:3.3-slim
 ENV BUNDLE_GEMS__ACME__CO__UK="user:token"

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
@@ -130,5 +130,28 @@ RUN bundle install
 `,
 			WantViolations: 2,
 		},
+		// --- Bundler config-key disambiguation (codex P2) ---
+		{
+			Name: "BUNDLE_LOCAL__RACK is a config key (local.rack), not a credential",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_LOCAL__RACK=/path/to/rack
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "BUNDLE_GEMFURY__IO triggers (.io TLD)",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_GEMFURY__IO="user:token"
+`,
+			WantViolations: 1,
+		},
+		// --- Meta-ARG suppression honors per-stage filters (codex P2) ---
+		{
+			Name: "meta-ARG with only dev Ruby stage does not trigger",
+			Content: `ARG BUNDLE_GITHUB__COM
+FROM ruby:3.3-slim AS dev
+`,
+			WantViolations: 0,
+		},
 	})
 }

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
@@ -1,0 +1,101 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestPreferSecretMountsForBuildCredentialsRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewPreferSecretMountsForBuildCredentialsRule().Metadata()
+	if meta.Code != PreferSecretMountsForBuildCredentialsRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, PreferSecretMountsForBuildCredentialsRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "security" {
+		t.Errorf("Category = %q, want %q", meta.Category, "security")
+	}
+}
+
+func TestPreferSecretMountsForBuildCredentialsRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewPreferSecretMountsForBuildCredentialsRule(), []testutil.RuleTestCase{
+		// --- Violations: well-known credential env vars ---
+		{
+			Name: "ENV BUNDLE_GITHUB__COM triggers",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_GITHUB__COM="user:token"
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ARG BUNDLE_GITHUB__COM triggers",
+			Content: `FROM ruby:3.3-slim
+ARG BUNDLE_GITHUB__COM
+RUN bundle install
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ENV GEM_HOST_API_KEY triggers",
+			Content: `FROM ruby:3.3-slim
+ENV GEM_HOST_API_KEY="abc123"
+RUN gem push some.gem
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "ENV NPM_TOKEN triggers (used during yarn install for asset compile)",
+			Content: `FROM ruby:3.3-slim
+ENV NPM_TOKEN="abc123"
+RUN yarn install
+`,
+			WantViolations: 1,
+		},
+		// --- Violations: BUNDLE_<HOST>__<TLD> generic pattern ---
+		{
+			Name: "ARG BUNDLE_GEMS__MYCOMPANY__COM triggers (generic Bundler host pattern)",
+			Content: `FROM ruby:3.3-slim
+ARG BUNDLE_GEMS__MYCOMPANY__COM
+`,
+			WantViolations: 1,
+		},
+		// --- meta-ARG (before any FROM) ---
+		{
+			Name: "meta-ARG BUNDLE_GITHUB__COM triggers",
+			Content: `ARG BUNDLE_GITHUB__COM
+FROM ruby:3.3-slim
+`,
+			WantViolations: 1,
+		},
+		// --- Suppressions ---
+		{
+			Name: "non-credential ENV (BUNDLE_PATH) does not trigger (no host pattern)",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_PATH="/usr/local/bundle"
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Bundler ENV does not trigger",
+			Content: `FROM ruby:3.3-slim
+ENV RAILS_ENV="production"
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev stage skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+ENV BUNDLE_GITHUB__COM="user:token"
+`,
+			WantViolations: 0,
+		},
+	})
+}

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
@@ -97,5 +97,38 @@ ENV BUNDLE_GITHUB__COM="user:token"
 `,
 			WantViolations: 0,
 		},
+		// --- Ruby gate: non-Ruby Dockerfiles should not trigger ---
+		{
+			Name: "Node.js stage with NPM_TOKEN does not trigger (not a Ruby rule's concern)",
+			Content: `FROM node:20-slim
+ENV NPM_TOKEN="abc"
+RUN npm ci
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "non-Ruby stage with YARN_AUTH_TOKEN does not trigger",
+			Content: `FROM node:20-slim
+ARG YARN_AUTH_TOKEN
+RUN yarn install
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "meta-ARG without any Ruby stage does not trigger",
+			Content: `ARG BUNDLE_GITHUB__COM
+FROM node:20-slim
+`,
+			WantViolations: 0,
+		},
+		// --- Multiple ARG vars on a single line ---
+		{
+			Name: "ARG with multiple credential vars yields one violation per var",
+			Content: `FROM ruby:3.3-slim
+ARG BUNDLE_GITHUB__COM BUNDLE_GITLAB__COM
+RUN bundle install
+`,
+			WantViolations: 2,
+		},
 	})
 }

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
@@ -181,6 +181,13 @@ ENV BUNDLE_DISABLE__VERSION_CHECK=true
 			WantViolations: 0,
 		},
 		{
+			Name: "BUNDLE_IGNORE_MESSAGES__HTTPARTY is config, not a credential",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_IGNORE_MESSAGES__HTTPARTY=true
+`,
+			WantViolations: 0,
+		},
+		{
 			Name: "BUNDLE_GEMS__ACME__CO__UK triggers (compound TLD)",
 			Content: `FROM ruby:3.3-slim
 ENV BUNDLE_GEMS__ACME__CO__UK="user:token"

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
@@ -145,6 +145,27 @@ ENV BUNDLE_GEMFURY__IO="user:token"
 `,
 			WantViolations: 1,
 		},
+		{
+			Name: "BUNDLE_BUILD__NOKOGIRI is per-gem build flag, not a credential",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_BUILD__NOKOGIRI=--use-system-libraries
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "BUNDLE_GEMS__ACME__CO__UK triggers (compound TLD)",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_GEMS__ACME__CO__UK="user:token"
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "BUNDLE_PRIVATE__HOST__DE triggers (German TLD)",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_PRIVATE__HOST__DE="user:token"
+`,
+			WantViolations: 1,
+		},
 		// --- Meta-ARG suppression honors per-stage filters (codex P2) ---
 		{
 			Name: "meta-ARG with only dev Ruby stage does not trigger",

--- a/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
+++ b/internal/rules/tally/ruby/prefer_secret_mounts_for_build_credentials_test.go
@@ -153,6 +153,34 @@ ENV BUNDLE_BUILD__NOKOGIRI=--use-system-libraries
 			WantViolations: 0,
 		},
 		{
+			Name: "BUNDLE_PATH__SYSTEM is path.system config, not a credential",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_PATH__SYSTEM=true
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "BUNDLE_GEM__COC is gem-template flag, not a credential",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_GEM__COC=true
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "BUNDLE_CACHE__ALL is cache config, not a credential",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_CACHE__ALL=true
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "BUNDLE_DISABLE__VERSION_CHECK is feature flag, not a credential",
+			Content: `FROM ruby:3.3-slim
+ENV BUNDLE_DISABLE__VERSION_CHECK=true
+`,
+			WantViolations: 0,
+		},
+		{
 			Name: "BUNDLE_GEMS__ACME__CO__UK triggers (compound TLD)",
 			Content: `FROM ruby:3.3-slim
 ENV BUNDLE_GEMS__ACME__CO__UK="user:token"


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/prefer-secret-mounts-for-build-credentials`](https://tally.wharflab.com/rules/tally/ruby/prefer-secret-mounts-for-build-credentials/) — Section 4.4 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

Constructive companion to [`tally/ruby/secrets-in-arg-or-env`](https://tally.wharflab.com/rules/tally/ruby/secrets-in-arg-or-env/) (PR #678). Fires at info severity when ARG/ENV declares a Ruby-ecosystem build-time credential, pointing the user at BuildKit secret mounts.

- **Coverage:** `BUNDLE_GITHUB__COM` / `BUNDLE_BITBUCKET__ORG` / `BUNDLE_GITLAB__COM` (well-known Bundler hosts), `BUNDLE_<HOST>__<TLD>` (generic Bundler host pattern), `GEM_HOST_API_KEY` (RubyGems push), `NPM_TOKEN` / `YARN_AUTH_TOKEN` (used during `assets:precompile` for private npm packages).
- **Detection:** triggers on both ARG and ENV, including meta-ARG (before any FROM).
- **Suppressions:** dev/test/ci stages, non-Ruby, Windows. Non-credential `BUNDLE_*` vars (e.g. `BUNDLE_PATH`) don't match the host pattern.
- **Auto-fix:** `FixSuggestion` (no-edit). Description names the canonical `RUN --mount=type=secret,id=<id>,env=<VAR>` form with a suggested `secret_id` (case-lowered env-var name).

Corpus uptake: 1 of 196 Dockerfiles use `RUN --mount=type=secret` (`basecamp/fizzy/saas` is the textbook example).

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint fixture: `internal/integration/fixtures/lint/ruby-prefer-secret-mounts-for-build-credentials/`