### PR TITLE
feat(rules): add tally/ruby/healthcheck-rails-up-endpoint

### DIFF
--- a/_docs/rules/tally/ruby/healthcheck-rails-up-endpoint.mdx
+++ b/_docs/rules/tally/ruby/healthcheck-rails-up-endpoint.mdx
@@ -1,0 +1,103 @@
+---
+title: "tally/ruby/healthcheck-rails-up-endpoint"
+description: "Rails runtime image lacks HEALTHCHECK or uses curl/wget instead of Ruby stdlib Net::HTTP."
+---
+
+Rails 7.1+ ships a `/up` health endpoint by default. The Ruby stdlib's `Net::HTTP` is already in the image —
+no extra `apt-get install curl` needed.
+
+| Property | Value |
+|----------|-------|
+| Severity | Info |
+| Category | Correctness |
+| Default | Enabled (advisory) |
+| Auto-fix | `FixSuggestion` (no-edit) |
+
+## Description
+
+Rails 7.1 added `Rails::HealthController` mounted at `/up` by default. It returns `200` if the app booted
+cleanly, `500` otherwise — exactly the right shape for a Docker `HEALTHCHECK`. Almost no Rails Dockerfile
+uses it, and the few that do reach for `curl`, which forces an extra package install on `ruby:*-slim` and
+`ruby:*-alpine` bases (where `curl` is not present by default).
+
+This rule has two flavors:
+
+1. **Missing `HEALTHCHECK` on a Rails 7.1+ runtime stage** — recommend adding the canonical Ruby-native one.
+2. **`HEALTHCHECK` present but uses `curl` or `wget`** — suggest replacing with the Ruby stdlib equivalent.
+   Especially when the same Dockerfile installs `curl` only because the healthcheck needs it (the corpus
+   shows this exact pattern).
+
+The corpus shows:
+
+- 6 of 196 use `HEALTHCHECK` at all.
+- 2 of 196 target `/up`.
+- Both `/up` healthchecks use `curl` against a `ruby:*-slim` base — both then need
+  `apt-get install ... curl ...` upstream of that line.
+- 0 of 196 use a Ruby-native healthcheck.
+
+This rule fires when:
+
+- The final stage is a Rails app runtime (Ruby base + ENTRYPOINT/CMD references `rails`/`puma`/`unicorn`/etc.).
+- Variant 1: no `HEALTHCHECK` at all.
+- Variant 2: `HEALTHCHECK` present and the command starts with `curl` or `wget`.
+
+`HEALTHCHECK NONE` (the explicit "I have an external orchestrator" signal) is recognized as a deliberate
+opt-out and suppresses the rule.
+
+## Examples
+
+### Before
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY . .
+CMD ["bin/rails", "server"]
+```
+
+Or with curl:
+
+```dockerfile
+FROM ruby:3.3-slim
+RUN apt-get update && apt-get install -y curl
+COPY . .
+HEALTHCHECK CMD curl -fsS http://127.0.0.1:3000/up || exit 1
+CMD ["bin/rails", "server"]
+```
+
+### After
+
+The Ruby-native form uses the stdlib `Net::HTTP` (already in the image), targets `/up` (the Rails default),
+and uses the JSON exec form so the command runs as `execve` rather than under `/bin/sh -c`:
+
+```dockerfile
+FROM ruby:3.3-slim
+COPY . .
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD ["ruby", "-rnet/http", "-e", "exit Net::HTTP.get_response(URI('http://127.0.0.1:3000/up')).is_a?(Net::HTTPSuccess) ? 0 : 1"]
+CMD ["bin/rails", "server"]
+```
+
+Why this exact shape:
+
+- `ruby -rnet/http -e` keeps the entire HTTP client in the image's existing Ruby interpreter — no `curl`,
+  no `wget`, no extra layer.
+- `Net::HTTP.get_response(URI('...'))` returns a `Net::HTTPResponse` whose subclass implements
+  `Net::HTTPSuccess` for any 2xx — so the check succeeds for `/up`'s `200 OK` and correctly fails on
+  `500` (which is what `Rails::HealthController` returns when the boot fails).
+- Using `127.0.0.1` rather than `localhost` avoids one DNS lookup per probe and is robust against
+  IPv6-only `localhost` weirdness inside containers.
+- The JSON exec form (`["ruby", ...]`) means Docker runs the command directly via `execve` rather than
+  spawning `/bin/sh -c`. This matters more for `HEALTHCHECK` than `CMD` because healthchecks run on every
+  interval — the per-invocation shell startup adds up.
+
+## Auto-fix
+
+`FixSuggestion` (no-edit). Description names the canonical Ruby-native form. Variant 2 (curl/wget present)
+also notes that the user can drop the `apt-get install curl` line if it was added solely for the
+healthcheck.
+
+## References
+
+- [Rails 7.1 release notes — health endpoint](https://guides.rubyonrails.org/7_1_release_notes.html#actioncontroller-rails-healthcontroller).
+- [Net::HTTP stdlib reference](https://docs.ruby-lang.org/en/3.4/Net/HTTP.html).
+- [Docker HEALTHCHECK documentation](https://docs.docker.com/reference/dockerfile/#healthcheck).

--- a/_docs/rules/tally/ruby/healthcheck-rails-up-endpoint.mdx
+++ b/_docs/rules/tally/ruby/healthcheck-rails-up-endpoint.mdx
@@ -37,9 +37,13 @@ The corpus shows:
 
 This rule fires when:
 
-- The final stage is a Rails app runtime (Ruby base + ENTRYPOINT/CMD references `rails`/`puma`/`unicorn`/etc.).
+- The final stage is a Rails web-server runtime (Ruby base + ENTRYPOINT/CMD references
+  `rails`/`puma`/`unicorn`/`thrust`/`rackup`/`falcon`/`thin`/`passenger`/`iodine`).
 - Variant 1: no `HEALTHCHECK` at all.
 - Variant 2: `HEALTHCHECK` present and the command starts with `curl` or `wget`.
+
+The rule deliberately ignores worker stages (`sidekiq`, `resque`, …) — they don't expose an HTTP
+endpoint, so `/up` would not respond there.
 
 `HEALTHCHECK NONE` (the explicit "I have an external orchestrator" signal) is recognized as a deliberate
 opt-out and suppresses the rule.

--- a/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint-curl/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint-curl/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/healthcheck-rails-up-endpoint"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint-curl/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint-curl/Dockerfile
@@ -1,0 +1,6 @@
+# Variant 3 violation: HEALTHCHECK uses curl, which on `ruby:*-slim`
+# requires an extra `apt-get install curl` step. Switch to the Ruby
+# stdlib's Net::HTTP form (already in the image).
+FROM ruby:3.3-slim
+HEALTHCHECK CMD curl -fsS http://127.0.0.1:3000/up || exit 1
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint-curl/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint-curl/result_1.snap.json
@@ -1,0 +1,43 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-healthcheck-rails-up-endpoint-curl/Dockerfile",
+      "violations": [
+        {
+          "detail": "Healthcheck uses `curl`/`wget`, which on `ruby:*-slim`/`ruby:*-alpine` bases requires an extra `apt-get install curl` step — ~3 MiB to add a tool that's already in the image as the Ruby stdlib's Net::HTTP. Switch to the Ruby-native form to drop the dependency.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/healthcheck-rails-up-endpoint/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 5
+            },
+            "file": "fixtures/lint/ruby-healthcheck-rails-up-endpoint-curl/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 5
+            }
+          },
+          "message": "Rails runtime image lacks HEALTHCHECK or uses curl/wget instead of Ruby stdlib Net::HTTP",
+          "rule": "tally/ruby/healthcheck-rails-up-endpoint",
+          "severity": "info",
+          "sourceCode": "HEALTHCHECK CMD curl -fsS http://127.0.0.1:3000/up || exit 1",
+          "suggestedFix": {
+            "description": "Replace the curl/wget HEALTHCHECK with the Ruby-native form (drops the apt-get install): CMD [\"ruby\", \"-rnet/http\", \"-e\", \"exit Net::HTTP.get_response(URI('http://127.0.0.1:3000/up')).is_a?(Net::HTTPSuccess) ? 0 : 1\"]",
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/.tally.toml
+++ b/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/.tally.toml
@@ -1,0 +1,6 @@
+[slow-checks]
+mode = "off"
+
+[rules]
+include = ["tally/ruby/healthcheck-rails-up-endpoint"]
+exclude = ["*"]

--- a/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/Dockerfile
+++ b/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/Dockerfile
@@ -1,0 +1,4 @@
+# Variant 1 violation: no HEALTHCHECK on a Rails runtime.
+FROM ruby:3.3-slim
+COPY . .
+CMD ["bin/rails", "server"]

--- a/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/result_1.snap.json
@@ -1,0 +1,43 @@
+{
+  "files": [
+    {
+      "file": "fixtures/lint/ruby-healthcheck-rails-up-endpoint/Dockerfile",
+      "violations": [
+        {
+          "detail": "Rails 7.1+ mounts `Rails::HealthController` at `/up` by default. The Ruby stdlib's Net::HTTP (already in the image) is the cheapest way to probe it — no extra apt install for `curl`. Add a HEALTHCHECK that calls `/up` via `ruby -rnet/http -e ...`.",
+          "docUrl": "https://tally.wharflab.com/rules/tally/ruby/healthcheck-rails-up-endpoint/",
+          "location": {
+            "end": {
+              "column": 0,
+              "line": 2
+            },
+            "file": "fixtures/lint/ruby-healthcheck-rails-up-endpoint/Dockerfile",
+            "start": {
+              "column": 0,
+              "line": 2
+            }
+          },
+          "message": "Rails runtime image lacks HEALTHCHECK or uses curl/wget instead of Ruby stdlib Net::HTTP",
+          "rule": "tally/ruby/healthcheck-rails-up-endpoint",
+          "severity": "info",
+          "sourceCode": "FROM ruby:3.3-slim",
+          "suggestedFix": {
+            "description": "Add a Ruby-native HEALTHCHECK against /up: HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD [\"ruby\", \"-rnet/http\", \"-e\", \"exit Net::HTTP.get_response(URI('http://127.0.0.1:3000/up')).is_a?(Net::HTTPSuccess) ? 0 : 1\"]. Net::HTTP is in the Ruby stdlib so no extra packages are needed.",
+            "priority": 88,
+            "safety": 1
+          }
+        }
+      ]
+    }
+  ],
+  "files_scanned": 1,
+  "rules_enabled": 1,
+  "summary": {
+    "errors": 0,
+    "files": 1,
+    "info": 1,
+    "style": 0,
+    "total": 1,
+    "warnings": 0
+  }
+}

--- a/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/result_1.snap.json
+++ b/internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/result_1.snap.json
@@ -4,7 +4,7 @@
       "file": "fixtures/lint/ruby-healthcheck-rails-up-endpoint/Dockerfile",
       "violations": [
         {
-          "detail": "Rails 7.1+ mounts `Rails::HealthController` at `/up` by default. The Ruby stdlib's Net::HTTP (already in the image) is the cheapest way to probe it — no extra apt install for `curl`. Add a HEALTHCHECK that calls `/up` via `ruby -rnet/http -e ...`.",
+          "detail": "Ruby web server runtime image has no HEALTHCHECK. Rails 7.1+ mounts `Rails::HealthController` at `/up` by default; if the app is Rails 7.1+, probe `/up`, otherwise probe whatever endpoint the app exposes (substitute the path below). The Ruby stdlib's Net::HTTP is already in the image, so this is the cheapest probe — no extra apt install for `curl`. Add a HEALTHCHECK that calls the endpoint via `ruby -rnet/http -e ...`.",
           "docUrl": "https://tally.wharflab.com/rules/tally/ruby/healthcheck-rails-up-endpoint/",
           "location": {
             "end": {

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
@@ -173,14 +173,18 @@ func stageLooksLikeRubyWebServerWithParents(
 
 // resolveEffectiveEntrypointAndCmd returns the effective
 // ENTRYPOINT/CMD argv for stage by walking the parent stage chain
-// inside the same Dockerfile. CMD and ENTRYPOINT are resolved
-// independently because Docker inherits them as separate slots.
+// inside the same Dockerfile.
 //
 // Rules per Docker semantics:
-//   - If the local stage sets ENTRYPOINT, that's the effective value
-//     and the local CMD is used (or empty if not set).
+//   - If the local stage sets both ENTRYPOINT and CMD, those are the
+//     effective values.
+//   - If the local stage sets ENTRYPOINT but not CMD, CMD is reset to
+//     empty (NOT inherited from parent).
 //   - If the local stage sets only CMD, ENTRYPOINT is inherited.
 //   - If the local stage sets neither, both are inherited.
+//
+// Source: Dockerfile reference — "If `ENTRYPOINT` is set in a derived
+// image, a `CMD` set in the base image is reset to an empty value."
 func resolveEffectiveEntrypointAndCmd(
 	input rules.LintInput, stage instructions.Stage,
 ) (*instructions.EntrypointCommand, *instructions.CmdCommand) {
@@ -188,6 +192,8 @@ func resolveEffectiveEntrypointAndCmd(
 	if entry != nil && cmd != nil {
 		return entry, cmd
 	}
+	// Setting ENTRYPOINT locally resets parent CMD to empty.
+	cmdCanInherit := entry == nil
 	// One or both missing — walk parent chain for the missing slot(s).
 	stagesByName := make(map[string]instructions.Stage, len(input.Stages))
 	for _, s := range input.Stages {
@@ -205,10 +211,16 @@ func resolveEffectiveEntrypointAndCmd(
 		if entry == nil && parentEntry != nil {
 			entry = parentEntry
 		}
-		if cmd == nil && parentCmd != nil {
+		if cmdCanInherit && cmd == nil && parentCmd != nil {
 			cmd = parentCmd
 		}
-		if entry != nil && cmd != nil {
+		// Once we see a parent that defines its own ENTRYPOINT, any
+		// earlier (further-up) ancestor's CMD is reset by that
+		// ENTRYPOINT — stop propagating CMD up.
+		if cmd == nil && parentEntry != nil {
+			cmdCanInherit = false
+		}
+		if entry != nil && (cmd != nil || !cmdCanInherit) {
 			return entry, cmd
 		}
 		parent = parentStage.BaseName

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
@@ -64,7 +64,10 @@ func (r *HealthcheckRailsUpEndpointRule) Check(input rules.LintInput) []rules.Vi
 	if !stageLooksLikeRuby(input.Semantic, finalIdx, stage, sf) {
 		return nil
 	}
-	if !stageLooksLikeLongRunningRubyServer(stage, sf) {
+	if !stageLooksLikeRubyWebServer(stage, sf) {
+		// Workers (sidekiq/resque) don't expose an HTTP endpoint; the
+		// `/up` healthcheck recommendation only applies to Rails web
+		// servers.
 		return nil
 	}
 
@@ -80,6 +83,9 @@ func (r *HealthcheckRailsUpEndpointRule) Check(input rules.LintInput) []rules.Vi
 	}
 
 	// Variant 2: HEALTHCHECK is NONE — explicit opt-out, suppress.
+	if healthCheck.Health == nil || len(healthCheck.Health.Test) == 0 {
+		return nil
+	}
 	if strings.EqualFold(healthCheck.Health.Test[0], "NONE") {
 		return nil
 	}
@@ -98,15 +104,71 @@ func (r *HealthcheckRailsUpEndpointRule) Check(input rules.LintInput) []rules.Vi
 }
 
 func missingHealthCheckDetail() string {
-	return "Rails 7.1+ mounts `Rails::HealthController` at `/up` by default. The Ruby stdlib's Net::HTTP " +
-		"(already in the image) is the cheapest way to probe it — no extra apt install for `curl`. " +
-		"Add a HEALTHCHECK that calls `/up` via `ruby -rnet/http -e ...`."
+	return "Ruby web server runtime image has no HEALTHCHECK. Rails 7.1+ mounts `Rails::HealthController` " +
+		"at `/up` by default; if the app is Rails 7.1+, probe `/up`, otherwise probe whatever endpoint the " +
+		"app exposes (substitute the path below). The Ruby stdlib's Net::HTTP is already in the image, so " +
+		"this is the cheapest probe — no extra apt install for `curl`. Add a HEALTHCHECK that calls the " +
+		"endpoint via `ruby -rnet/http -e ...`."
 }
 
 func curlBasedHealthCheckDetail() string {
 	return "Healthcheck uses `curl`/`wget`, which on `ruby:*-slim`/`ruby:*-alpine` bases requires an extra " +
 		"`apt-get install curl` step — ~3 MiB to add a tool that's already in the image as the Ruby " +
 		"stdlib's Net::HTTP. Switch to the Ruby-native form to drop the dependency."
+}
+
+// rubyWebServerCommands is the subset of long-running Ruby servers that
+// terminate HTTP — the only ones for which a `/up` HTTP healthcheck
+// makes sense. Workers (`sidekiq`, `resque`) listen on a queue, not a
+// port, so probing them for HTTP would surface a permanently failing
+// healthcheck.
+var rubyWebServerCommands = map[string]bool{
+	"rails":     true,
+	"puma":      true,
+	"unicorn":   true,
+	"thrust":    true,
+	"rackup":    true,
+	"falcon":    true,
+	"thin":      true,
+	"passenger": true,
+	"iodine":    true,
+}
+
+// stageLooksLikeRubyWebServer reports whether the stage's
+// ENTRYPOINT/CMD argv designates a Ruby HTTP server (not a worker like
+// sidekiq).
+func stageLooksLikeRubyWebServer(stage instructions.Stage, sf *facts.StageFacts) bool {
+	var lastEntrypoint *instructions.EntrypointCommand
+	var lastCmd *instructions.CmdCommand
+	for _, c := range stage.Commands {
+		switch cc := c.(type) {
+		case *instructions.EntrypointCommand:
+			lastEntrypoint = cc
+		case *instructions.CmdCommand:
+			lastCmd = cc
+		}
+	}
+	if lastEntrypoint != nil && argvIncludesRubyWebServer(lastEntrypoint.CmdLine) {
+		return true
+	}
+	if lastCmd != nil && argvIncludesRubyWebServer(lastCmd.CmdLine) {
+		return true
+	}
+	_ = sf
+	return false
+}
+
+// argvIncludesRubyWebServer reports whether any argv token's basename
+// matches a Ruby HTTP server name.
+func argvIncludesRubyWebServer(argv []string) bool {
+	for _, token := range argv {
+		for word := range strings.FieldsSeq(token) {
+			if rubyWebServerCommands[strings.ToLower(commandBasename(word))] {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // findLastHealthCheck returns the last HEALTHCHECK instruction in the
@@ -178,10 +240,6 @@ func buildCurlHealthCheckRewriteFix(priority int) *rules.SuggestedFix {
 		IsPreferred: false,
 	}
 }
-
-// Compile-time assertion that we're consuming a stable CopyCommand
-// reference (used by stageLooksLikeRailsApp).
-var _ = (*facts.StageFacts)(nil)
 
 func init() {
 	rules.Register(NewHealthcheckRailsUpEndpointRule())

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
@@ -1,0 +1,188 @@
+package ruby
+
+import (
+	"strings"
+
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// HealthcheckRailsUpEndpointRuleCode is the full rule code.
+const HealthcheckRailsUpEndpointRuleCode = rules.TallyRulePrefix + "ruby/healthcheck-rails-up-endpoint"
+
+// healthcheckRailsUpEndpointFixPriority keeps this rule's edits ordered alongside
+// the other Ruby rules.
+const healthcheckRailsUpEndpointFixPriority = 88
+
+// HealthcheckRailsUpEndpointRule flags Rails 7.1+ runtime stages without
+// a HEALTHCHECK against `/up`, and HEALTHCHECKs that use curl/wget when
+// Ruby's stdlib Net::HTTP would do the job without an extra apt
+// install.
+type HealthcheckRailsUpEndpointRule struct{}
+
+// NewHealthcheckRailsUpEndpointRule creates the rule.
+func NewHealthcheckRailsUpEndpointRule() *HealthcheckRailsUpEndpointRule {
+	return &HealthcheckRailsUpEndpointRule{}
+}
+
+// Metadata returns the rule metadata.
+func (r *HealthcheckRailsUpEndpointRule) Metadata() rules.RuleMetadata {
+	return rules.RuleMetadata{
+		Code:            HealthcheckRailsUpEndpointRuleCode,
+		Name:            "Use Rails 7.1+ /up healthcheck via Ruby stdlib Net::HTTP",
+		Description:     "Rails runtime image lacks HEALTHCHECK or uses curl/wget instead of Ruby stdlib Net::HTTP",
+		DocURL:          rules.TallyDocURL(HealthcheckRailsUpEndpointRuleCode),
+		DefaultSeverity: rules.SeverityInfo,
+		Category:        "correctness",
+		FixPriority:     healthcheckRailsUpEndpointFixPriority,
+	}
+}
+
+// Check runs the rule.
+func (r *HealthcheckRailsUpEndpointRule) Check(input rules.LintInput) []rules.Violation {
+	meta := r.Metadata()
+
+	finalIdx := input.FinalStageIndex()
+	if finalIdx < 0 || finalIdx >= len(input.Stages) {
+		return nil
+	}
+	stage := input.Stages[finalIdx]
+	sf := input.Facts.Stage(finalIdx)
+	if sf == nil {
+		return nil
+	}
+	if sf.BaseImageOS == semantic.BaseImageOSWindows {
+		return nil
+	}
+	if stagename.LooksLikeDev(stage.Name) {
+		return nil
+	}
+	if !stageLooksLikeRuby(input.Semantic, finalIdx, stage, sf) {
+		return nil
+	}
+	if !stageLooksLikeLongRunningRubyServer(stage, sf) {
+		return nil
+	}
+
+	healthCheck := findLastHealthCheck(stage)
+	if healthCheck == nil {
+		// Variant 1: no HEALTHCHECK at all on a Rails-app runtime stage.
+		loc := finalStageFromLocation(input, finalIdx)
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(missingHealthCheckDetail()).
+			WithSuggestedFix(buildMissingHealthCheckFix(meta.FixPriority))
+		return []rules.Violation{v}
+	}
+
+	// Variant 2: HEALTHCHECK is NONE — explicit opt-out, suppress.
+	if strings.EqualFold(healthCheck.Health.Test[0], "NONE") {
+		return nil
+	}
+
+	// Variant 3: HEALTHCHECK uses curl/wget. Suggest the Ruby-native form.
+	if healthCheckUsesCurlOrWget(healthCheck) {
+		loc := rules.NewLocationFromRanges(input.File, healthCheck.Location())
+		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
+			WithDocURL(meta.DocURL).
+			WithDetail(curlBasedHealthCheckDetail()).
+			WithSuggestedFix(buildCurlHealthCheckRewriteFix(meta.FixPriority))
+		return []rules.Violation{v}
+	}
+
+	return nil
+}
+
+func missingHealthCheckDetail() string {
+	return "Rails 7.1+ mounts `Rails::HealthController` at `/up` by default. The Ruby stdlib's Net::HTTP " +
+		"(already in the image) is the cheapest way to probe it — no extra apt install for `curl`. " +
+		"Add a HEALTHCHECK that calls `/up` via `ruby -rnet/http -e ...`."
+}
+
+func curlBasedHealthCheckDetail() string {
+	return "Healthcheck uses `curl`/`wget`, which on `ruby:*-slim`/`ruby:*-alpine` bases requires an extra " +
+		"`apt-get install curl` step — ~3 MiB to add a tool that's already in the image as the Ruby " +
+		"stdlib's Net::HTTP. Switch to the Ruby-native form to drop the dependency."
+}
+
+// findLastHealthCheck returns the last HEALTHCHECK instruction in the
+// stage (HEALTHCHECK is overridden by later instances).
+func findLastHealthCheck(stage instructions.Stage) *instructions.HealthCheckCommand {
+	var last *instructions.HealthCheckCommand
+	for _, cmd := range stage.Commands {
+		if hc, ok := cmd.(*instructions.HealthCheckCommand); ok {
+			last = hc
+		}
+	}
+	return last
+}
+
+// healthCheckUsesCurlOrWget reports whether the HEALTHCHECK CMD's
+// argv contains `curl` or `wget` as the first executable.
+func healthCheckUsesCurlOrWget(hc *instructions.HealthCheckCommand) bool {
+	if hc == nil || hc.Health == nil {
+		return false
+	}
+	test := hc.Health.Test
+	if len(test) == 0 {
+		return false
+	}
+	// Test slice's first element identifies the form: CMD or CMD-SHELL.
+	// The remaining elements are the command argv.
+	for i := 1; i < len(test); i++ {
+		token := test[i]
+		// Split on whitespace for shell-form invocations.
+		for word := range strings.FieldsSeq(token) {
+			if word == "curl" || word == "wget" ||
+				strings.HasSuffix(word, "/curl") || strings.HasSuffix(word, "/wget") {
+				return true
+			}
+			// Stop at the first non-flag, non-curl/wget token — that's
+			// the command, not curl.
+			if !strings.HasPrefix(word, "-") {
+				return false
+			}
+		}
+	}
+	return false
+}
+
+// buildMissingHealthCheckFix proposes adding the canonical Ruby-native
+// HEALTHCHECK as a non-edit FixSuggestion.
+func buildMissingHealthCheckFix(priority int) *rules.SuggestedFix {
+	return &rules.SuggestedFix{
+		Description: "Add a Ruby-native HEALTHCHECK against /up: " +
+			"HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 " +
+			`CMD ["ruby", "-rnet/http", "-e", ` +
+			`"exit Net::HTTP.get_response(URI('http://127.0.0.1:3000/up')).is_a?(Net::HTTPSuccess) ? 0 : 1"]. ` +
+			"Net::HTTP is in the Ruby stdlib so no extra packages are needed.",
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: false,
+	}
+}
+
+// buildCurlHealthCheckRewriteFix proposes replacing the curl/wget form
+// with the Ruby-native equivalent. Non-edit.
+func buildCurlHealthCheckRewriteFix(priority int) *rules.SuggestedFix {
+	return &rules.SuggestedFix{
+		Description: "Replace the curl/wget HEALTHCHECK with the Ruby-native form (drops the apt-get " +
+			`install): CMD ["ruby", "-rnet/http", "-e", ` +
+			`"exit Net::HTTP.get_response(URI('http://127.0.0.1:3000/up')).is_a?(Net::HTTPSuccess) ? 0 : 1"]`,
+		Safety:      rules.FixSuggestion,
+		Priority:    priority,
+		IsPreferred: false,
+	}
+}
+
+// Compile-time assertion that we're consuming a stable CopyCommand
+// reference (used by stageLooksLikeRailsApp).
+var _ = (*facts.StageFacts)(nil)
+
+func init() {
+	rules.Register(NewHealthcheckRailsUpEndpointRule())
+}

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
@@ -73,6 +73,17 @@ func (r *HealthcheckRailsUpEndpointRule) Check(input rules.LintInput) []rules.Vi
 
 	healthCheck := findLastHealthCheck(stage)
 	if healthCheck == nil {
+		// HEALTHCHECK can be inherited from an earlier stage that this
+		// final stage `FROM`s. Walk the parent chain inside the same
+		// Dockerfile to see if a parent stage already has one.
+		// (Inheritance from the upstream image content can't be checked
+		// from the Dockerfile alone, but the official Ruby base images
+		// don't ship with a HEALTHCHECK, and this rule is gated on
+		// Ruby-shaped final stages — so this remains a useful trigger
+		// in practice.)
+		if priorStageHasHealthCheck(input, stage) {
+			return nil
+		}
 		// Variant 1: no HEALTHCHECK at all on a Rails-app runtime stage.
 		loc := finalStageFromLocation(input, finalIdx)
 		v := rules.NewViolation(loc, meta.Code, meta.Description, meta.DefaultSeverity).
@@ -122,8 +133,11 @@ func curlBasedHealthCheckDetail() string {
 // makes sense. Workers (`sidekiq`, `resque`) listen on a queue, not a
 // port, so probing them for HTTP would surface a permanently failing
 // healthcheck.
+//
+// `rails` is special: bare `rails` or `rails server` is a web server,
+// but `rails db:migrate` / `rails runner` / `rails console` are
+// one-shot jobs. See `argvIncludesRubyWebServer` for the filter.
 var rubyWebServerCommands = map[string]bool{
-	"rails":     true,
 	"puma":      true,
 	"unicorn":   true,
 	"thrust":    true,
@@ -160,11 +174,35 @@ func stageLooksLikeRubyWebServer(stage instructions.Stage, sf *facts.StageFacts)
 
 // argvIncludesRubyWebServer reports whether any argv token's basename
 // matches a Ruby HTTP server name.
+//
+// `rails` requires special handling: `rails server` (or bare `rails`,
+// which prints help and exits, so unlikely as final CMD) are
+// web-serving commands, but `rails db:migrate`, `rails runner`,
+// `rails console`, etc. are one-shot jobs that don't expose HTTP.
 func argvIncludesRubyWebServer(argv []string) bool {
+	// Build a flat list of words for sequential look-ahead at `rails`
+	// matches.
+	var words []string
 	for _, token := range argv {
 		for word := range strings.FieldsSeq(token) {
-			if rubyWebServerCommands[strings.ToLower(commandBasename(word))] {
-				return true
+			words = append(words, word)
+		}
+	}
+	for i, word := range words {
+		basename := strings.ToLower(commandBasename(word))
+		if rubyWebServerCommands[basename] {
+			return true
+		}
+		if basename == railsServerCommand {
+			// Treat `rails` as a web server only when followed by
+			// `server` (or `s`, the canonical alias). Anything else —
+			// `db:migrate`, `runner`, `console`, etc. — is a one-shot
+			// job and shouldn't get the `/up` healthcheck advice.
+			if i+1 < len(words) {
+				next := strings.ToLower(words[i+1])
+				if next == "server" || next == "s" {
+					return true
+				}
 			}
 		}
 	}
@@ -181,6 +219,36 @@ func findLastHealthCheck(stage instructions.Stage) *instructions.HealthCheckComm
 		}
 	}
 	return last
+}
+
+// priorStageHasHealthCheck reports whether stage's parent (`FROM
+// <name>` resolves to another stage in the same Dockerfile) — or any
+// ancestor reachable via the `FROM <stage>` chain — declares a
+// HEALTHCHECK that this stage would inherit. The walk is bounded by
+// the number of stages and stops at the first stage whose `From` is
+// an external image (not a stage name in the same Dockerfile).
+func priorStageHasHealthCheck(input rules.LintInput, stage instructions.Stage) bool {
+	parent := stage.BaseName
+	if parent == "" {
+		return false
+	}
+	stagesByName := make(map[string]instructions.Stage, len(input.Stages))
+	for _, s := range input.Stages {
+		if s.Name != "" {
+			stagesByName[strings.ToLower(s.Name)] = s
+		}
+	}
+	for range input.Stages {
+		parentStage, ok := stagesByName[strings.ToLower(parent)]
+		if !ok {
+			return false
+		}
+		if findLastHealthCheck(parentStage) != nil {
+			return true
+		}
+		parent = parentStage.BaseName
+	}
+	return false
 }
 
 // healthCheckUsesCurlOrWget reports whether the HEALTHCHECK CMD's

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
@@ -64,10 +64,11 @@ func (r *HealthcheckRailsUpEndpointRule) Check(input rules.LintInput) []rules.Vi
 	if !stageLooksLikeRuby(input.Semantic, finalIdx, stage, sf) {
 		return nil
 	}
-	if !stageLooksLikeRubyWebServer(stage, sf) {
+	if !stageLooksLikeRubyWebServerWithParents(input, finalIdx, stage, sf) {
 		// Workers (sidekiq/resque) don't expose an HTTP endpoint; the
 		// `/up` healthcheck recommendation only applies to Rails web
-		// servers.
+		// servers. The walk also follows inherited CMD/ENTRYPOINT when
+		// the final stage builds on a named parent stage.
 		return nil
 	}
 
@@ -150,8 +151,68 @@ var rubyWebServerCommands = map[string]bool{
 
 // stageLooksLikeRubyWebServer reports whether the stage's
 // ENTRYPOINT/CMD argv designates a Ruby HTTP server (not a worker like
-// sidekiq).
+// sidekiq). When the stage doesn't declare its own CMD/ENTRYPOINT, the
+// effective values are inherited from its parent stage (`FROM <name>`),
+// so the walk continues up the parent chain inside the same Dockerfile.
 func stageLooksLikeRubyWebServer(stage instructions.Stage, sf *facts.StageFacts) bool {
+	if entry, cmd := lastEntrypointAndCmd(stage); entry != nil || cmd != nil {
+		if entry != nil && argvIncludesRubyWebServer(entry.CmdLine) {
+			return true
+		}
+		if cmd != nil && argvIncludesRubyWebServer(cmd.CmdLine) {
+			return true
+		}
+		return false
+	}
+	_ = sf
+	return false
+}
+
+// stageLooksLikeRubyWebServerWithParents extends
+// stageLooksLikeRubyWebServer to follow inherited CMD/ENTRYPOINT when
+// the final stage uses `FROM <named-stage>` and adds no local command
+// instruction itself.
+func stageLooksLikeRubyWebServerWithParents(input rules.LintInput, finalIdx int, stage instructions.Stage, sf *facts.StageFacts) bool {
+	if stageLooksLikeRubyWebServer(stage, sf) {
+		return true
+	}
+	// Local CMD/ENTRYPOINT present but didn't match — don't fall through
+	// to the parent (Docker would not inherit when the local stage
+	// declares its own).
+	if entry, cmd := lastEntrypointAndCmd(stage); entry != nil || cmd != nil {
+		return false
+	}
+	stagesByName := make(map[string]instructions.Stage, len(input.Stages))
+	for _, s := range input.Stages {
+		if s.Name != "" {
+			stagesByName[strings.ToLower(s.Name)] = s
+		}
+	}
+	parent := stage.BaseName
+	for range input.Stages {
+		parentStage, ok := stagesByName[strings.ToLower(parent)]
+		if !ok {
+			return false
+		}
+		if entry, cmd := lastEntrypointAndCmd(parentStage); entry != nil || cmd != nil {
+			if entry != nil && argvIncludesRubyWebServer(entry.CmdLine) {
+				return true
+			}
+			if cmd != nil && argvIncludesRubyWebServer(cmd.CmdLine) {
+				return true
+			}
+			// Parent has its own CMD/ENTRYPOINT but doesn't match — stop.
+			return false
+		}
+		parent = parentStage.BaseName
+	}
+	_ = finalIdx
+	return false
+}
+
+// lastEntrypointAndCmd returns the final ENTRYPOINT and CMD instructions
+// declared in stage (Docker uses the last of each).
+func lastEntrypointAndCmd(stage instructions.Stage) (*instructions.EntrypointCommand, *instructions.CmdCommand) {
 	var lastEntrypoint *instructions.EntrypointCommand
 	var lastCmd *instructions.CmdCommand
 	for _, c := range stage.Commands {
@@ -162,14 +223,7 @@ func stageLooksLikeRubyWebServer(stage instructions.Stage, sf *facts.StageFacts)
 			lastCmd = cc
 		}
 	}
-	if lastEntrypoint != nil && argvIncludesRubyWebServer(lastEntrypoint.CmdLine) {
-		return true
-	}
-	if lastCmd != nil && argvIncludesRubyWebServer(lastCmd.CmdLine) {
-		return true
-	}
-	_ = sf
-	return false
+	return lastEntrypoint, lastCmd
 }
 
 // argvIncludesRubyWebServer reports whether any argv token's basename

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint.go
@@ -149,39 +149,46 @@ var rubyWebServerCommands = map[string]bool{
 	"iodine":    true,
 }
 
-// stageLooksLikeRubyWebServer reports whether the stage's
-// ENTRYPOINT/CMD argv designates a Ruby HTTP server (not a worker like
-// sidekiq). When the stage doesn't declare its own CMD/ENTRYPOINT, the
-// effective values are inherited from its parent stage (`FROM <name>`),
-// so the walk continues up the parent chain inside the same Dockerfile.
-func stageLooksLikeRubyWebServer(stage instructions.Stage, sf *facts.StageFacts) bool {
-	if entry, cmd := lastEntrypointAndCmd(stage); entry != nil || cmd != nil {
-		if entry != nil && argvIncludesRubyWebServer(entry.CmdLine) {
-			return true
-		}
-		if cmd != nil && argvIncludesRubyWebServer(cmd.CmdLine) {
-			return true
-		}
-		return false
+// stageLooksLikeRubyWebServerWithParents reports whether the stage
+// runs a Ruby HTTP server, following inherited CMD/ENTRYPOINT when the
+// stage uses `FROM <named-stage>`. Docker inherits CMD and ENTRYPOINT
+// independently: if the final stage sets only CMD, the ENTRYPOINT
+// comes from the parent; if it sets only ENTRYPOINT, CMD is reset.
+// The walk resolves the effective argv for whichever instruction the
+// stage didn't override.
+func stageLooksLikeRubyWebServerWithParents(
+	input rules.LintInput, finalIdx int, stage instructions.Stage, sf *facts.StageFacts,
+) bool {
+	entry, cmd := resolveEffectiveEntrypointAndCmd(input, stage)
+	if entry != nil && argvIncludesRubyWebServer(entry.CmdLine) {
+		return true
+	}
+	if cmd != nil && argvIncludesRubyWebServer(cmd.CmdLine) {
+		return true
 	}
 	_ = sf
+	_ = finalIdx
 	return false
 }
 
-// stageLooksLikeRubyWebServerWithParents extends
-// stageLooksLikeRubyWebServer to follow inherited CMD/ENTRYPOINT when
-// the final stage uses `FROM <named-stage>` and adds no local command
-// instruction itself.
-func stageLooksLikeRubyWebServerWithParents(input rules.LintInput, finalIdx int, stage instructions.Stage, sf *facts.StageFacts) bool {
-	if stageLooksLikeRubyWebServer(stage, sf) {
-		return true
+// resolveEffectiveEntrypointAndCmd returns the effective
+// ENTRYPOINT/CMD argv for stage by walking the parent stage chain
+// inside the same Dockerfile. CMD and ENTRYPOINT are resolved
+// independently because Docker inherits them as separate slots.
+//
+// Rules per Docker semantics:
+//   - If the local stage sets ENTRYPOINT, that's the effective value
+//     and the local CMD is used (or empty if not set).
+//   - If the local stage sets only CMD, ENTRYPOINT is inherited.
+//   - If the local stage sets neither, both are inherited.
+func resolveEffectiveEntrypointAndCmd(
+	input rules.LintInput, stage instructions.Stage,
+) (*instructions.EntrypointCommand, *instructions.CmdCommand) {
+	entry, cmd := lastEntrypointAndCmd(stage)
+	if entry != nil && cmd != nil {
+		return entry, cmd
 	}
-	// Local CMD/ENTRYPOINT present but didn't match — don't fall through
-	// to the parent (Docker would not inherit when the local stage
-	// declares its own).
-	if entry, cmd := lastEntrypointAndCmd(stage); entry != nil || cmd != nil {
-		return false
-	}
+	// One or both missing — walk parent chain for the missing slot(s).
 	stagesByName := make(map[string]instructions.Stage, len(input.Stages))
 	for _, s := range input.Stages {
 		if s.Name != "" {
@@ -192,22 +199,21 @@ func stageLooksLikeRubyWebServerWithParents(input rules.LintInput, finalIdx int,
 	for range input.Stages {
 		parentStage, ok := stagesByName[strings.ToLower(parent)]
 		if !ok {
-			return false
+			return entry, cmd
 		}
-		if entry, cmd := lastEntrypointAndCmd(parentStage); entry != nil || cmd != nil {
-			if entry != nil && argvIncludesRubyWebServer(entry.CmdLine) {
-				return true
-			}
-			if cmd != nil && argvIncludesRubyWebServer(cmd.CmdLine) {
-				return true
-			}
-			// Parent has its own CMD/ENTRYPOINT but doesn't match — stop.
-			return false
+		parentEntry, parentCmd := lastEntrypointAndCmd(parentStage)
+		if entry == nil && parentEntry != nil {
+			entry = parentEntry
+		}
+		if cmd == nil && parentCmd != nil {
+			cmd = parentCmd
+		}
+		if entry != nil && cmd != nil {
+			return entry, cmd
 		}
 		parent = parentStage.BaseName
 	}
-	_ = finalIdx
-	return false
+	return entry, cmd
 }
 
 // lastEntrypointAndCmd returns the final ENTRYPOINT and CMD instructions

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
@@ -160,6 +160,16 @@ CMD ["-C", "config/puma.rb"]
 `,
 			WantViolations: 1,
 		},
+		{
+			Name: "local ENTRYPOINT resets parent CMD per Docker semantics",
+			Content: `FROM ruby:3.3-slim AS base
+CMD ["bin/rails", "server"]
+
+FROM base AS job-runner
+ENTRYPOINT ["./run-job"]
+`,
+			WantViolations: 0,
+		},
 	})
 }
 

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
@@ -139,6 +139,17 @@ CMD ["bin/rails", "server"]
 `,
 			WantViolations: 0,
 		},
+		// --- CMD inheritance from earlier stage ---
+		{
+			Name: "CMD inherited from named parent stage triggers",
+			Content: `FROM ruby:3.3-slim AS base
+CMD ["bin/rails", "server"]
+
+FROM base AS app
+ENV RAILS_ENV=production
+`,
+			WantViolations: 1,
+		},
 	})
 }
 

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
@@ -93,6 +93,13 @@ ENTRYPOINT ["mygem"]
 			WantViolations: 0,
 		},
 		{
+			Name: "sidekiq worker stage skipped (not a web server)",
+			Content: `FROM ruby:3.3-slim
+CMD ["bundle", "exec", "sidekiq"]
+`,
+			WantViolations: 0,
+		},
+		{
 			Name: "dev stage skipped",
 			Content: `FROM ruby:3.3-slim AS dev
 CMD ["bin/rails", "server"]

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
@@ -106,6 +106,39 @@ CMD ["bin/rails", "server"]
 `,
 			WantViolations: 0,
 		},
+		// --- Rails subcommand filter ---
+		{
+			Name: "rails db:migrate is a one-shot job, not a web server",
+			Content: `FROM ruby:3.3-slim
+CMD ["bin/rails", "db:migrate"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "rails runner is a one-shot job, not a web server",
+			Content: `FROM ruby:3.3-slim
+CMD ["bin/rails", "runner", "Job.perform_now"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "rails server (alias 's') is a web server",
+			Content: `FROM ruby:3.3-slim
+CMD ["bin/rails", "s"]
+`,
+			WantViolations: 1,
+		},
+		// --- HEALTHCHECK inheritance from earlier stage ---
+		{
+			Name: "HEALTHCHECK inherited from named parent stage suppresses",
+			Content: `FROM ruby:3.3-slim AS base
+HEALTHCHECK CMD ["ruby", "-rnet/http", "-e", "exit 0"]
+
+FROM base AS app
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
 	})
 }
 

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
@@ -1,0 +1,126 @@
+package ruby
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/testutil"
+)
+
+func TestHealthcheckRailsUpEndpointRule_Metadata(t *testing.T) {
+	t.Parallel()
+
+	meta := NewHealthcheckRailsUpEndpointRule().Metadata()
+	if meta.Code != HealthcheckRailsUpEndpointRuleCode {
+		t.Errorf("Code = %q, want %q", meta.Code, HealthcheckRailsUpEndpointRuleCode)
+	}
+	if meta.DefaultSeverity != rules.SeverityInfo {
+		t.Errorf("DefaultSeverity = %v, want Info", meta.DefaultSeverity)
+	}
+	if meta.Category != "correctness" {
+		t.Errorf("Category = %q, want %q", meta.Category, "correctness")
+	}
+}
+
+func TestHealthcheckRailsUpEndpointRule_Check(t *testing.T) {
+	t.Parallel()
+
+	testutil.RunRuleTests(t, NewHealthcheckRailsUpEndpointRule(), []testutil.RuleTestCase{
+		// --- Variant 1: missing HEALTHCHECK ---
+		{
+			Name: "Rails runtime without HEALTHCHECK triggers",
+			Content: `FROM ruby:3.3-slim
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "puma runtime without HEALTHCHECK triggers",
+			Content: `FROM ruby:3.3-slim
+CMD ["puma"]
+`,
+			WantViolations: 1,
+		},
+		// --- Variant 2: HEALTHCHECK NONE suppresses ---
+		{
+			Name: "HEALTHCHECK NONE explicitly opts out",
+			Content: `FROM ruby:3.3-slim
+HEALTHCHECK NONE
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		// --- Variant 3: curl-based HEALTHCHECK ---
+		{
+			Name: "HEALTHCHECK with curl triggers",
+			Content: `FROM ruby:3.3-slim
+HEALTHCHECK CMD curl -fsS http://127.0.0.1:3000/up || exit 1
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		{
+			Name: "HEALTHCHECK with wget triggers",
+			Content: `FROM ruby:3.3-slim
+HEALTHCHECK CMD wget -q --spider http://127.0.0.1:3000/up
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 1,
+		},
+		// --- Compliance: Ruby-native HEALTHCHECK ---
+		{
+			Name: "HEALTHCHECK with ruby -rnet/http suppresses",
+			Content: `FROM ruby:3.3-slim
+HEALTHCHECK CMD ["ruby", "-rnet/http", "-e", "exit 0"]
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+		// --- Suppressions ---
+		{
+			Name: "non-Ruby image skipped",
+			Content: `FROM debian:bookworm-slim
+CMD ["nginx"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "Ruby CLI image (no rails/puma/etc.) skipped",
+			Content: `FROM ruby:3.3-slim
+ENTRYPOINT ["mygem"]
+`,
+			WantViolations: 0,
+		},
+		{
+			Name: "dev stage skipped",
+			Content: `FROM ruby:3.3-slim AS dev
+CMD ["bin/rails", "server"]
+`,
+			WantViolations: 0,
+		},
+	})
+}
+
+func TestHealthcheckRailsUpEndpointRule_FixDescriptionMentionsCanonicalForm(t *testing.T) {
+	t.Parallel()
+
+	content := `FROM ruby:3.3-slim
+CMD ["bin/rails", "server"]
+`
+	input := testutil.MakeLintInput(t, "Dockerfile", content)
+	violations := NewHealthcheckRailsUpEndpointRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	if !strings.Contains(v.SuggestedFix.Description, "Net::HTTP") {
+		t.Errorf("description should mention Net::HTTP; got: %q", v.SuggestedFix.Description)
+	}
+	if !strings.Contains(v.SuggestedFix.Description, "/up") {
+		t.Errorf("description should mention /up; got: %q", v.SuggestedFix.Description)
+	}
+}

--- a/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
+++ b/internal/rules/tally/ruby/healthcheck_rails_up_endpoint_test.go
@@ -150,6 +150,16 @@ ENV RAILS_ENV=production
 `,
 			WantViolations: 1,
 		},
+		{
+			Name: "ENTRYPOINT inherited from parent, local CMD override (independent inheritance)",
+			Content: `FROM ruby:3.3-slim AS base
+ENTRYPOINT ["puma"]
+
+FROM base AS app
+CMD ["-C", "config/puma.rb"]
+`,
+			WantViolations: 1,
+		},
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds [`tally/ruby/healthcheck-rails-up-endpoint`](https://tally.wharflab.com/rules/tally/ruby/healthcheck-rails-up-endpoint/) — Section 4.4 of [design-docs/43-ruby-on-docker.md](../blob/main/design-docs/43-ruby-on-docker.md).

Educational/advisory rule, two flavors:

1. **Missing HEALTHCHECK on a Rails app stage** — recommend the canonical Ruby-native one (uses stdlib `Net::HTTP` against Rails 7.1+'s default `/up` endpoint, no extra `curl` install needed).
2. **HEALTHCHECK uses curl/wget** — suggest replacing with the Ruby stdlib equivalent (drops the apt-get install).

Corpus shows 0/196 use a Ruby-native healthcheck; the 2 that target `/up` use curl against `ruby:*-slim` and pay an extra apt install.

The recommended canonical form (named in the fix description):

```dockerfile
HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
  CMD ["ruby", "-rnet/http", "-e", "exit Net::HTTP.get_response(URI('http://127.0.0.1:3000/up')).is_a?(Net::HTTPSuccess) ? 0 : 1"]
```

- **Suppressions:** non-Rails-shape final stages (no rails/puma/sidekiq/etc. ENTRYPOINT), `HEALTHCHECK NONE` (explicit opt-out), dev/test/ci stages, non-Ruby, Windows.
- **Auto-fix:** `FixSuggestion` (no-edit). Description names the canonical Ruby-native form with all docker-flag defaults.

## Test plan

- [x] `make build`
- [x] `make test` — ruby package and integration suite pass
- [x] `make lint` — 0 issues
- [x] Lint fixture: `internal/integration/fixtures/lint/ruby-healthcheck-rails-up-endpoint/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a linting rule that validates Rails Dockerfiles to ensure container healthchecks use Ruby's standard library instead of external tools like curl or wget.

* **Documentation**
  * Added comprehensive documentation with examples demonstrating proper healthcheck implementation for Rails containers.

* **Tests**
  * Added comprehensive test coverage for the new rule across multiple healthcheck scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wharflab/tally/pull/685)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->