### PR TITLE
chore(rules): dedupe BuildKit syntax pragma helper

### DIFF
--- a/internal/rules/tally/ruby/buildkit_pragma.go
+++ b/internal/rules/tally/ruby/buildkit_pragma.go
@@ -12,17 +12,27 @@ var dockerfileSyntaxBuildKitMarkers = []string{"docker/dockerfile", "dockerfile/
 
 // hasBuildKitSyntaxPragma reports whether the Dockerfile carries a
 // `# syntax=docker/dockerfile:1` (or compatible) directive at its top.
+//
+// BuildKit recognizes parser directives as a contiguous run of `# k=v`
+// comment lines at the start of the file. A bare `#` (empty comment)
+// terminates the directive block, as does the first non-comment line.
+// Whitespace around `=` is tolerated to match BuildKit's parser.
 func hasBuildKitSyntaxPragma(input rules.LintInput) bool {
 	for line := range strings.SplitSeq(string(input.Source), "\n") {
 		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "#") {
-			break
+		// A bare `#` or any non-comment line ends the directive block.
+		if trimmed == "#" || !strings.HasPrefix(trimmed, "#") {
+			return false
 		}
-		if strings.Contains(trimmed, "syntax=") {
-			for _, m := range dockerfileSyntaxBuildKitMarkers {
-				if strings.Contains(trimmed, m) {
-					return true
-				}
+		directive := strings.TrimSpace(strings.TrimPrefix(trimmed, "#"))
+		name, value, ok := strings.Cut(directive, "=")
+		if !ok || strings.TrimSpace(name) != "syntax" {
+			continue
+		}
+		v := strings.TrimSpace(value)
+		for _, m := range dockerfileSyntaxBuildKitMarkers {
+			if strings.Contains(v, m) {
+				return true
 			}
 		}
 	}

--- a/internal/rules/tally/ruby/buildkit_pragma.go
+++ b/internal/rules/tally/ruby/buildkit_pragma.go
@@ -1,0 +1,30 @@
+package ruby
+
+import (
+	"strings"
+
+	"github.com/wharflab/tally/internal/rules"
+)
+
+// dockerfileSyntaxBuildKitMarkers identifies BuildKit-frontend syntax
+// pragmas. Cache and bind mounts require one of these.
+var dockerfileSyntaxBuildKitMarkers = []string{"docker/dockerfile", "dockerfile/labs"}
+
+// hasBuildKitSyntaxPragma reports whether the Dockerfile carries a
+// `# syntax=docker/dockerfile:1` (or compatible) directive at its top.
+func hasBuildKitSyntaxPragma(input rules.LintInput) bool {
+	for line := range strings.SplitSeq(string(input.Source), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") {
+			break
+		}
+		if strings.Contains(trimmed, "syntax=") {
+			for _, m := range dockerfileSyntaxBuildKitMarkers {
+				if strings.Contains(trimmed, m) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/rules/tally/ruby/buildkit_pragma_test.go
+++ b/internal/rules/tally/ruby/buildkit_pragma_test.go
@@ -1,0 +1,78 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/wharflab/tally/internal/rules"
+)
+
+func TestHasBuildKitSyntaxPragma(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "canonical syntax pragma",
+			src:  "# syntax=docker/dockerfile:1\nFROM ruby:3.3\n",
+			want: true,
+		},
+		{
+			name: "labs frontend",
+			src:  "# syntax=docker/dockerfile:labs\nFROM ruby:3.3\n",
+			want: true,
+		},
+		{
+			name: "spaces around equals are tolerated",
+			src:  "# syntax = docker/dockerfile:1\nFROM ruby:3.3\n",
+			want: true,
+		},
+		{
+			name: "absent",
+			src:  "FROM ruby:3.3\n",
+			want: false,
+		},
+		{
+			name: "non-buildkit syntax (e.g. legacy frontend)",
+			src:  "# syntax=docker/notbuildkit:1\nFROM ruby:3.3\n",
+			want: false,
+		},
+		{
+			name: "comment containing 'syntax=' word but no directive",
+			src:  "# Note: we don't use syntax=... here\nFROM ruby:3.3\n",
+			want: false,
+		},
+		{
+			name: "bare # comment terminates directive block",
+			src:  "#\n# syntax=docker/dockerfile:1\nFROM ruby:3.3\n",
+			want: false,
+		},
+		{
+			name: "directive block ends at first non-comment line",
+			src:  "FROM ruby:3.3\n# syntax=docker/dockerfile:1\n",
+			want: false,
+		},
+		{
+			name: "syntax pragma with leading whitespace",
+			src:  "  # syntax=docker/dockerfile:1\nFROM ruby:3.3\n",
+			want: true,
+		},
+		{
+			name: "preceded by a different directive",
+			src:  "# escape=`\n# syntax=docker/dockerfile:1\nFROM ruby:3.3\n",
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			input := rules.LintInput{Source: []byte(tc.src)}
+			if got := hasBuildKitSyntaxPragma(input); got != tc.want {
+				t.Errorf("hasBuildKitSyntaxPragma(%q) = %v, want %v", tc.src, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go
+++ b/internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go
@@ -12,29 +12,6 @@ import (
 	"github.com/wharflab/tally/internal/stagename"
 )
 
-// dockerfileSyntaxBuildKitMarkers identifies BuildKit-frontend syntax
-// pragmas. Cache and bind mounts require one of these.
-var dockerfileSyntaxBuildKitMarkers = []string{"docker/dockerfile", "dockerfile/labs"}
-
-// hasBuildKitSyntaxPragma reports whether the Dockerfile carries a
-// `# syntax=docker/dockerfile:1` (or compatible) directive at its top.
-func hasBuildKitSyntaxPragma(input rules.LintInput) bool {
-	for line := range strings.SplitSeq(string(input.Source), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "#") {
-			break
-		}
-		if strings.Contains(trimmed, "syntax=") {
-			for _, m := range dockerfileSyntaxBuildKitMarkers {
-				if strings.Contains(trimmed, m) {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
 // PreferGemfileBindMountsRuleCode is the full rule code.
 const PreferGemfileBindMountsRuleCode = rules.TallyRulePrefix + "ruby/prefer-gemfile-bind-mounts"
 

--- a/internal/rules/tally/ruby/prefer_network_none_install.go
+++ b/internal/rules/tally/ruby/prefer_network_none_install.go
@@ -1,8 +1,6 @@
 package ruby
 
 import (
-	"strings"
-
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 
 	"github.com/wharflab/tally/internal/facts"
@@ -11,29 +9,6 @@ import (
 	"github.com/wharflab/tally/internal/semantic"
 	"github.com/wharflab/tally/internal/stagename"
 )
-
-// dockerfileSyntaxBuildKitMarkers identifies BuildKit-frontend syntax
-// pragmas. Cache and bind mounts require one of these.
-var dockerfileSyntaxBuildKitMarkers = []string{"docker/dockerfile", "dockerfile/labs"}
-
-// hasBuildKitSyntaxPragma reports whether the Dockerfile carries a
-// `# syntax=docker/dockerfile:1` (or compatible) directive at its top.
-func hasBuildKitSyntaxPragma(input rules.LintInput) bool {
-	for line := range strings.SplitSeq(string(input.Source), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "#") {
-			break
-		}
-		if strings.Contains(trimmed, "syntax=") {
-			for _, m := range dockerfileSyntaxBuildKitMarkers {
-				if strings.Contains(trimmed, m) {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
 
 // PreferNetworkNoneInstallRuleCode is the full rule code.
 const PreferNetworkNoneInstallRuleCode = rules.TallyRulePrefix + "ruby/prefer-network-none-install"


### PR DESCRIPTION
## Summary

PRs #682 (prefer-gemfile-bind-mounts) and #683 (prefer-network-none-install) both introduced identical `dockerfileSyntaxBuildKitMarkers` and `hasBuildKitSyntaxPragma` helpers. They merged in parallel and produced a duplicate-symbol build break on `main`:

```
internal/rules/tally/ruby/prefer_network_none_install.go:17:5: dockerfileSyntaxBuildKitMarkers redeclared in this block
        internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go:17:5: other declaration of dockerfileSyntaxBuildKitMarkers
internal/rules/tally/ruby/prefer_network_none_install.go:21:6: hasBuildKitSyntaxPragma redeclared in this block
        internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go:21:6: other declaration of hasBuildKitSyntaxPragma
```

Move the helper into a shared `internal/rules/tally/ruby/buildkit_pragma.go` and remove the duplicates from the two rule files. No behavior change.

## Test plan

- [x] `go build ./internal/rules/tally/ruby/...` — green (was failing on main)
- [x] `go test ./internal/rules/tally/ruby/...` — passes
- [x] `go test ./internal/integration/...` — passes
- [x] `make lint` — 0 issues