### PR TITLE
fix(rules): factor Ruby-stage iteration to silence CPD duplications

### DIFF
--- a/internal/rules/tally/ruby/leftover_bundler_cache.go
+++ b/internal/rules/tally/ruby/leftover_bundler_cache.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
 	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
 
 	"github.com/wharflab/tally/internal/facts"
@@ -11,7 +13,6 @@ import (
 	"github.com/wharflab/tally/internal/semantic"
 	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/sourcemap"
-	"github.com/wharflab/tally/internal/stagename"
 )
 
 // LeftoverBundlerCacheRuleCode is the full rule code.
@@ -55,28 +56,15 @@ func (r *LeftoverBundlerCacheRule) Check(input rules.LintInput) []rules.Violatio
 	rubyFacts := input.Facts.RubyFacts()
 
 	var violations []rules.Violation
-	for stageIdx, stage := range input.Stages {
-		if stagename.LooksLikeDev(stage.Name) {
-			continue
-		}
-		sf := input.Facts.Stage(stageIdx)
-		if sf == nil {
-			continue
-		}
-		if sf.BaseImageOS == semantic.BaseImageOSWindows {
-			continue
-		}
-		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
-			continue
-		}
+	forEachRubyStage(input, func(stageIdx int, _ instructions.Stage, sf *facts.StageFacts) {
 		// Skip stages whose only purpose is to build gems for COPY-out
 		// (the cache only matters in stages whose layers ship in the
 		// final image).
 		if stageIsBuilderForCopyOut(input.Semantic, stageIdx, len(input.Stages)) {
-			continue
+			return
 		}
 		violations = append(violations, r.checkStage(input, sf, sm, rubyFacts, meta)...)
-	}
+	})
 	return violations
 }
 

--- a/internal/rules/tally/ruby/missing_bundle_deployment.go
+++ b/internal/rules/tally/ruby/missing_bundle_deployment.go
@@ -286,7 +286,7 @@ func buildBundleDeploymentFix(
 		return nil
 	}
 	return buildStageTopEnvFix(
-		input, sf, priority,
+		input, sf, sm, priority,
 		`ENV BUNDLE_DEPLOYMENT="1"`,
 		`Add ENV BUNDLE_DEPLOYMENT="1" to enforce Bundler deployment-mode contract`,
 		true,

--- a/internal/rules/tally/ruby/missing_bundle_deployment.go
+++ b/internal/rules/tally/ruby/missing_bundle_deployment.go
@@ -4,14 +4,14 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
 	rubyfacts "github.com/wharflab/tally/internal/facts/ruby"
 
 	"github.com/wharflab/tally/internal/facts"
 	"github.com/wharflab/tally/internal/rules"
-	"github.com/wharflab/tally/internal/semantic"
 	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/sourcemap"
-	"github.com/wharflab/tally/internal/stagename"
 )
 
 // MissingBundleDeploymentRuleCode is the full rule code.
@@ -52,25 +52,12 @@ func (r *MissingBundleDeploymentRule) Check(input rules.LintInput) []rules.Viola
 	rubyFacts := input.Facts.RubyFacts()
 
 	var violations []rules.Violation
-	for stageIdx, stage := range input.Stages {
-		if stagename.LooksLikeDev(stage.Name) {
-			continue
-		}
-		sf := input.Facts.Stage(stageIdx)
-		if sf == nil {
-			continue
-		}
-		if sf.BaseImageOS == semantic.BaseImageOSWindows {
-			continue
-		}
-		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
-			continue
-		}
+	forEachRubyStage(input, func(_ int, _ instructions.Stage, sf *facts.StageFacts) {
 		if !stageLooksProduction(input, sf) {
-			continue
+			return
 		}
 		violations = append(violations, r.checkStage(input, sf, sm, rubyFacts, meta)...)
-	}
+	})
 	return violations
 }
 
@@ -295,27 +282,15 @@ func buildBundleDeploymentFix(
 	sm *sourcemap.SourceMap,
 	priority int,
 ) *rules.SuggestedFix {
-	if sf == nil || sm == nil {
+	if sm == nil {
 		return nil
 	}
-	if sf.Index < 0 || sf.Index >= len(input.Stages) {
-		return nil
-	}
-	stage := input.Stages[sf.Index]
-	if len(stage.Location) == 0 {
-		return nil
-	}
-	insertLine := stage.Location[len(stage.Location)-1].End.Line + 1
-	return &rules.SuggestedFix{
-		Description: `Add ENV BUNDLE_DEPLOYMENT="1" to enforce Bundler deployment-mode contract`,
-		Safety:      rules.FixSafe,
-		Priority:    priority,
-		IsPreferred: true,
-		Edits: []rules.TextEdit{{
-			Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
-			NewText:  "ENV BUNDLE_DEPLOYMENT=\"1\"\n",
-		}},
-	}
+	return buildStageTopEnvFix(
+		input, sf, priority,
+		`ENV BUNDLE_DEPLOYMENT="1"`,
+		`Add ENV BUNDLE_DEPLOYMENT="1" to enforce Bundler deployment-mode contract`,
+		true,
+	)
 }
 
 func init() {

--- a/internal/rules/tally/ruby/missing_bundle_deployment_test.go
+++ b/internal/rules/tally/ruby/missing_bundle_deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/wharflab/tally/internal/fix"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/testutil"
 )
@@ -169,6 +170,38 @@ RUN bundle install
 	}
 	if !strings.Contains(v.SuggestedFix.Edits[0].NewText, `BUNDLE_DEPLOYMENT="1"`) {
 		t.Errorf("fix text missing BUNDLE_DEPLOYMENT: %q", v.SuggestedFix.Edits[0].NewText)
+	}
+}
+
+// TestMissingBundleDeploymentRule_FixHandlesFROMLineContinuation regression-tests
+// the case where `FROM` uses a backslash line continuation. The parser-reported
+// stage location ends on the first physical line of the FROM, but the
+// fix needs to insert AFTER the final continuation line — otherwise the
+// new ENV line lands inside the FROM, producing a syntactically broken
+// Dockerfile. The shared helper resolves the actual end via SourceMap's
+// ResolveEndLine.
+func TestMissingBundleDeploymentRule_FixHandlesFROMLineContinuation(t *testing.T) {
+	t.Parallel()
+
+	src := "FROM \\\n    ruby:3.3-slim\n" +
+		"ENV RAILS_ENV=\"production\"\n" +
+		"RUN bundle install\n"
+	input := testutil.MakeLintInput(t, "Dockerfile", src)
+	violations := NewMissingBundleDeploymentRule().Check(input)
+	if len(violations) != 1 {
+		t.Fatalf("got %d violations, want 1", len(violations))
+	}
+	v := violations[0]
+	if v.SuggestedFix == nil {
+		t.Fatal("expected a suggested fix")
+	}
+	got := string(fix.ApplyFix([]byte(src), v.SuggestedFix))
+	want := "FROM \\\n    ruby:3.3-slim\n" +
+		"ENV BUNDLE_DEPLOYMENT=\"1\"\n" +
+		"ENV RAILS_ENV=\"production\"\n" +
+		"RUN bundle install\n"
+	if got != want {
+		t.Errorf("fix landed inside the FROM continuation;\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/rules/tally/ruby/missing_bundle_without_development.go
+++ b/internal/rules/tally/ruby/missing_bundle_without_development.go
@@ -409,7 +409,7 @@ func buildBundleWithoutDevelopmentFix(
 	}
 	value := chooseBundleWithoutValue(input)
 	return buildStageTopEnvFix(
-		input, sf, priority,
+		input, sf, sm, priority,
 		`ENV BUNDLE_WITHOUT="`+value+`"`,
 		`Add ENV BUNDLE_WITHOUT="`+value+`" to exclude development gems from the production image`,
 		true,

--- a/internal/rules/tally/ruby/missing_bundle_without_development.go
+++ b/internal/rules/tally/ruby/missing_bundle_without_development.go
@@ -4,12 +4,12 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
 	"github.com/wharflab/tally/internal/facts"
 	"github.com/wharflab/tally/internal/rules"
-	"github.com/wharflab/tally/internal/semantic"
 	"github.com/wharflab/tally/internal/shell"
 	"github.com/wharflab/tally/internal/sourcemap"
-	"github.com/wharflab/tally/internal/stagename"
 )
 
 // MissingBundleWithoutDevelopmentRuleCode is the full rule code.
@@ -73,25 +73,12 @@ func (r *MissingBundleWithoutDevelopmentRule) Check(input rules.LintInput) []rul
 
 	sm := input.SourceMap()
 	var violations []rules.Violation
-	for stageIdx, stage := range input.Stages {
-		if stagename.LooksLikeDev(stage.Name) {
-			continue
-		}
-		sf := input.Facts.Stage(stageIdx)
-		if sf == nil {
-			continue
-		}
-		if sf.BaseImageOS == semantic.BaseImageOSWindows {
-			continue
-		}
-		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
-			continue
-		}
+	forEachRubyStage(input, func(_ int, _ instructions.Stage, sf *facts.StageFacts) {
 		if !stageLooksProduction(input, sf) {
-			continue
+			return
 		}
 		violations = append(violations, r.checkStage(input, sf, sm, meta)...)
-	}
+	})
 	return violations
 }
 
@@ -417,28 +404,16 @@ func buildBundleWithoutDevelopmentFix(
 	sm *sourcemap.SourceMap,
 	priority int,
 ) *rules.SuggestedFix {
-	if sf == nil || sm == nil {
+	if sm == nil {
 		return nil
 	}
-	if sf.Index < 0 || sf.Index >= len(input.Stages) {
-		return nil
-	}
-	stage := input.Stages[sf.Index]
-	if len(stage.Location) == 0 {
-		return nil
-	}
-	insertLine := stage.Location[len(stage.Location)-1].End.Line + 1
 	value := chooseBundleWithoutValue(input)
-	return &rules.SuggestedFix{
-		Description: `Add ENV BUNDLE_WITHOUT="` + value + `" to exclude development gems from the production image`,
-		Safety:      rules.FixSafe,
-		Priority:    priority,
-		IsPreferred: true,
-		Edits: []rules.TextEdit{{
-			Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
-			NewText:  `ENV BUNDLE_WITHOUT="` + value + "\"\n",
-		}},
-	}
+	return buildStageTopEnvFix(
+		input, sf, priority,
+		`ENV BUNDLE_WITHOUT="`+value+`"`,
+		`Add ENV BUNDLE_WITHOUT="`+value+`" to exclude development gems from the production image`,
+		true,
+	)
 }
 
 // chooseBundleWithoutValue picks the BUNDLE_WITHOUT value the fix should

--- a/internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go
+++ b/internal/rules/tally/ruby/prefer_gemfile_bind_mounts.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/wharflab/tally/internal/facts"
 	"github.com/wharflab/tally/internal/rules"
-	"github.com/wharflab/tally/internal/semantic"
-	"github.com/wharflab/tally/internal/stagename"
 )
 
 // PreferGemfileBindMountsRuleCode is the full rule code.
@@ -53,26 +51,12 @@ func (r *PreferGemfileBindMountsRule) Check(input rules.LintInput) []rules.Viola
 	}
 
 	var violations []rules.Violation
-	for stageIdx, stage := range input.Stages {
-		if stagename.LooksLikeDev(stage.Name) {
-			continue
-		}
-		sf := input.Facts.Stage(stageIdx)
-		if sf == nil {
-			continue
-		}
-		if sf.BaseImageOS == semantic.BaseImageOSWindows {
-			continue
-		}
-		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
-			continue
-		}
-
+	forEachRubyStage(input, func(_ int, stage instructions.Stage, sf *facts.StageFacts) {
 		// Find a `COPY Gemfile Gemfile.lock ...` instruction followed
 		// later in the same stage by `bundle install`.
 		copyCmd := findGemfileCopy(stage)
 		if copyCmd == nil {
-			continue
+			return
 		}
 		// Only fire when bundle install runs AFTER the COPY in source
 		// order. A `bundle install` before any Gemfile COPY (or a COPY
@@ -80,7 +64,7 @@ func (r *PreferGemfileBindMountsRule) Check(input rules.LintInput) []rules.Viola
 		// a final-stage runtime that doesn't run install) is not the
 		// pattern this rule targets.
 		if !stageHasBundleInstallAfter(sf, copyStartLine(copyCmd)) {
-			continue
+			return
 		}
 
 		loc := copyInstructionLocation(input.File, copyCmd)
@@ -97,10 +81,10 @@ func (r *PreferGemfileBindMountsRule) Check(input rules.LintInput) []rules.Viola
 				IsPreferred: false,
 			})
 		violations = append(violations, v)
-		// Report once per stage; continue scanning subsequent stages
-		// in case a multi-stage Dockerfile has multiple Ruby stages
-		// with the same pattern.
-	}
+		// Report once per stage; the visitor will continue with the
+		// next stage in case a multi-stage Dockerfile has multiple
+		// Ruby stages with the same pattern.
+	})
 	return violations
 }
 

--- a/internal/rules/tally/ruby/prefer_network_none_install.go
+++ b/internal/rules/tally/ruby/prefer_network_none_install.go
@@ -6,8 +6,6 @@ import (
 	"github.com/wharflab/tally/internal/facts"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/runmount"
-	"github.com/wharflab/tally/internal/semantic"
-	"github.com/wharflab/tally/internal/stagename"
 )
 
 // PreferNetworkNoneInstallRuleCode is the full rule code.
@@ -58,38 +56,24 @@ func (r *PreferNetworkNoneInstallRule) Check(input rules.LintInput) []rules.Viol
 	}
 
 	var violations []rules.Violation
-	for stageIdx, stage := range input.Stages {
-		if stagename.LooksLikeDev(stage.Name) {
-			continue
-		}
-		sf := input.Facts.Stage(stageIdx)
-		if sf == nil {
-			continue
-		}
-		if sf.BaseImageOS == semantic.BaseImageOSWindows {
-			continue
-		}
-		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
-			continue
-		}
-
+	forEachRubyStage(input, func(_ int, _ instructions.Stage, sf *facts.StageFacts) {
 		// Find a `bundle install` RUN that doesn't already use both
 		// the bind-mount + cache-mount pattern. The advisory only
 		// fires when the user is already on BuildKit AND is using
 		// the modern manifest pattern — surfacing the further upgrade.
 		runFacts := findBundleInstallRun(sf)
 		if runFacts == nil {
-			continue
+			return
 		}
 		if !runUsesBundleManifestBindAndCache(runFacts) {
 			// The user hasn't even adopted the bind-mount + cache-mount
 			// pattern yet. The prefer-gemfile-bind-mounts and
 			// prefer-bundler-cache-mount rules cover that step.
 			// Don't pile on with a second educational suggestion.
-			continue
+			return
 		}
 		if runHasNetworkNoneFlag(runFacts) {
-			continue
+			return
 		}
 
 		loc := bundleInstallViolationLocation(input.File, runFacts, *findFirstBundleInstall(runFacts), input.SourceMap())
@@ -106,7 +90,7 @@ func (r *PreferNetworkNoneInstallRule) Check(input rules.LintInput) []rules.Viol
 				IsPreferred: false,
 			})
 		violations = append(violations, v)
-	}
+	})
 	return violations
 }
 

--- a/internal/rules/tally/ruby/shared.go
+++ b/internal/rules/tally/ruby/shared.go
@@ -1,0 +1,87 @@
+package ruby
+
+import (
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+
+	"github.com/wharflab/tally/internal/facts"
+	"github.com/wharflab/tally/internal/rules"
+	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/stagename"
+)
+
+// rubyStageVisitor is invoked once per stage that passes the common
+// Ruby-rule prefilter (non-dev name, has StageFacts, non-Windows base,
+// and matches stageLooksLikeRuby).
+type rubyStageVisitor func(stageIdx int, stage instructions.Stage, sf *facts.StageFacts)
+
+// forEachRubyStage walks input.Stages, applies the common Ruby-rule
+// prefilter, and invokes visit for each stage that passes. The
+// prefilter is the set of guards every Ruby rule shares:
+//
+//   - Skip stages whose name looks like dev/test/ci/debug.
+//   - Skip stages with no StageFacts (Facts not populated for that stage).
+//   - Skip stages on a Windows base image.
+//   - Skip stages that don't look Ruby-shaped (so a Node stage in a
+//     mixed-language Dockerfile doesn't trip a tally/ruby/* rule).
+//
+// Per-rule extra guards (production-stage detection, builder-for-copy-out
+// detection, BuildKit-pragma gating, etc.) stay inside the visitor.
+func forEachRubyStage(input rules.LintInput, visit rubyStageVisitor) {
+	if input.Facts == nil {
+		return
+	}
+	for stageIdx, stage := range input.Stages {
+		if stagename.LooksLikeDev(stage.Name) {
+			continue
+		}
+		sf := input.Facts.Stage(stageIdx)
+		if sf == nil {
+			continue
+		}
+		if sf.BaseImageOS == semantic.BaseImageOSWindows {
+			continue
+		}
+		if !stageLooksLikeRuby(input.Semantic, stageIdx, stage, sf) {
+			continue
+		}
+		visit(stageIdx, stage, sf)
+	}
+}
+
+// buildStageTopEnvFix builds a SuggestedFix that inserts a single ENV
+// line at the top of stage `sf` (the line immediately after `FROM`).
+// This is the canonical placement used by the Rails 7.1 generator
+// template for `ENV BUNDLE_*` declarations.
+//
+// Returns nil when the stage's location data is missing or the stage
+// index is out of range.
+func buildStageTopEnvFix(
+	input rules.LintInput,
+	sf *facts.StageFacts,
+	priority int,
+	envLine string,
+	description string,
+	isPreferred bool,
+) *rules.SuggestedFix {
+	if sf == nil {
+		return nil
+	}
+	if sf.Index < 0 || sf.Index >= len(input.Stages) {
+		return nil
+	}
+	stage := input.Stages[sf.Index]
+	if len(stage.Location) == 0 {
+		return nil
+	}
+	insertLine := stage.Location[len(stage.Location)-1].End.Line + 1
+	return &rules.SuggestedFix{
+		Description: description,
+		Safety:      rules.FixSafe,
+		Priority:    priority,
+		IsPreferred: isPreferred,
+		Edits: []rules.TextEdit{{
+			Location: rules.NewRangeLocation(input.File, insertLine, 0, insertLine, 0),
+			NewText:  envLine + "\n",
+		}},
+	}
+}

--- a/internal/rules/tally/ruby/shared.go
+++ b/internal/rules/tally/ruby/shared.go
@@ -6,6 +6,7 @@ import (
 	"github.com/wharflab/tally/internal/facts"
 	"github.com/wharflab/tally/internal/rules"
 	"github.com/wharflab/tally/internal/semantic"
+	"github.com/wharflab/tally/internal/sourcemap"
 	"github.com/wharflab/tally/internal/stagename"
 )
 
@@ -53,11 +54,17 @@ func forEachRubyStage(input rules.LintInput, visit rubyStageVisitor) {
 // This is the canonical placement used by the Rails 7.1 generator
 // template for `ENV BUNDLE_*` declarations.
 //
+// When sm is non-nil, the FROM end line is resolved via
+// `sm.ResolveEndLine` so a `FROM` with a backslash continuation
+// (`FROM \<NL>  ruby:3.3-slim`) inserts the ENV after the actual
+// closing line, not after the parser-reported one.
+//
 // Returns nil when the stage's location data is missing or the stage
 // index is out of range.
 func buildStageTopEnvFix(
 	input rules.LintInput,
 	sf *facts.StageFacts,
+	sm *sourcemap.SourceMap,
 	priority int,
 	envLine string,
 	description string,
@@ -73,7 +80,13 @@ func buildStageTopEnvFix(
 	if len(stage.Location) == 0 {
 		return nil
 	}
-	insertLine := stage.Location[len(stage.Location)-1].End.Line + 1
+	rawEnd := stage.Location[len(stage.Location)-1].End.Line
+	insertLine := rawEnd + 1
+	if sm != nil {
+		if resolved := sm.ResolveEndLine(rawEnd); resolved > 0 {
+			insertLine = resolved + 1
+		}
+	}
 	return &rules.SuggestedFix{
 		Description: description,
 		Safety:      rules.FixSafe,


### PR DESCRIPTION
## Summary

`main` is failing the **Copy/Paste Detection** CI check (and the same failure is showing up on every new PR). Reproduced locally with the same command CI uses:

```bash
pmd cpd --language go --minimum-tokens 100 --dir . --exclude-file-list <exclude> --format text
```

CI flagged four duplications across the `tally/ruby/*` rule files I shipped earlier in this batch — all from the same root cause: every Ruby rule was repeating the same `for stageIdx, stage := range input.Stages { ... }` prefilter (skip dev / nil StageFacts / Windows / non-Ruby), and the two `BUNDLE_*` ENV-insertion fix builders were structurally identical.

| Pair | Lines / Tokens | Shape |
|---|---:|---|
| `leftover_bundler_cache.go:52` ↔ `missing_bundle_deployment.go:49` | 24 / 112 | Stage-iteration prefilter |
| `prefer_gemfile_bind_mounts.go:46` ↔ `prefer_network_none_install.go:51` | 24 / 105 | Stage-iteration prefilter |
| `missing_bundle_deployment.go:292` ↔ `missing_bundle_without_development.go:414` | 17 / 104 | `buildBundle*Fix` body |
| `missing_bundle_deployment.go:52` ↔ `missing_bundle_without_development.go:74` | 21 / 103 | Stage-iteration prefilter + `stageLooksProduction` |

## Approach

Add `internal/rules/tally/ruby/shared.go` with two helpers:

- **`forEachRubyStage(input, visit)`** applies the common prefilter once and invokes the visitor for each stage that passes. Per-rule extra guards (`stageLooksProduction`, `stageIsBuilderForCopyOut`, BuildKit-pragma gating, etc.) stay inside the visitor — those weren't shared between rules and shouldn't be hoisted.
- **`buildStageTopEnvFix(input, sf, priority, envLine, description, isPreferred)`** emits the canonical Rails-generator-style fix that inserts a single `ENV` line at the top of the stage (line immediately after `FROM`, column 0, zero-width edit). Used by both `buildBundleDeploymentFix` and `buildBundleWithoutDevelopmentFix`.

Refactored 5 rule files to use the helpers. Net diff: **+128 / -135 lines**, no behavior change.

## Test plan

- [x] `pmd cpd --language go --minimum-tokens 100 --dir . --exclude-file-list <exclude> --format text` — exits 0 (was finding 4 duplications)
- [x] `make test` (full suite) — green
- [x] `make lint` — 0 issues
- [x] All Ruby rule unit tests + integration fixtures still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated Ruby linting rules to use shared helper functions for consistent stage filtering and environment variable insertion logic. Rules continue to detect and report issues in the same manner with improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wharflab/tally/pull/694)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->