### PR TITLE
fix(intellij): write Marketplace-extractable plugin zip; bump verifier 1.405 & ktlint 1.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,11 @@ package-lock.json
 # Kotlin Toolchain build directory (replaces the legacy bash .cache/out/dist
 # layout). dist/ holds the published plugin zip; build/ is all transient
 # state — Amper task outputs, downloaded toolchains, logs, incremental state.
+# bundled/ holds the platform binaries CI copies in before packaging
+# (~400MB across six targets); it is generated, never committed.
 _integrations/intellij-tally/build/
 _integrations/intellij-tally/dist/
+_integrations/intellij-tally/bundled/
 _integrations/zed-tally/target/
 verification-*/
 packaging/npm/**/bin/tally*

--- a/_integrations/intellij-tally/intellij-plugin/module.yaml
+++ b/_integrations/intellij-tally/intellij-plugin/module.yaml
@@ -53,5 +53,5 @@ plugins:
     ideArchiveSha256: 13f4174ba16c1cef04871cb261433536d002586c269a809392c20ee3f94959f5
     pluginVerifierUrl: https://github.com/JetBrains/intellij-plugin-verifier/releases/download/1.405/verifier-cli-1.405-all.jar
     pluginVerifierSha256: 30625df0d376f5a6d4cecfa8a8b932b176b635eee4959d4fab6e17fa17a3291d
-    ktlintVersion: "1.5.0"
-    ktlintSha256: a16be01dcc480aab2f55f444b620142152f66e31564b3b9376506d624c28a2ad
+    ktlintVersion: "1.8.0"
+    ktlintSha256: a3fd620207d5c40da6ca789b95e7f823c54e854b7fade7f613e91096a3706d75

--- a/_integrations/intellij-tally/intellij-plugin/module.yaml
+++ b/_integrations/intellij-tally/intellij-plugin/module.yaml
@@ -51,7 +51,7 @@ plugins:
     # smoke-check against, so we only need one IDE distribution.
     ideArchiveUrl: https://download.jetbrains.com/idea/idea-2025.3.tar.gz
     ideArchiveSha256: 13f4174ba16c1cef04871cb261433536d002586c269a809392c20ee3f94959f5
-    pluginVerifierUrl: https://github.com/JetBrains/intellij-plugin-verifier/releases/download/1.400/verifier-cli-1.400-all.jar
-    pluginVerifierSha256: 11865375fd0d7008164ba3500351e4d8fe475ba89ee18371ba9668ef33ecffa8
+    pluginVerifierUrl: https://github.com/JetBrains/intellij-plugin-verifier/releases/download/1.405/verifier-cli-1.405-all.jar
+    pluginVerifierSha256: 30625df0d376f5a6d4cecfa8a8b932b176b635eee4959d4fab6e17fa17a3291d
     ktlintVersion: "1.5.0"
     ktlintSha256: a16be01dcc480aab2f55f444b620142152f66e31564b3b9376506d624c28a2ad

--- a/_integrations/intellij-tally/tally-build/src/PackagePlugin.kt
+++ b/_integrations/intellij-tally/tally-build/src/PackagePlugin.kt
@@ -85,10 +85,21 @@ fun packagePlugin(
  * commons-compress writes; `java.util.zip.ZipOutputStream` does not). Files
  * with no POSIX view (Windows hosts) fall back to `0644`/`0755` based on
  * directory-vs-file.
+ *
+ * The archive is written through the seekable [Path] constructor, NOT an
+ * `OutputStream`. That distinction is load-bearing: given a non-seekable
+ * stream, commons-compress falls back to *streaming mode* and emits a data
+ * descriptor (general-purpose bit 3) for every entry, zeroing the size/CRC
+ * fields in each local file header. The JetBrains Marketplace upload + zip
+ * signing pipeline rejects such archives ("The plugin archive file cannot be
+ * extracted") even though central-directory readers (unzip, jar, the plugin
+ * verifier) accept them. With a seekable target, commons-compress backfills
+ * the real CRC/sizes into the local headers and writes a conventional archive
+ * matching the previous `zip`-built layout.
  */
 @OptIn(ExperimentalPathApi::class)
 private fun zipDirectory(source: Path, target: Path) {
-    ZipArchiveOutputStream(target.outputStream().buffered()).use { zout ->
+    ZipArchiveOutputStream(target).use { zout ->
         source.walk(PathWalkOption.INCLUDE_DIRECTORIES)
             .filter { it != source }
             .sortedBy { it.relativeTo(source).toString() }
@@ -98,6 +109,11 @@ private fun zipDirectory(source: Path, target: Path) {
                 val entryName = if (isDir) "$rel/" else rel
                 val entry = ZipArchiveEntry(entryName).apply {
                     unixMode = unixModeFor(path, isDir)
+                    // Store (not deflate) empty directory entries, matching a
+                    // conventional `zip` layout. Deflating zero-byte dirs only
+                    // existed because streaming mode defaulted everything to
+                    // DEFLATED.
+                    if (isDir) method = ZipArchiveEntry.STORED
                 }
                 zout.putArchiveEntry(entry)
                 if (!isDir) Files.newInputStream(path).use { it.copyTo(zout) }

--- a/_integrations/intellij-tally/tally-build/src/PackagePlugin.kt
+++ b/_integrations/intellij-tally/tally-build/src/PackagePlugin.kt
@@ -112,8 +112,14 @@ private fun zipDirectory(source: Path, target: Path) {
                     // Store (not deflate) empty directory entries, matching a
                     // conventional `zip` layout. Deflating zero-byte dirs only
                     // existed because streaming mode defaulted everything to
-                    // DEFLATED.
-                    if (isDir) method = ZipArchiveEntry.STORED
+                    // DEFLATED. A directory entry has no data, so its size and
+                    // CRC-32 are both 0 — set them explicitly so the local file
+                    // header is written in one pass (no seek-back on close).
+                    if (isDir) {
+                        method = ZipArchiveEntry.STORED
+                        size = 0L
+                        crc = 0L
+                    }
                 }
                 zout.putArchiveEntry(entry)
                 if (!isDir) Files.newInputStream(path).use { it.copyTo(zout) }


### PR DESCRIPTION
## Summary

The IntelliJ plugin (Tally `0.44.0`) was rejected by the JetBrains Marketplace with **"The plugin archive file cannot be extracted" / "configuration is invalid"**. Root cause: the Kotlin Toolchain build migration (`568039af`) replaced the old bash `zip -qr` packaging with a custom commons-compress `zipDirectory` that produced a structurally-different archive the Marketplace pipeline can't process.

This PR fixes the packaging, and while here, bumps the two pinned build tools.

## Root cause

`zipDirectory` in `PackagePlugin.kt` handed `ZipArchiveOutputStream` a **non-seekable `OutputStream`** (`target.outputStream().buffered()`). Unable to seek back and backfill CRC/size into each local file header, commons-compress fell into **streaming mode**: it set general-purpose **bit 3** and appended a **data descriptor** on every entry (and deflated even empty directories).

Central-directory readers (`unzip`, `jar`, the plugin verifier, `ditto`, Python `zipfile`) all accept that layout — which is **why every local and CI gate passed** — but the Marketplace **upload + zip-signing pipeline reads local headers** and rejects it.

### Evidence: last-known-good vs rejected artifact

Diffing the published **0.40.0** (good) against the rejected **0.44.0**, same contents, different container:

| Property | GOOD 0.40.0 (`zip -qr`) | BAD 0.44.0 (new build) |
|---|---|---|
| data-descriptor flag (bit 3) | **0 entries** | **all 19 entries** |
| directory entries | **STORED** | **DEFLATED** |
| version-needed-to-extract | 10 / 20 | 20 |

## The fix

Construct `ZipArchiveOutputStream` from the **seekable `Path`** instead of an `OutputStream`, and explicitly `STORED` empty directories. The rebuilt archive's structure now **matches 0.40.0 exactly** (0 data descriptors, stored dirs, extract-version 10/20).

## Also in this PR

- **Bump JetBrains plugin verifier `1.400` → `1.405`** (latest release).
- **Bump ktlint `1.5.0` → `1.8.0`** (latest release) — lint passes clean, no new findings.
- **gitignore `_integrations/intellij-tally/bundled/`** — CI copies ~400 MB of platform binaries there before packaging; it is generated, never committed.

## Validation

Against a faithful ~132 MB artifact (six bundled platform binaries, matching the real Marketplace upload):

- `make intellij-plugin-verify` → exit 0 on verifier **1.405**
- `make intellij-plugin-smoke` → "smoke check passed against IntelliJ IDEA Community Edition" on **1.405**
- `make intellij-plugin-ktlint` → clean on ktlint **1.8.0** (all 18 sources)
- Verdict unchanged: **`Compatible. 14 usages of experimental API`** (pre-existing, non-blocking `TrustedProjectsListener` usages)
- Rebuilt zip integrity confirmed via Info-ZIP `-t`, Python `testzip`, JVM `ZipFile`/`ZipInputStream`, `jar xf`, and `ditto`

## Note: the Internal-API email is separate

The Marketplace's "uses an Internal API" email refers to `com.intellij.ide.trustedProjects.TrustedProjectsListener` (used in `TallyServerService`). The verifier classifies it as **Experimental** (allowed on the Marketplace), not Internal — it is **not** the cause of this rejection and is left unchanged here. Can be addressed in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin build tool versions and development configuration.

* **Bug Fixes**
  * Improved plugin package generation for better compatibility with JetBrains' distribution platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->