### PR TITLE
fix(intellij): drop internal-API PluginManager.getPluginByClass

### DIFF
--- a/_integrations/intellij-tally/intellij-plugin/src/io/github/wharflab/tally/intellij/lsp/TallyBinaryResolver.kt
+++ b/_integrations/intellij-tally/intellij-plugin/src/io/github/wharflab/tally/intellij/lsp/TallyBinaryResolver.kt
@@ -26,10 +26,15 @@ internal data class TallyCommand(
  * these from the injected descriptor avoids the internal-API
  * `PluginManager.getPluginByClass`, which the JetBrains Marketplace rejects
  * (and which is unreliable when the IDE runs from sources anyway).
+ *
+ * A real loaded plugin descriptor always supplies both fields, so they are
+ * non-null here. The *absence* of a descriptor (e.g. before injection, or in
+ * a test harness) is modeled by passing a null [TallyPluginInfo] rather than
+ * one with null fields — there is no meaningful partially-populated state.
  */
 internal data class TallyPluginInfo(
-    val path: Path?,
-    val version: String?,
+    val path: Path,
+    val version: String,
 )
 
 internal object TallyBinaryResolver {
@@ -42,7 +47,7 @@ internal object TallyBinaryResolver {
         projectBasePath: String?,
         projectSdkHomePath: String?,
         isTrustedProject: Boolean,
-        plugin: TallyPluginInfo,
+        plugin: TallyPluginInfo?,
     ): TallyCommand? {
         if (settings.importStrategy == TallySettings.IMPORT_STRATEGY_USE_BUNDLED) {
             resolveBundledBinary(plugin)?.let { return it }
@@ -153,8 +158,8 @@ internal object TallyBinaryResolver {
         return null
     }
 
-    private fun resolveBundledBinary(plugin: TallyPluginInfo): TallyCommand? {
-        val pluginPath = plugin.path ?: return null
+    private fun resolveBundledBinary(plugin: TallyPluginInfo?): TallyCommand? {
+        val pluginPath = plugin?.path ?: return null
         val binaryName = if (SystemInfo.isWindows) "tally.exe" else "tally"
         val candidate =
             pluginPath
@@ -183,12 +188,12 @@ internal object TallyBinaryResolver {
 
     private fun compatibleOrNull(
         command: TallyCommand?,
-        plugin: TallyPluginInfo,
+        plugin: TallyPluginInfo?,
     ): TallyCommand? = command?.takeIf { isCompatibleBinary(Paths.get(it.executable), plugin) }
 
-    private fun getMinCompatibleVersion(plugin: TallyPluginInfo): String? {
-        val version = plugin.version
-        if (version.isNullOrBlank() || version.contains("dev")) {
+    private fun getMinCompatibleVersion(plugin: TallyPluginInfo?): String? {
+        val version = plugin?.version ?: return null
+        if (version.isBlank() || version.contains("dev")) {
             return null // dev build – skip version gating
         }
         return version
@@ -196,7 +201,7 @@ internal object TallyBinaryResolver {
 
     private fun isCompatibleBinary(
         path: Path,
-        plugin: TallyPluginInfo,
+        plugin: TallyPluginInfo?,
     ): Boolean {
         val minVersion = getMinCompatibleVersion(plugin) ?: return true
         return try {

--- a/_integrations/intellij-tally/intellij-plugin/src/io/github/wharflab/tally/intellij/lsp/TallyBinaryResolver.kt
+++ b/_integrations/intellij-tally/intellij-plugin/src/io/github/wharflab/tally/intellij/lsp/TallyBinaryResolver.kt
@@ -4,7 +4,6 @@ import com.google.gson.JsonParser
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.PathEnvironmentVariableUtil
 import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.text.VersionComparatorUtil
@@ -20,6 +19,19 @@ internal data class TallyCommand(
     val args: List<String>,
 )
 
+/**
+ * The plugin's own install path and version, captured from the
+ * [com.intellij.openapi.extensions.PluginDescriptor] the platform injects
+ * into [TallyLspServerSupportProvider] (a `PluginAware` extension). Sourcing
+ * these from the injected descriptor avoids the internal-API
+ * `PluginManager.getPluginByClass`, which the JetBrains Marketplace rejects
+ * (and which is unreliable when the IDE runs from sources anyway).
+ */
+internal data class TallyPluginInfo(
+    val path: Path?,
+    val version: String?,
+)
+
 internal object TallyBinaryResolver {
     private val LOG = Logger.getInstance(TallyBinaryResolver::class.java)
     private val SERVER_ARGS = listOf("lsp", "--stdio")
@@ -30,20 +42,21 @@ internal object TallyBinaryResolver {
         projectBasePath: String?,
         projectSdkHomePath: String?,
         isTrustedProject: Boolean,
+        plugin: TallyPluginInfo,
     ): TallyCommand? {
         if (settings.importStrategy == TallySettings.IMPORT_STRATEGY_USE_BUNDLED) {
-            resolveBundledBinary()?.let { return it }
+            resolveBundledBinary(plugin)?.let { return it }
             return null
         }
 
         resolveExplicitPaths(settings.executablePaths, projectBasePath, isTrustedProject)
             ?.let { return it }
         if (isTrustedProject) {
-            compatibleOrNull(resolveFromPath())?.let { return it }
-            compatibleOrNull(resolveFromInterpreterDirectory(projectSdkHomePath))?.let { return it }
-            compatibleOrNull(resolveFromProjectVenv(projectBasePath))?.let { return it }
+            compatibleOrNull(resolveFromPath(), plugin)?.let { return it }
+            compatibleOrNull(resolveFromInterpreterDirectory(projectSdkHomePath), plugin)?.let { return it }
+            compatibleOrNull(resolveFromProjectVenv(projectBasePath), plugin)?.let { return it }
         }
-        return resolveBundledBinary()
+        return resolveBundledBinary(plugin)
     }
 
     private fun resolveExplicitPaths(
@@ -140,13 +153,11 @@ internal object TallyBinaryResolver {
         return null
     }
 
-    private fun resolveBundledBinary(): TallyCommand? {
-        val descriptor =
-            PluginManager.getPluginByClass(TallyBinaryResolver::class.java)
-                ?: return null
+    private fun resolveBundledBinary(plugin: TallyPluginInfo): TallyCommand? {
+        val pluginPath = plugin.path ?: return null
         val binaryName = if (SystemInfo.isWindows) "tally.exe" else "tally"
         val candidate =
-            descriptor.pluginPath
+            pluginPath
                 .resolve("bin")
                 .resolve(platformFolder())
                 .resolve(normalizeArch())
@@ -170,21 +181,24 @@ internal object TallyBinaryResolver {
             args = SERVER_ARGS,
         )
 
-    private fun compatibleOrNull(command: TallyCommand?): TallyCommand? = command?.takeIf { isCompatibleBinary(Paths.get(it.executable)) }
+    private fun compatibleOrNull(
+        command: TallyCommand?,
+        plugin: TallyPluginInfo,
+    ): TallyCommand? = command?.takeIf { isCompatibleBinary(Paths.get(it.executable), plugin) }
 
-    private fun getMinCompatibleVersion(): String? {
-        val descriptor =
-            PluginManager.getPluginByClass(TallyBinaryResolver::class.java)
-                ?: return null
-        val version = descriptor.version
+    private fun getMinCompatibleVersion(plugin: TallyPluginInfo): String? {
+        val version = plugin.version
         if (version.isNullOrBlank() || version.contains("dev")) {
             return null // dev build – skip version gating
         }
         return version
     }
 
-    private fun isCompatibleBinary(path: Path): Boolean {
-        val minVersion = getMinCompatibleVersion() ?: return true
+    private fun isCompatibleBinary(
+        path: Path,
+        plugin: TallyPluginInfo,
+    ): Boolean {
+        val minVersion = getMinCompatibleVersion(plugin) ?: return true
         return try {
             val commandLine = GeneralCommandLine(path.absolutePathString(), "version", "--json")
             val output = CapturingProcessHandler(commandLine).runProcess(VERSION_CHECK_TIMEOUT_MS.toInt())

--- a/_integrations/intellij-tally/intellij-plugin/src/io/github/wharflab/tally/intellij/lsp/TallyLspServerSupportProvider.kt
+++ b/_integrations/intellij-tally/intellij-plugin/src/io/github/wharflab/tally/intellij/lsp/TallyLspServerSupportProvider.kt
@@ -46,10 +46,12 @@ internal class TallyLspServerSupportProvider :
                 project.basePath,
                 sdkHomePath,
                 isTrustedProject,
-                TallyPluginInfo(
-                    path = pluginDescriptor?.pluginPath,
-                    version = pluginDescriptor?.version,
-                ),
+                pluginDescriptor?.let {
+                    TallyPluginInfo(
+                        path = it.pluginPath,
+                        version = it.version,
+                    )
+                },
             ) ?: return
         serverStarter.ensureServerStarted(
             TallyLspServerDescriptor(project, command, service.formatOnReformat),

--- a/_integrations/intellij-tally/intellij-plugin/src/io/github/wharflab/tally/intellij/lsp/TallyLspServerSupportProvider.kt
+++ b/_integrations/intellij-tally/intellij-plugin/src/io/github/wharflab/tally/intellij/lsp/TallyLspServerSupportProvider.kt
@@ -1,6 +1,8 @@
 package io.github.wharflab.tally.intellij.lsp
 
 import com.intellij.ide.trustedProjects.TrustedProjects
+import com.intellij.openapi.extensions.PluginAware
+import com.intellij.openapi.extensions.PluginDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
@@ -8,7 +10,18 @@ import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.platform.lsp.api.lsWidget.LspServerWidgetItem
 
-internal class TallyLspServerSupportProvider : LspServerSupportProvider {
+internal class TallyLspServerSupportProvider :
+    LspServerSupportProvider,
+    PluginAware {
+    // Injected by the extensions framework when this provider is loaded from
+    // plugin.xml. This is the supported, public way for an extension to learn
+    // its own install path and version (replaces PluginManager.getPluginByClass).
+    private var pluginDescriptor: PluginDescriptor? = null
+
+    override fun setPluginDescriptor(pluginDescriptor: PluginDescriptor) {
+        this.pluginDescriptor = pluginDescriptor
+    }
+
     override fun fileOpened(
         project: Project,
         file: VirtualFile,
@@ -33,6 +46,10 @@ internal class TallyLspServerSupportProvider : LspServerSupportProvider {
                 project.basePath,
                 sdkHomePath,
                 isTrustedProject,
+                TallyPluginInfo(
+                    path = pluginDescriptor?.pluginPath,
+                    version = pluginDescriptor?.version,
+                ),
             ) ?: return
         serverStarter.ensureServerStarted(
             TallyLspServerDescriptor(project, command, service.formatOnReformat),


### PR DESCRIPTION
## Summary

The JetBrains Marketplace moderators flagged the published plugin for **2 usages of internal API** — `PluginManager.getPluginByClass(Class)`. (This is the genuine Internal-API issue from the original moderation email; it was previously masked because the verifier pinned to build 253 reported it only as *experimental*. The verifier against the **2026.2 EAP / 262** platform now reports it explicitly as internal.)

> Compatible. 14 usages of experimental API. **2 usages of internal API**
> Internal methods usages (2): `PluginManager.getPluginByClass(Class)`

## Root cause

`getPluginByClass` is `@ApiStatus.Internal`. `TallyBinaryResolver` (a Kotlin `object`) called it twice to discover the plugin's own:
- **install path** → to locate the bundled `tally` binary
- **version** → to gate binary-vs-plugin compatibility

## Fix

Use the supported public mechanism instead of reaching for the plugin descriptor globally. `TallyLspServerSupportProvider` is a registered extension, so it now implements **`PluginAware`** and receives its `PluginDescriptor` via framework injection (`setPluginDescriptor`). It passes the plugin's `pluginPath` and `version` into the resolver as a small `TallyPluginInfo` value.

Both `PluginAware` and `PluginDescriptor.getPluginPath()` / `getVersion()` are **stable, public** API (no `@ApiStatus` annotation). This is also strictly more correct: `getPluginByClass`'s own javadoc notes it returns `null` when the IDE runs from sources; framework injection always provides the descriptor.

## Validation

- `make intellij-plugin-verify` → **`Compatible. 14 usages of experimental API`** — no `internal-api-usages.txt` emitted at all (was "14 experimental + 2 internal"); `getPluginByClass` appears nowhere in the report
- `make intellij-plugin-smoke` → passes against IntelliJ IDEA Community Edition
- `make intellij-plugin` build + `make intellij-plugin-ktlint` → clean
- The 14 experimental usages are the pre-existing, Marketplace-**allowed** `TrustedProjectsListener` references — left unchanged

## Note

The packaging/extraction fix and the verifier/ktlint bumps from #787 are already merged; this PR is the follow-up that clears the Internal-API moderation flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured plugin information handling in the IntelliJ integration to improve code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->