### PR TITLE
fix(docker-plugin): recognize mise installs in register-docker-plugin

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -173,11 +173,11 @@ linters:
           - paralleltest
         path: "internal/fix/(resolver|fixer)_test\\.go"
         text: "TestResolverRegistry|TestRegisterResolver_Duplicate|TestFixer_Apply_AsyncFix|TestFixer_Apply_DefaultConcurrency"
-      # paralleltest: test clears env vars via t.Setenv, which forbids t.Parallel
+      # paralleltest: tests mutate env vars via t.Setenv, which forbids t.Parallel
       - linters:
           - paralleltest
         path: "cmd/tally/cmd/docker_plugin_register_test\\.go"
-        text: "TestDockerPluginRegistrarMiseInstallRootsWindowsHomeFallback"
+        text: "TestDockerPluginRegistrarMiseInstallRootsWindowsHomeFallback|TestDockerPluginRegistrarMiseInstallsDirOverride"
       # dupl: allow duplicate code in tests (table-driven test patterns)
       - linters:
           - dupl

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -173,6 +173,11 @@ linters:
           - paralleltest
         path: "internal/fix/(resolver|fixer)_test\\.go"
         text: "TestResolverRegistry|TestRegisterResolver_Duplicate|TestFixer_Apply_AsyncFix|TestFixer_Apply_DefaultConcurrency"
+      # paralleltest: test clears env vars via t.Setenv, which forbids t.Parallel
+      - linters:
+          - paralleltest
+        path: "cmd/tally/cmd/docker_plugin_register_test\\.go"
+        text: "TestDockerPluginRegistrarMiseInstallRootsWindowsHomeFallback"
       # dupl: allow duplicate code in tests (table-driven test patterns)
       - linters:
           - dupl

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -173,11 +173,12 @@ linters:
           - paralleltest
         path: "internal/fix/(resolver|fixer)_test\\.go"
         text: "TestResolverRegistry|TestRegisterResolver_Duplicate|TestFixer_Apply_AsyncFix|TestFixer_Apply_DefaultConcurrency"
-      # paralleltest: tests mutate env vars via t.Setenv, which forbids t.Parallel
+      # paralleltest: these mise tests mutate env vars via t.Setenv, which forbids
+      # t.Parallel
       - linters:
           - paralleltest
         path: "cmd/tally/cmd/docker_plugin_register_test\\.go"
-        text: "TestDockerPluginRegistrarMiseInstallRootsWindowsHomeFallback|TestDockerPluginRegistrarMiseInstallsDirOverride"
+        text: "TestDockerPluginRegistrarMise(InstallRootsWindowsHomeFallback|InstallsDirOverride|SharedInstallDirs|SystemRoot)"
       # dupl: allow duplicate code in tests (table-driven test patterns)
       - linters:
           - dupl

--- a/_docs/installation.mdx
+++ b/_docs/installation.mdx
@@ -66,6 +66,8 @@ mise use -g github:wharflab/tally@latest
 
 This installs the latest tally release from GitHub and exposes the `tally` binary through mise's global tool shims.
 
+Run `tally register-docker-plugin` after installation to register the plugin with Docker.
+
 ## WinGet (Windows)
 
 ```powershell

--- a/_docs/integrations/docker-cli-plugin.mdx
+++ b/_docs/integrations/docker-cli-plugin.mdx
@@ -20,6 +20,11 @@ brew install --require-sha wharflab/tap/tally
 tally register-docker-plugin
 ```
 
+```bash mise
+mise use -g github:wharflab/tally@latest
+tally register-docker-plugin
+```
+
 ```powershell WinGet
 winget install --id Wharflab.Tally
 tally register-docker-plugin

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -720,16 +720,20 @@ func (r dockerPluginRegistrar) isMisePath(path string) bool {
 // tools. mise installs tools into MISE_INSTALLS_DIR, which defaults to
 // <data dir>/installs; the data dir defaults to $XDG_DATA_HOME/mise
 // (~/.local/share/mise) on Unix and %LOCALAPPDATA%\mise on Windows, and can be
-// overridden with MISE_DATA_DIR. See https://mise.jdx.dev/directories.html.
+// overridden with MISE_DATA_DIR. mise also reads tools from shared install dirs
+// (MISE_SHARED_INSTALL_DIRS) and a system root (MISE_SYSTEM_DATA_DIR/installs,
+// default /usr/local/share/mise/installs). See
+// https://mise.jdx.dev/directories.html and
+// https://mise.jdx.dev/configuration/settings.html#shared_install_dirs.
 func (r dockerPluginRegistrar) miseInstallRoots() []string {
 	var roots []string
-	// MISE_INSTALLS_DIR overrides the installs location directly, so it is a
-	// root as-is rather than a data dir that gets "installs" appended.
-	if v := strings.TrimSpace(os.Getenv("TALLY_MISE_INSTALLS_DIR")); v != "" {
-		roots = appendPathList(roots, v)
-	}
-	if v := strings.TrimSpace(os.Getenv("MISE_INSTALLS_DIR")); v != "" {
-		roots = appendPathList(roots, v)
+	// These point directly at installs dirs, so they are roots as-is rather than
+	// data dirs that get "installs" appended. MISE_SHARED_INSTALL_DIRS is an
+	// OS-path-separated list, which appendPathList splits.
+	for _, env := range []string{"TALLY_MISE_INSTALLS_DIR", "MISE_INSTALLS_DIR", "MISE_SHARED_INSTALL_DIRS"} {
+		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+			roots = appendPathList(roots, v)
+		}
 	}
 
 	var dataDirs []string
@@ -750,6 +754,13 @@ func (r dockerPluginRegistrar) miseInstallRoots() []string {
 			filepath.Join(r.homeDir, ".local", "share", "mise"),
 			filepath.Join(r.homeDir, "AppData", "Local", "mise"),
 		)
+	}
+	// mise checks the system data dir automatically; it defaults to
+	// /usr/local/share/mise on Unix.
+	if v := strings.TrimSpace(os.Getenv("MISE_SYSTEM_DATA_DIR")); v != "" {
+		dataDirs = appendPathList(dataDirs, v)
+	} else if r.goos != windowsGOOS {
+		dataDirs = append(dataDirs, filepath.Join(string(filepath.Separator), "usr", "local", "share", "mise"))
 	}
 
 	for _, dir := range dataDirs {

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -95,8 +95,9 @@ func registerDockerPluginCommand() *cobra.Command {
 
 The command registers docker-lint in Docker's per-user CLI plugin directory.
 It does not download Docker, Docker Compose, Docker Buildx, or another tally
-binary. It only runs from persistent global installs such as Homebrew, WinGet,
-global npm or Bun installs, uv tool installs, or a direct global binary.`,
+binary. It only runs from persistent global installs such as Homebrew, mise,
+WinGet, global npm or Bun installs, uv tool installs, or a direct global
+binary.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			registrar := newDockerPluginRegistrar()
 			out := cmd.OutOrStdout()
@@ -435,6 +436,8 @@ func (r dockerPluginRegistrar) classifySource(source string) (string, error) {
 	}
 
 	switch {
+	case r.isMisePath(source):
+		return "mise", nil
 	case looksLikeHomebrewPath(source):
 		return "Homebrew", nil
 	case looksLikeWingetPath(source):
@@ -699,6 +702,44 @@ func (r dockerPluginRegistrar) uvToolDirs() []string {
 			filepath.Join(r.homeDir, "Library", "Application Support", "uv", "tools"),
 			filepath.Join(r.homeDir, "AppData", "Roaming", "uv", "tools"),
 		)
+	}
+	return cleanPathList(roots)
+}
+
+func (r dockerPluginRegistrar) isMisePath(path string) bool {
+	for _, root := range r.miseInstallRoots() {
+		if r.pathWithin(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+// miseInstallRoots resolves the directories under which mise extracts managed
+// tools. mise stores installs in <data dir>/installs; the data dir defaults to
+// $XDG_DATA_HOME/mise (~/.local/share/mise) on Unix and %LOCALAPPDATA%\mise on
+// Windows, and can be overridden with MISE_DATA_DIR.
+func (r dockerPluginRegistrar) miseInstallRoots() []string {
+	var dataDirs []string
+	if v := strings.TrimSpace(os.Getenv("TALLY_MISE_DATA_DIR")); v != "" {
+		dataDirs = appendPathList(dataDirs, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("MISE_DATA_DIR")); v != "" {
+		dataDirs = appendPathList(dataDirs, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("XDG_DATA_HOME")); v != "" {
+		dataDirs = append(dataDirs, filepath.Join(v, "mise"))
+	}
+	if v := strings.TrimSpace(os.Getenv("LOCALAPPDATA")); v != "" {
+		dataDirs = append(dataDirs, filepath.Join(v, "mise"))
+	}
+	if r.homeDir != "" {
+		dataDirs = append(dataDirs, filepath.Join(r.homeDir, ".local", "share", "mise"))
+	}
+
+	roots := make([]string, 0, len(dataDirs))
+	for _, dir := range dataDirs {
+		roots = append(roots, filepath.Join(dir, "installs"))
 	}
 	return cleanPathList(roots)
 }

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -29,6 +29,7 @@ const (
 	registrationActionUpgrade       = "Upgrading"
 	installModeCopy                 = "copy"
 	installModeSymlink              = "symlink"
+	sourceKindMise                  = "mise"
 	minimumDockerCLIVersion         = "20.10.0"
 	tallyDockerPluginVendor         = "Wharflab"
 	tallyExecutableBaseName         = "tally"
@@ -437,7 +438,7 @@ func (r dockerPluginRegistrar) classifySource(source string) (string, error) {
 
 	switch {
 	case r.isMisePath(source):
-		return "mise", nil
+		return sourceKindMise, nil
 	case looksLikeHomebrewPath(source):
 		return "Homebrew", nil
 	case looksLikeWingetPath(source):
@@ -716,10 +717,21 @@ func (r dockerPluginRegistrar) isMisePath(path string) bool {
 }
 
 // miseInstallRoots resolves the directories under which mise extracts managed
-// tools. mise stores installs in <data dir>/installs; the data dir defaults to
-// $XDG_DATA_HOME/mise (~/.local/share/mise) on Unix and %LOCALAPPDATA%\mise on
-// Windows, and can be overridden with MISE_DATA_DIR.
+// tools. mise installs tools into MISE_INSTALLS_DIR, which defaults to
+// <data dir>/installs; the data dir defaults to $XDG_DATA_HOME/mise
+// (~/.local/share/mise) on Unix and %LOCALAPPDATA%\mise on Windows, and can be
+// overridden with MISE_DATA_DIR. See https://mise.jdx.dev/directories.html.
 func (r dockerPluginRegistrar) miseInstallRoots() []string {
+	var roots []string
+	// MISE_INSTALLS_DIR overrides the installs location directly, so it is a
+	// root as-is rather than a data dir that gets "installs" appended.
+	if v := strings.TrimSpace(os.Getenv("TALLY_MISE_INSTALLS_DIR")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+	if v := strings.TrimSpace(os.Getenv("MISE_INSTALLS_DIR")); v != "" {
+		roots = appendPathList(roots, v)
+	}
+
 	var dataDirs []string
 	if v := strings.TrimSpace(os.Getenv("TALLY_MISE_DATA_DIR")); v != "" {
 		dataDirs = appendPathList(dataDirs, v)
@@ -740,7 +752,6 @@ func (r dockerPluginRegistrar) miseInstallRoots() []string {
 		)
 	}
 
-	roots := make([]string, 0, len(dataDirs))
 	for _, dir := range dataDirs {
 		roots = append(roots, filepath.Join(dir, "installs"))
 	}

--- a/cmd/tally/cmd/docker_plugin_register.go
+++ b/cmd/tally/cmd/docker_plugin_register.go
@@ -734,7 +734,10 @@ func (r dockerPluginRegistrar) miseInstallRoots() []string {
 		dataDirs = append(dataDirs, filepath.Join(v, "mise"))
 	}
 	if r.homeDir != "" {
-		dataDirs = append(dataDirs, filepath.Join(r.homeDir, ".local", "share", "mise"))
+		dataDirs = append(dataDirs,
+			filepath.Join(r.homeDir, ".local", "share", "mise"),
+			filepath.Join(r.homeDir, "AppData", "Local", "mise"),
+		)
 	}
 
 	roots := make([]string, 0, len(dataDirs))

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -200,6 +201,36 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 				t.Fatalf("classifySource(%q) = %q, want %q", tc.path, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDockerPluginRegistrarMiseInstallRootsWindowsHomeFallback(t *testing.T) {
+	// Cannot run in parallel: clears env vars that feed miseInstallRoots so the
+	// homeDir fallbacks are exercised in isolation.
+	for _, key := range []string{"TALLY_MISE_DATA_DIR", "MISE_DATA_DIR", "XDG_DATA_HOME", "LOCALAPPDATA"} {
+		t.Setenv(key, "")
+	}
+
+	home := filepath.Join(string(filepath.Separator), "Users", "me")
+	registrar := dockerPluginRegistrar{goos: windowsGOOS, homeDir: home}
+
+	roots := registrar.miseInstallRoots()
+	wantWindows := filepath.Clean(filepath.Join(home, "AppData", "Local", "mise", "installs"))
+	wantUnix := filepath.Clean(filepath.Join(home, ".local", "share", "mise", "installs"))
+	if !slices.Contains(roots, wantWindows) {
+		t.Fatalf("miseInstallRoots() = %v, want containing Windows fallback %q", roots, wantWindows)
+	}
+	if !slices.Contains(roots, wantUnix) {
+		t.Fatalf("miseInstallRoots() = %v, want containing Unix fallback %q", roots, wantUnix)
+	}
+
+	source := filepath.Join(home, "AppData", "Local", "mise", "installs", "github-wharflab-tally", "latest", "tally.exe")
+	got, err := registrar.classifySource(source)
+	if err != nil {
+		t.Fatalf("classifySource(%q): %v", source, err)
+	}
+	if got != "mise" {
+		t.Fatalf("classifySource(%q) = %q, want %q", source, got, "mise")
 	}
 }
 

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -138,12 +138,12 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 		{
 			name: "mise github backend bare binary",
 			path: filepath.Join(miseInstalls, "github-wharflab-tally", "latest", "tally"),
-			want: "mise",
+			want: sourceKindMise,
 		},
 		{
 			name: "mise asdf backend bin layout",
 			path: filepath.Join(miseInstalls, "tally", "0.44.2", "bin", "tally"),
-			want: "mise",
+			want: sourceKindMise,
 		},
 		{
 			name: "python package install",
@@ -240,8 +240,33 @@ func TestDockerPluginRegistrarMiseInstallRootsWindowsHomeFallback(t *testing.T) 
 	if err != nil {
 		t.Fatalf("classifySource(%q): %v", source, err)
 	}
-	if got != "mise" {
-		t.Fatalf("classifySource(%q) = %q, want %q", source, got, "mise")
+	if got != sourceKindMise {
+		t.Fatalf("classifySource(%q) = %q, want %q", source, got, sourceKindMise)
+	}
+}
+
+func TestDockerPluginRegistrarMiseInstallsDirOverride(t *testing.T) {
+	// Cannot run in parallel: sets/clears env vars that feed miseInstallRoots.
+	installsDir := filepath.Join(t.TempDir(), "opt", "mise-installs")
+	t.Setenv("MISE_INSTALLS_DIR", installsDir)
+	for _, key := range []string{"TALLY_MISE_INSTALLS_DIR", "TALLY_MISE_DATA_DIR", "MISE_DATA_DIR"} {
+		t.Setenv(key, "")
+	}
+
+	registrar := dockerPluginRegistrar{
+		goos:    "linux",
+		homeDir: filepath.Join(t.TempDir(), "home"),
+	}
+
+	// MISE_INSTALLS_DIR is the installs root directly (no "installs" suffix), so
+	// the bare github/ubi layout lives one level under it.
+	source := filepath.Join(installsDir, "github-wharflab-tally", "latest", "tally")
+	got, err := registrar.classifySource(source)
+	if err != nil {
+		t.Fatalf("classifySource(%q): %v", source, err)
+	}
+	if got != sourceKindMise {
+		t.Fatalf("classifySource(%q) = %q, want %q", source, got, sourceKindMise)
 	}
 }
 

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -16,6 +16,7 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 	bunRoot := filepath.Join(home, ".bun", "install", "global")
 	bunBin := filepath.Join(home, ".bun", "bin")
 	uvToolDir := filepath.Join(home, ".local", "share", "uv", "tools")
+	miseInstalls := filepath.Join(home, ".local", "share", "mise", "installs")
 	virtualEnv := filepath.Join(home, "work", "project", ".custom-env")
 	registrar := dockerPluginRegistrar{
 		goos:       "linux",
@@ -132,6 +133,16 @@ func TestDockerPluginRegistrarClassifySource(t *testing.T) {
 				"tally",
 			),
 			want: "uv tool",
+		},
+		{
+			name: "mise github backend bare binary",
+			path: filepath.Join(miseInstalls, "github-wharflab-tally", "latest", "tally"),
+			want: "mise",
+		},
+		{
+			name: "mise asdf backend bin layout",
+			path: filepath.Join(miseInstalls, "tally", "0.44.2", "bin", "tally"),
+			want: "mise",
 		},
 		{
 			name: "python package install",

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -270,6 +270,63 @@ func TestDockerPluginRegistrarMiseInstallsDirOverride(t *testing.T) {
 	}
 }
 
+func TestDockerPluginRegistrarMiseSharedInstallDirs(t *testing.T) {
+	// Cannot run in parallel: sets/clears env vars that feed miseInstallRoots.
+	first := filepath.Join(t.TempDir(), "shared-a", "installs")
+	second := filepath.Join(t.TempDir(), "shared-b", "installs")
+	t.Setenv("MISE_SHARED_INSTALL_DIRS", first+string(os.PathListSeparator)+second)
+	for _, key := range []string{"TALLY_MISE_INSTALLS_DIR", "MISE_INSTALLS_DIR", "TALLY_MISE_DATA_DIR", "MISE_DATA_DIR"} {
+		t.Setenv(key, "")
+	}
+
+	registrar := dockerPluginRegistrar{
+		goos:    "linux",
+		homeDir: filepath.Join(t.TempDir(), "home"),
+	}
+
+	// Each shared dir is an installs root directly, so the bare github/ubi layout
+	// lives one level under it.
+	for _, root := range []string{first, second} {
+		source := filepath.Join(root, "github-wharflab-tally", "latest", "tally")
+		got, err := registrar.classifySource(source)
+		if err != nil {
+			t.Fatalf("classifySource(%q): %v", source, err)
+		}
+		if got != sourceKindMise {
+			t.Fatalf("classifySource(%q) = %q, want %q", source, got, sourceKindMise)
+		}
+	}
+}
+
+func TestDockerPluginRegistrarMiseSystemRoot(t *testing.T) {
+	// Cannot run in parallel: clears env vars that feed miseInstallRoots so the
+	// default system root is exercised.
+	for _, key := range []string{
+		"TALLY_MISE_INSTALLS_DIR", "MISE_INSTALLS_DIR", "MISE_SHARED_INSTALL_DIRS",
+		"TALLY_MISE_DATA_DIR", "MISE_DATA_DIR", "MISE_SYSTEM_DATA_DIR",
+	} {
+		t.Setenv(key, "")
+	}
+
+	registrar := dockerPluginRegistrar{
+		goos:    "linux",
+		homeDir: filepath.Join(t.TempDir(), "home"),
+	}
+
+	// mise's default system installs root: /usr/local/share/mise/installs.
+	source := filepath.Join(
+		string(filepath.Separator), "usr", "local", "share", "mise", "installs",
+		"github-wharflab-tally", "latest", "tally",
+	)
+	got, err := registrar.classifySource(source)
+	if err != nil {
+		t.Fatalf("classifySource(%q): %v", source, err)
+	}
+	if got != sourceKindMise {
+		t.Fatalf("classifySource(%q) = %q, want %q", source, got, sourceKindMise)
+	}
+}
+
 func TestDockerPluginRegistrarTargetPath(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/tally/cmd/docker_plugin_register_test.go
+++ b/cmd/tally/cmd/docker_plugin_register_test.go
@@ -214,9 +214,20 @@ func TestDockerPluginRegistrarMiseInstallRootsWindowsHomeFallback(t *testing.T) 
 	home := filepath.Join(string(filepath.Separator), "Users", "me")
 	registrar := dockerPluginRegistrar{goos: windowsGOOS, homeDir: home}
 
+	// miseInstallRoots normalizes via cleanPathList (filepath.Abs -> Clean), which
+	// on Windows resolves a drive-less rooted path against the current drive.
+	// Mirror that here so the expected values match regardless of platform.
+	normalize := func(elems ...string) string {
+		abs, err := filepath.Abs(filepath.Join(elems...))
+		if err != nil {
+			t.Fatalf("filepath.Abs(%v): %v", elems, err)
+		}
+		return filepath.Clean(abs)
+	}
+
 	roots := registrar.miseInstallRoots()
-	wantWindows := filepath.Clean(filepath.Join(home, "AppData", "Local", "mise", "installs"))
-	wantUnix := filepath.Clean(filepath.Join(home, ".local", "share", "mise", "installs"))
+	wantWindows := normalize(home, "AppData", "Local", "mise", "installs")
+	wantUnix := normalize(home, ".local", "share", "mise", "installs")
 	if !slices.Contains(roots, wantWindows) {
 		t.Fatalf("miseInstallRoots() = %v, want containing Windows fallback %q", roots, wantWindows)
 	}


### PR DESCRIPTION
## Problem

`tally register-docker-plugin` rejects mise-managed installs:

```
$ mise use -g github:wharflab/tally@latest
$ tally register-docker-plugin
Found Docker CLI version 25.0.8
Unable to register tally plugin - /home/vyatkin/.local/share/mise/installs/github-wharflab-tally/latest/tally is not a recognized persistent global tally install
```

## Root cause

`classifySource` (`cmd/tally/cmd/docker_plugin_register.go`) didn't recognize mise. The mise `github:`/`ubi` backend extracts a **single binary directly** into `<mise data dir>/installs/<tool>/<version>/tally` with **no `bin/` subdirectory**, so it failed the `looksLikeGlobalBinaryPath` heuristic — which requires a `bin`/`sbin`/`go`/`tools`/`packages` path segment — and fell through to the "not a recognized persistent global install" error.

## Fix

Add a mise classifier following the same **env-resolved-root** pattern already used for uv and Bun (rather than brittle substring matching, since mise's data dir is configurable):

- **`miseInstallRoots()`** resolves the install dir across platforms: `TALLY_MISE_DATA_DIR` (test/override hook) → `MISE_DATA_DIR` → `$XDG_DATA_HOME/mise` → `%LOCALAPPDATA%\mise` (Windows) → `~/.local/share/mise` default, each joined with `installs`.
- **`isMisePath()`** tests containment via the existing `pathWithin` helper.
- Wired as the **first** `classifySource` case so a real mise root wins over the generic `bin/` heuristic (which would otherwise mislabel the asdf-style layout as "global binary").

## Tests

Extended the table-driven `TestDockerPluginRegistrarClassifySource` with two cases, both using the `homeDir`-derived default root so they stay `t.Parallel()`-safe with no env mutation:

- **github backend** bare binary: `installs/github-wharflab-tally/latest/tally` (the exact bug layout)
- **asdf-style** layout: `installs/tally/0.44.2/bin/tally`

## Docs

mise was already a documented install method but lacked plugin-registration guidance:

- Command `Long` help now lists mise among recognized sources.
- `installation.mdx` mise section gained the `register-docker-plugin` note.
- `docker-cli-plugin.mdx` got a mise tab in the install `CodeGroup`.

## Verification

- `go test ./cmd/tally/cmd/ -run TestDockerPlugin` — pass
- `go vet`, `gofmt`, `make lint-fix` (via pre-commit hooks) — clean

> Note: the Mintlify docs validator (`npx mint validate`) could not run locally — it rejects Node 26 (requires an LTS version). The MDX changes are a new tab in an existing `CodeGroup` plus a prose line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation and Docker CLI plugin guides with additional mise install/register steps.

* **New Features**
  * Enhanced `register-docker-plugin` to recognize and classify plugin executables installed via mise-managed global installs directories.

* **Tests**
  * Added/extended coverage for mise installs path detection, including Windows home fallback and multiple env-driven root layouts.

* **Chores**
  * Adjusted linting rules to allow a specific env-mutating test to remain non-parallel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->