### PR TITLE
test(vscode): add Playwright + code-server UI tests

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -25,10 +25,20 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      # code-server is a devDependency whose postinstall hard-requires Node 22
+      # (it parses the node major out of the npm user-agent string), so the
+      # install step needs the same Node/user-agent setup as the UI job even
+      # though the smoke test itself does not launch code-server.
+      - name: Set up Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
       - name: Install extension dependencies
         working-directory: _integrations/vscode-tally
+        env:
+          npm_config_user_agent: npm/10.0.0 node/v22.0.0
         run: bun install --frozen-lockfile
       - name: Typescript check
         working-directory: _integrations/vscode-tally

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -35,6 +35,11 @@ jobs:
           node-version: 22
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+      # code-server's postinstall rebuilds native node modules bundled in
+      # lib/vscode (kerberos -> libkrb5-dev, keytar -> libsecret-1-dev); their
+      # headers are absent on the runner and the build fails hard without them.
+      - name: Install code-server native build deps
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev libsecret-1-dev
       - name: Install extension dependencies
         working-directory: _integrations/vscode-tally
         env:
@@ -105,6 +110,11 @@ jobs:
           node-version: 22
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+      # code-server's postinstall rebuilds native node modules bundled in
+      # lib/vscode (kerberos -> libkrb5-dev, keytar -> libsecret-1-dev); their
+      # headers are absent on the runner and the build fails hard without them.
+      - name: Install code-server native build deps
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev libsecret-1-dev
       - name: Install extension dependencies
         working-directory: _integrations/vscode-tally
         env:

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -75,3 +75,67 @@ jobs:
           use_oidc: true
           files: coverage-vscode-smoke.filtered.txt
           fail_ci_if_error: true
+  vscode-ui-tests:
+    name: VS Code UI Tests (Playwright)
+    runs-on: ubuntu-latest
+    env:
+      GOCOVERDIR: ${{ github.workspace }}/coverage-vscode-ui
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/shellcheck-wasm
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      # code-server hard-requires Node 22 (its postinstall parses the node major
+      # version out of the npm user-agent string and refuses anything else).
+      - name: Set up Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install extension dependencies
+        working-directory: _integrations/vscode-tally
+        env:
+          # bun does not advertise an npm-compatible user-agent; code-server's
+          # postinstall rejects anything that is not npm*/yarn* and reads the
+          # node major from this same string, so it must say node/v22.
+          npm_config_user_agent: npm/10.0.0 node/v22.0.0
+        run: bun install --frozen-lockfile
+      - name: Install Playwright Chromium
+        working-directory: _integrations/vscode-tally
+        # channel:"chromium" needs the full browser, not the headless shell.
+        run: bunx playwright install --with-deps chromium
+      - name: Prepare coverage dir
+        run: mkdir -p "$GOCOVERDIR"
+      - name: Run Playwright UI tests
+        working-directory: _integrations/vscode-tally
+        run: bun run test:e2e:ui
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: _integrations/vscode-tally/playwright-report
+          retention-days: 7
+      - name: Upload Playwright traces and videos on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-test-results
+          path: _integrations/vscode-tally/test-results
+          retention-days: 7
+      - name: Convert coverage
+        if: ${{ !cancelled() }}
+        run: |
+          go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage-vscode-ui.txt
+          # Force generated code to 100% coverage to avoid skewing project totals.
+          bash scripts/filter-go-coverprofile.sh coverage-vscode-ui.txt coverage-vscode-ui.filtered.txt
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
+          files: coverage-vscode-ui.filtered.txt
+          fail_ci_if_error: false

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -146,14 +146,17 @@ jobs:
           name: playwright-test-results
           path: _integrations/vscode-tally/test-results
           retention-days: 7
+      # Only on success: a failed run can leave GOCOVERDIR empty (e.g. setup
+      # never built the binary), and `covdata textfmt` exits non-zero on an
+      # empty dir — which would add a spurious red step to an already-red job.
       - name: Convert coverage
-        if: ${{ !cancelled() }}
+        if: success()
         run: |
           go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage-vscode-ui.txt
           # Force generated code to 100% coverage to avoid skewing project totals.
           bash scripts/filter-go-coverprofile.sh coverage-vscode-ui.txt coverage-vscode-ui.filtered.txt
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
+        if: success()
         uses: codecov/codecov-action@v7
         with:
           use_oidc: true

--- a/_integrations/vscode-tally/.gitignore
+++ b/_integrations/vscode-tally/.gitignore
@@ -1,1 +1,5 @@
 LICENSE
+playwright-report/
+test-results/
+.test_setup/
+*.vsix

--- a/_integrations/vscode-tally/.vscodeignore
+++ b/_integrations/vscode-tally/.vscodeignore
@@ -4,6 +4,11 @@ bunfig.toml
 bun.lock
 node_modules/**
 test/**
+tests-ui/**
+playwright.config.ts
+playwright-report/**
+test-results/**
+.test_setup/**
 .oxfmtrc.json
 .oxlintrc.json
 bundled/bin/.gitkeep

--- a/_integrations/vscode-tally/DEVELOPMENT.md
+++ b/_integrations/vscode-tally/DEVELOPMENT.md
@@ -8,6 +8,39 @@ This folder contains the VS Code extension that talks to `tally lsp --stdio`.
 - `bun run typecheck`
 - `bun run compile`
 - `bun run test:e2e` (launches VS Code via `@vscode/test-electron`)
+- `bun run test:e2e:ui` (drives rendered VS Code via code-server + Playwright)
+
+## End-to-end tests
+
+There are two complementary e2e layers:
+
+1. **Extension-host smoke test** (`test/`, `bun run test:e2e`) — launches desktop
+   VS Code with `@vscode/test-electron` and asserts the programmatic LSP contract
+   (exact diagnostic counts, snapshot-equal formatting, `tally.applyAllFixes`
+   output) from *inside* the extension host.
+2. **UI tests** (`tests-ui/`, `bun run test:e2e:ui`) — install the packaged
+   `.vsix` into a headless [code-server](https://github.com/coder/code-server)
+   and drive the *rendered* workbench in headless Chromium via
+   [`@playwright/test`](https://playwright.dev). These prove the behaviour
+   actually surfaces in the UI (Problems panel, Format Document, the quick-fix
+   menu, the status bar).
+
+### Running the UI tests locally
+
+```bash
+# code-server requires Node 22 (its postinstall hard-checks the node major).
+# If your default node differs, select 22 (e.g. via mise/nvm) for the install.
+npm_config_user_agent="npm/10.0.0 node/v22.0.0" bun install
+bunx playwright install chromium
+bun run test:e2e:ui            # packages the vsix, then runs Playwright
+bun run test:e2e:ui:headed     # watch it run in a real browser window
+bun run test:e2e:ui:debug      # Playwright UI mode
+```
+
+The `setup` Playwright project builds a `tally` LSP binary into `.test_setup/`
+and installs the freshly packaged `.vsix`; the `cleanup` project removes
+`.test_setup/` afterwards. Pass `VSIX_PATH=<rel>` or `TALLY_BIN=<abs>` to
+override either artifact.
 
 ## Packaging
 

--- a/_integrations/vscode-tally/bun.lock
+++ b/_integrations/vscode-tally/bun.lock
@@ -9,6 +9,7 @@
         "vscode-languageclient": "^10.0.0",
       },
       "devDependencies": {
+        "@playwright/test": "1.61.0",
         "@types/bun": "1.3.14",
         "@types/node": "26.0.0",
         "@types/semver": "7.7.1",
@@ -16,6 +17,7 @@
         "@typescript/native-preview": "7.0.0-dev.20260619.1",
         "@vscode/test-electron": "3.0.0",
         "@vscode/vsce": "3.9.2",
+        "code-server": "4.106.3",
         "exponential-backoff": "3.1.3",
         "oxfmt": "0.55.0",
         "oxlint": "1.70.0",
@@ -24,6 +26,13 @@
       },
     },
   },
+  "trustedDependencies": [
+    "@vscode/vsce",
+    "keytar",
+    "@vscode/vsce-sign",
+    "argon2",
+    "code-server",
+  ],
   "packages": {
     "@azu/format-text": ["@azu/format-text@1.0.2", "", {}, "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="],
 
@@ -55,7 +64,11 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
+
+    "@coder/logger": ["@coder/logger@3.0.1", "", {}, "sha512-G/wWSaNZW8HvQZWXlXdbZbp/MOQBPH4W1AKSEI3PBfr0qc9G+pdLrXvm3XakQpNVqmD6WFAbLfcjdG0BuoAO0g=="],
 
     "@iarna/toml": ["@iarna/toml@2.2.5", "", {}, "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="],
 
@@ -68,6 +81,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@1.0.11", "", { "dependencies": { "detect-libc": "^2.0.0", "https-proxy-agent": "^5.0.0", "make-dir": "^3.1.0", "node-fetch": "^2.6.7", "nopt": "^5.0.0", "npmlog": "^5.0.1", "rimraf": "^3.0.2", "semver": "^7.3.5", "tar": "^6.1.11" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ=="],
 
     "@microsoft/1ds-core-js": ["@microsoft/1ds-core-js@4.4.2", "", { "dependencies": { "@microsoft/applicationinsights-core-js": "3.4.2", "@microsoft/applicationinsights-shims": "3.0.1", "@microsoft/dynamicproto-js": "^2.0.3", "@nevware21/ts-async": ">= 0.5.5 < 0.6.0", "@nevware21/ts-utils": ">= 0.14.0 < 2.x" } }, "sha512-8cF2XKBMOOASA3l/SLqybGeZ5e+vhtpYeHTBCM1WoQJ5M8suw181FBKgdyz8XP0fTgv1LTOHqPDSmddMiFaJ/g=="],
 
@@ -181,7 +196,11 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.70.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g=="],
 
+    "@phc/format": ["@phc/format@1.0.0", "", {}, "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
 
     "@renovatebot/pep440": ["@renovatebot/pep440@4.2.4", "", {}, "sha512-r+Pwj9ud/5QOOHoSsD7mWzU0Qkj105UPOyPwihGAtbNCl9pqnWkEDNRM5an63QvsFsS9tt+X3o+npT3AKBiTVg=="],
 
@@ -220,6 +239,8 @@
     "@textlint/resolver": ["@textlint/resolver@15.7.1", "", {}, "sha512-8XnO0pgF6mXnm41VvWmBbEIdGPhiCUt31uLZkOis1ECeg/1SoUcIT6Mx/F0e1rukq8l0UlOSeY9a31CsvRMK0g=="],
 
     "@textlint/types": ["@textlint/types@15.7.1", "", { "dependencies": { "@textlint/ast-node-types": "15.7.1" } }, "sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -283,6 +304,10 @@
 
     "@vscode/vsce-sign-win32-x64": ["@vscode/vsce-sign-win32-x64@2.0.6", "", { "os": "win32", "cpu": "x64" }, "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ=="],
 
+    "abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -297,7 +322,15 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "aproba": ["aproba@2.1.0", "", {}, "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew=="],
+
+    "are-we-there-yet": ["are-we-there-yet@2.0.0", "", { "dependencies": { "delegates": "^1.0.0", "readable-stream": "^3.6.0" } }, "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw=="],
+
+    "argon2": ["argon2@0.31.2", "", { "dependencies": { "@mapbox/node-pre-gyp": "^1.0.11", "@phc/format": "^1.0.0", "node-addon-api": "^7.0.0" } }, "sha512-QSnJ8By5Mth60IEte45w9Y7v6bWcQw3YhRtJKKN8oNCxnTLDiv/AXXkDPf2srTMfxFVn3QJdVv2nhXESsUa+Yg=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
     "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
 
@@ -309,11 +342,15 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
     "binaryextensions": ["binaryextensions@6.11.0", "", { "dependencies": { "editions": "^6.21.0" } }, "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -327,13 +364,21 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
+    "buffer-alloc": ["buffer-alloc@1.2.0", "", { "dependencies": { "buffer-alloc-unsafe": "^1.1.0", "buffer-fill": "^1.0.0" } }, "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow=="],
+
+    "buffer-alloc-unsafe": ["buffer-alloc-unsafe@1.1.0", "", {}, "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="],
+
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
+    "buffer-fill": ["buffer-fill@1.0.0", "", {}, "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "c8": ["c8@9.1.0", "", { "dependencies": { "@bcoe/v8-coverage": "^0.2.3", "@istanbuljs/schema": "^0.1.3", "find-up": "^5.0.0", "foreground-child": "^3.1.1", "istanbul-lib-coverage": "^3.2.0", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.1.6", "test-exclude": "^6.0.0", "v8-to-istanbul": "^9.0.0", "yargs": "^17.7.2", "yargs-parser": "^21.1.1" }, "bin": { "c8": "bin/c8.js" } }, "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg=="],
 
@@ -344,6 +389,8 @@
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "charenc": ["charenc@0.0.2", "", {}, "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="],
 
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
 
@@ -361,25 +408,49 @@
 
     "cockatiel": ["cockatiel@3.2.1", "", {}, "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q=="],
 
+    "code-server": ["code-server@4.106.3", "", { "dependencies": { "@coder/logger": "^3.0.1", "argon2": "^0.31.1", "compression": "^1.7.4", "cookie-parser": "^1.4.6", "env-paths": "^2.2.1", "express": "^5.0.1", "http-proxy": "^1.18.1", "httpolyglot": "^0.1.2", "i18next": "^25.3.0", "js-yaml": "^4.1.0", "limiter": "^2.1.0", "pem": "^1.14.8", "proxy-agent": "^6.3.1", "qs": "6.14.0", "rotating-file-stream": "^3.1.1", "safe-compare": "^1.1.4", "semver": "^7.5.4", "ws": "^8.14.2", "xdg-basedir": "^4.0.0" }, "bin": { "code-server": "out/node/entry.js" } }, "sha512-GCspZ2Naj4/1pCVgfD3swU0/6RWGiodqeugwYLofT4rShPMCJXiw+hQYNREQlA6Yp53vJuRlR9ccrfIPLNQAKw=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
+    "compressible": ["compressible@2.0.18", "", { "dependencies": { "mime-db": ">= 1.43.0 < 2" } }, "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg=="],
+
+    "compression": ["compression@1.8.1", "", { "dependencies": { "bytes": "3.1.2", "compressible": "~2.0.18", "debug": "2.6.9", "negotiator": "~0.6.4", "on-headers": "~1.1.0", "safe-buffer": "5.2.1", "vary": "~1.1.2" } }, "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w=="],
+
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "console-control-strings": ["console-control-strings@1.1.0", "", {}, "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-parser": ["cookie-parser@1.4.7", "", { "dependencies": { "cookie": "0.7.2", "cookie-signature": "1.0.6" } }, "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw=="],
+
+    "cookie-signature": ["cookie-signature@1.0.6", "", {}, "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "crypt": ["crypt@0.0.2", "", {}, "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="],
+
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -395,7 +466,13 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "delegates": ["delegates@1.0.0", "", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -419,7 +496,11 @@
 
     "editions": ["editions@6.22.0", "", { "dependencies": { "version-range": "^4.15.0" } }, "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
@@ -428,6 +509,8 @@
     "enhanced-resolve": ["enhanced-resolve@5.24.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -439,13 +522,31 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "es6-promisify": ["es6-promisify@7.0.0", "", {}, "sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -457,23 +558,35 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
+
+    "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
 
+    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
+
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gauge": ["gauge@3.0.2", "", { "dependencies": { "aproba": "^1.0.3 || ^2.0.0", "color-support": "^1.1.2", "console-control-strings": "^1.0.0", "has-unicode": "^2.0.1", "object-assign": "^4.1.1", "signal-exit": "^3.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wide-align": "^1.1.2" } }, "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -482,6 +595,8 @@
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
@@ -501,6 +616,8 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
+    "has-unicode": ["has-unicode@2.0.1", "", {}, "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="],
+
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
@@ -511,9 +628,17 @@
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-proxy": ["http-proxy@1.18.1", "", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
+
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
+    "httpolyglot": ["httpolyglot@0.1.2", "", {}, "sha512-ouHI1AaQMLgn4L224527S5+vq6hgvqPteurVfbm7ChViM3He2Wa8KP1Ny7pTYd7QKnDSPKcN8JYfC8r/lmsE3A=="],
+
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "i18next": ["i18next@25.10.10", "", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -531,7 +656,13 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
@@ -548,6 +679,8 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
@@ -583,6 +716,8 @@
 
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
+    "just-performance": ["just-performance@4.3.0", "", {}, "sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q=="],
+
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
@@ -592,6 +727,8 @@
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
+    "limiter": ["limiter@2.1.0", "", { "dependencies": { "just-performance": "4.3.0" } }, "sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw=="],
 
     "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
 
@@ -619,13 +756,19 @@
 
     "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
-    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+    "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 
     "markdown-it": ["markdown-it@14.2.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.1", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "md5": ["md5@2.3.0", "", { "dependencies": { "charenc": "0.0.2", "crypt": "0.0.2", "is-buffer": "~1.1.6" } }, "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g=="],
+
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -647,6 +790,10 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
+
+    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
+
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mocha": ["mocha@10.8.2", "", { "dependencies": { "ansi-colors": "^4.1.3", "browser-stdout": "^1.3.1", "chokidar": "^3.5.3", "debug": "^4.3.5", "diff": "^5.2.0", "escape-string-regexp": "^4.0.0", "find-up": "^5.0.0", "glob": "^8.1.0", "he": "^1.2.0", "js-yaml": "^4.1.0", "log-symbols": "^4.1.0", "minimatch": "^5.1.6", "ms": "^2.1.3", "serialize-javascript": "^6.0.2", "strip-json-comments": "^3.1.1", "supports-color": "^8.1.1", "workerpool": "^6.5.1", "yargs": "^16.2.0", "yargs-parser": "^20.2.9", "yargs-unparser": "^2.0.0" }, "bin": { "mocha": "bin/mocha.js", "_mocha": "bin/_mocha" } }, "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg=="],
@@ -657,19 +804,35 @@
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
+    "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
     "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
 
     "node-addon-api": ["node-addon-api@4.3.0", "", {}, "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-sarif-builder": ["node-sarif-builder@3.4.0", "", { "dependencies": { "@types/sarif": "^2.1.7", "fs-extra": "^11.1.1" } }, "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg=="],
+
+    "nopt": ["nopt@5.0.0", "", { "dependencies": { "abbrev": "1" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ=="],
 
     "normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
+    "npmlog": ["npmlog@5.0.1", "", { "dependencies": { "are-we-there-yet": "^2.0.0", "console-control-strings": "^1.1.0", "gauge": "^3.0.0", "set-blocking": "^2.0.0" } }, "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw=="],
+
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "on-headers": ["on-headers@1.1.0", "", {}, "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -678,6 +841,8 @@
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
+
+    "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
 
     "oxfmt": ["oxfmt@0.55.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.55.0", "@oxfmt/binding-android-arm64": "0.55.0", "@oxfmt/binding-darwin-arm64": "0.55.0", "@oxfmt/binding-darwin-x64": "0.55.0", "@oxfmt/binding-freebsd-x64": "0.55.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.55.0", "@oxfmt/binding-linux-arm-musleabihf": "0.55.0", "@oxfmt/binding-linux-arm64-gnu": "0.55.0", "@oxfmt/binding-linux-arm64-musl": "0.55.0", "@oxfmt/binding-linux-ppc64-gnu": "0.55.0", "@oxfmt/binding-linux-riscv64-gnu": "0.55.0", "@oxfmt/binding-linux-riscv64-musl": "0.55.0", "@oxfmt/binding-linux-s390x-gnu": "0.55.0", "@oxfmt/binding-linux-x64-gnu": "0.55.0", "@oxfmt/binding-linux-x64-musl": "0.55.0", "@oxfmt/binding-openharmony-arm64": "0.55.0", "@oxfmt/binding-win32-arm64-msvc": "0.55.0", "@oxfmt/binding-win32-ia32-msvc": "0.55.0", "@oxfmt/binding-win32-x64-msvc": "0.55.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-jSj2wCTakwgPMxkfiVZX0jf+nX+Nz6xlyAZjqNE0qXTFdCBPYlP6JAN+ODjmealw7DXBjOzYbdsqwBMAZnPZ6A=="],
 
@@ -690,6 +855,10 @@
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
@@ -705,6 +874,8 @@
 
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
@@ -713,7 +884,11 @@
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
+
+    "pem": ["pem@1.14.8", "", { "dependencies": { "es6-promisify": "^7.0.0", "md5": "^2.3.0", "os-tmpdir": "^1.0.2", "which": "^2.0.2" } }, "sha512-ZpbOf4dj9/fQg5tQzTqv4jSKJQsK7tPl0pm4/pvPcZVjZcJg7TMfr3PBk6gJH97lnpJDu4e4v8UUqEz5daipCg=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -721,21 +896,35 @@
 
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
+
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
-    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+    "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -753,15 +942,25 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
+
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "rotating-file-stream": ["rotating-file-stream@3.2.9", "", {}, "sha512-i9i0KkHh12ryl4xtELg+0gyoFre2PJ9RcQQLzquWsiqygyYsrZLckrqqYrthhnJZGZb4g+KUHtcoWYVq34gaug=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-compare": ["safe-compare@1.1.4", "", { "dependencies": { "buffer-alloc": "^1.2.0" } }, "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -771,9 +970,17 @@
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
 
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -797,6 +1004,14 @@
 
     "slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "spdx-correct": ["spdx-correct@3.2.0", "", { "dependencies": { "spdx-expression-parse": "^3.0.0", "spdx-license-ids": "^3.0.0" } }, "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA=="],
 
     "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
@@ -806,6 +1021,8 @@
     "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
 
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
@@ -831,6 +1048,8 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
@@ -849,6 +1068,10 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
@@ -856,6 +1079,8 @@
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typed-rest-client": ["typed-rest-client@1.8.11", "", { "dependencies": { "qs": "^6.9.1", "tunnel": "0.0.6", "underscore": "^1.12.1" } }, "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA=="],
 
@@ -871,6 +1096,8 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
@@ -878,6 +1105,8 @@
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "version-range": ["version-range@4.15.0", "", {}, "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg=="],
 
@@ -893,11 +1122,17 @@
 
     "vscode-python-envs": ["vscode-python-envs@github:microsoft/vscode-python-environments#54f6628", { "dependencies": { "@iarna/toml": "^2.2.5", "@renovatebot/pep440": "^4.2.4", "@vscode/extension-telemetry": "^0.9.7", "@vscode/test-cli": "^0.0.10", "dotenv": "^16.4.5", "fs-extra": "^11.2.0", "stack-trace": "0.0.10", "vscode-jsonrpc": "^9.0.0-next.5", "which": "^4.0.0" } }, "microsoft-vscode-python-environments-54f6628", "sha512-spHhabzW3lARA3mDbynp/9VGdbERYGqnJ0WwDFgWgwPQzsRvakcmdqvsxoFeVIPuN6aQsRxpa/2dTocy2sVzAQ=="],
 
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
 
     "workerpool": ["workerpool@6.5.1", "", {}, "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA=="],
 
@@ -907,7 +1142,11 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "xdg-basedir": ["xdg-basedir@4.0.0", "", {}, "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="],
 
     "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
 
@@ -933,6 +1172,8 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
+    "@mapbox/node-pre-gyp/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "@secretlint/formatter/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@textlint/linter-formatter/pluralize": ["pluralize@2.0.0", "", {}, "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw=="],
@@ -947,27 +1188,61 @@
 
     "@vscode/test-cli/supports-color": ["supports-color@9.4.0", "", {}, "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw=="],
 
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "are-we-there-yet/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "argon2/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "body-parser/qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
     "bun-types/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "compressible/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "express/cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "express/qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "gauge/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "jwa/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "jws/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "istanbul-lib-report/make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "mocha/glob": ["glob@8.1.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^5.0.1", "once": "^1.3.0" } }, "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ=="],
 
@@ -991,15 +1266,27 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
-    "randombytes/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "pem/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "read-pkg/unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
 
+    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -1007,13 +1294,23 @@
 
     "table/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
+
+    "tar/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
+
     "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "test-exclude/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
-    "tunnel-agent/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "typed-rest-client/qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "wide-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1029,6 +1326,8 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "@mapbox/node-pre-gyp/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "@textlint/linter-formatter/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@textlint/linter-formatter/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -1037,13 +1336,23 @@
 
     "@vscode/test-cli/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "gauge/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "gauge/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "mocha/log-symbols/is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
@@ -1055,6 +1364,12 @@
 
     "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "pem/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "table/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1062,6 +1377,12 @@
     "table/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "wide-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wide-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -1087,12 +1408,18 @@
 
     "mocha/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
+
     "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "wide-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "mocha/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "mocha/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/_integrations/vscode-tally/package.json
+++ b/_integrations/vscode-tally/package.json
@@ -31,9 +31,12 @@
     "compile": "bun build src/extension.ts --outfile=dist/extension.cjs --format=cjs --target=node --external=vscode --sourcemap=inline",
     "typecheck": "tsgo",
     "lint": "oxlint --type-aware ./src",
-    "format": "oxfmt --write src test",
-    "format:check": "oxfmt --check src test",
+    "format": "oxfmt --write src test tests-ui",
+    "format:check": "oxfmt --check src test tests-ui",
     "test:e2e": "bun test test/e2e/*.test.ts",
+    "test:e2e:ui": "bun run vsce:package && node tests-ui/run-playwright.mjs",
+    "test:e2e:ui:headed": "bun run vsce:package && node tests-ui/run-playwright.mjs --headed",
+    "test:e2e:ui:debug": "bun run vsce:package && node tests-ui/run-playwright.mjs --ui",
     "prevsce:package": "cp ../../LICENSE . && bun run compile",
     "vsce:package": "bunx @vscode/vsce package --no-dependencies"
   },
@@ -42,6 +45,7 @@
     "vscode-languageclient": "^10.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "1.61.0",
     "@types/bun": "1.3.14",
     "@types/node": "26.0.0",
     "@types/semver": "7.7.1",
@@ -49,12 +53,21 @@
     "@typescript/native-preview": "7.0.0-dev.20260619.1",
     "@vscode/test-electron": "3.0.0",
     "@vscode/vsce": "3.9.2",
+    "code-server": "4.106.3",
     "exponential-backoff": "3.1.3",
     "oxfmt": "0.55.0",
     "oxlint": "1.70.0",
     "oxlint-tsgolint": "0.23.0",
     "vscode-python-envs": "github:microsoft/vscode-python-environments#v1.36.0"
   },
+  "trustedDependencies": [
+    "@vscode/vsce",
+    "@vscode/vsce-sign",
+    "argon2",
+    "code-server",
+    "esbuild",
+    "keytar"
+  ],
   "contributes": {
     "commands": [
       {

--- a/_integrations/vscode-tally/playwright.config.ts
+++ b/_integrations/vscode-tally/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig } from "@playwright/test";
+
+// End-to-end UI tests that drive a *rendered* VS Code (via code-server) in a
+// headless browser. This complements the in-extension-host smoke test under
+// `test/` (@vscode/test-electron): that one asserts the programmatic LSP
+// contract from inside the extension host, while this layer proves the
+// behaviour actually surfaces in the workbench UI a user sees.
+export default defineConfig({
+  testDir: "./tests-ui",
+  // VS Code UI work is stateful and chord-driven; keep it serialized.
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // A single worker amortizes the one shared code-server and avoids the
+  // focus races that plague parallel command-palette interactions.
+  workers: 1,
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "list",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  use: {
+    viewport: { width: 1512, height: 944 },
+    actionTimeout: 15_000,
+    video: "retain-on-failure",
+    trace: "retain-on-failure",
+    // Reading editor content goes through the clipboard (Monaco virtualizes
+    // `.view-line`, so DOM scraping is unreliable).
+    permissions: ["clipboard-read", "clipboard-write"],
+    launchOptions: {
+      // Needed only when running as root / in a container without user
+      // namespaces; harmless on the non-root GitHub runner.
+      args: process.env.CI ? ["--no-sandbox", "--disable-setuid-sandbox"] : [],
+    },
+  },
+  projects: [
+    // Builds the tally LSP binary and installs the packaged .vsix into a
+    // private extensions dir (sha256-cached). Runs once before the specs.
+    { name: "setup", testMatch: /extension\.setup\.ts$/ },
+    {
+      name: "ui",
+      testMatch: /.*\.spec\.ts$/,
+      dependencies: ["setup"],
+      // channel:"chromium" = Chrome new-headless, which Playwright recommends
+      // for high-accuracy UI/extension testing (needs the full chromium
+      // download, not the headless shell).
+      use: { browserName: "chromium", channel: "chromium", headless: true },
+    },
+    // Removes the .test_setup scratch dir after the specs finish.
+    { name: "cleanup", testMatch: /extension\.teardown\.ts$/, dependencies: ["ui"] },
+  ],
+});

--- a/_integrations/vscode-tally/src/vendor/pythonEnvsApi.d.ts
+++ b/_integrations/vscode-tally/src/vendor/pythonEnvsApi.d.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
+import type {
     Disposable,
     Event,
     FileChangeType,
@@ -337,6 +337,14 @@ export interface QuickCreateConfig {
 
 /**
  * Interface representing an environment manager.
+ *
+ * @remarks
+ * Methods on this interface are invoked both by the Python Environments extension itself
+ * (in response to UI actions, startup, terminal activation, script execution, and so on)
+ * and directly by other extensions that consume the published API. Any "called when…"
+ * notes on individual methods list representative triggers only — they are not
+ * exhaustive, and the precise set of call sites may evolve over time. Implementations
+ * should focus on the documented contract rather than any specific caller.
  */
 export interface EnvironmentManager {
     /**
@@ -390,6 +398,11 @@ export interface EnvironmentManager {
      * @param scope - The scope within which to create the environment.
      * @param options - Optional parameters for creating the Python environment.
      * @returns A promise that resolves to the created Python environment, or undefined if creation failed.
+     *
+     * @remarks
+     * Invoked when an environment of this manager's type should be created for the given
+     * scope. Typical triggers include user-initiated environment-creation flows and
+     * programmatic creation via the API.
      */
     create?(scope: CreateEnvironmentScope, options?: CreateEnvironmentOptions): Promise<PythonEnvironment | undefined>;
 
@@ -397,6 +410,10 @@ export interface EnvironmentManager {
      * Removes the specified Python environment.
      * @param environment - The Python environment to remove.
      * @returns A promise that resolves when the environment is removed.
+     *
+     * @remarks
+     * Invoked to delete the given environment. Typical triggers include an explicit user
+     * action (such as a "Delete Environment" command) and programmatic removal via the API.
      */
     remove?(environment: PythonEnvironment): Promise<void>;
 
@@ -404,6 +421,10 @@ export interface EnvironmentManager {
      * Refreshes the list of Python environments within the specified scope.
      * @param scope - The scope within which to refresh environments.
      * @returns A promise that resolves when the refresh is complete.
+     *
+     * @remarks
+     * Forces the manager to re-discover environments for the given scope. Typically
+     * triggered by an explicit user "refresh" action.
      */
     refresh(scope: RefreshEnvironmentsScope): Promise<void>;
 
@@ -411,6 +432,10 @@ export interface EnvironmentManager {
      * Retrieves a list of Python environments within the specified scope.
      * @param scope - The scope within which to retrieve environments.
      * @returns A promise that resolves to an array of Python environments.
+     *
+     * @remarks
+     * Returns the environments known to this manager for the given scope. Called
+     * frequently by UI surfaces (tree views, pickers) and by other consumers of the API.
      */
     getEnvironments(scope: GetEnvironmentsScope): Promise<PythonEnvironment[]>;
 
@@ -424,6 +449,14 @@ export interface EnvironmentManager {
      * @param scope - The scope within which to set the environment.
      * @param environment - The Python environment to set. If undefined, the environment is unset.
      * @returns A promise that resolves when the environment is set.
+     *
+     * @remarks
+     * Invoked when the active environment for the given scope should change — for example
+     * after the user selects an environment in a picker, after a newly created environment
+     * is auto-selected, or programmatically via the API.
+     *
+     * Also invoked at extension startup to rehydrate the active environment from
+     * persisted state.
      */
     set(scope: SetEnvironmentScope, environment?: PythonEnvironment): Promise<void>;
 
@@ -431,6 +464,12 @@ export interface EnvironmentManager {
      * Retrieves the current Python environment within the specified scope.
      * @param scope - The scope within which to retrieve the environment.
      * @returns A promise that resolves to the current Python environment, or undefined if none is set.
+     *
+     * @remarks
+     * Returns the currently active environment for the given scope, or `undefined` if
+     * none is selected. Called very frequently — at startup, after {@link set}, when a
+     * terminal is opened, before running Python, by UI surfaces that display the active
+     * interpreter, and by other extensions consuming the API.
      */
     get(scope: GetEnvironmentScope): Promise<PythonEnvironment | undefined>;
 
@@ -450,6 +489,14 @@ export interface EnvironmentManager {
      *
      * @param context - The context for resolving the environment, which can be a {@link PythonEnvironment} or a {@link Uri}.
      * @returns A promise that resolves to the fully detailed {@link PythonEnvironment}, or `undefined` if the environment cannot be resolved.
+     *
+     * @remarks
+     * Called to turn a lightly-populated {@link PythonEnvironment} or a {@link Uri}
+     * pointing at an interpreter or environment folder into a fully-populated
+     * {@link PythonEnvironment} with complete {@link PythonEnvironment.execInfo}. Typical
+     * triggers include the user manually selecting an interpreter path, resolving
+     * `python.defaultInterpreterPath` at startup, and populating execution details before
+     * launching Python.
      */
     resolve(context: ResolveEnvironmentContext): Promise<PythonEnvironment | undefined>;
 
@@ -457,6 +504,12 @@ export interface EnvironmentManager {
      * Clears the environment manager's cache.
      *
      * @returns A promise that resolves when the cache is cleared.
+     *
+     * @remarks
+     * Drops any cached environment data held by the manager so that subsequent calls to
+     * {@link EnvironmentManager.getEnvironments} or {@link EnvironmentManager.get}
+     * re-discover state from disk. Typically triggered by an explicit user "clear cache"
+     * action.
      */
     clearCache?(): Promise<void>;
 }
@@ -519,6 +572,11 @@ export interface PackageInfo {
      * The URIs associated with the package.
      */
     readonly uris?: readonly Uri[];
+
+    /**
+     * Whether the package is a transitive dependency.
+     */
+    readonly isTransitive?: boolean;
 }
 
 /**
@@ -611,21 +669,36 @@ export interface PackageManager {
     /**
      * Refreshes the package list for the specified Python environment.
      * @param environment - The Python environment for which to refresh the package list.
-     * @returns A promise that resolves when the refresh is complete.
+     * @returns A promise that resolves with the refreshed list of packages, or undefined.
      */
-    refresh(environment: PythonEnvironment): Promise<void>;
+    refresh(environment: PythonEnvironment): Promise<Package[] | undefined>;
 
     /**
      * Retrieves the list of packages for the specified Python environment.
      * @param environment - The Python environment for which to retrieve packages.
+     * @param options - Optional settings for package retrieval.
      * @returns An array of packages, or undefined if the packages could not be retrieved.
      */
-    getPackages(environment: PythonEnvironment): Promise<Package[] | undefined>;
+    getPackages(environment: PythonEnvironment, options?: GetPackagesOptions): Promise<Package[] | undefined>;
 
     /**
      * Event that is fired when packages change.
      */
     onDidChangePackages?: Event<DidChangePackagesEventArgs>;
+
+    /**
+     * Fetches the names of direct (non-transitive) packages for the specified Python environment.
+     *
+     * **Caveat:** Most package managers cannot track user install intent. For pip, this uses
+     * `pip list --not-required` which returns packages with no installed dependents (leaf packages),
+     * not necessarily packages the user explicitly installed. For example, if a user runs
+     * `pip install flask werkzeug`, werkzeug will still be reported as transitive because flask
+     * depends on it. This is a best-effort approximation.
+     *
+     * @param environment - The Python environment for which to fetch direct package names.
+     * @returns A promise that resolves to a set of package name strings, or undefined if not supported.
+     */
+    getDirectPackageNames?(environment: PythonEnvironment): Promise<Set<string> | undefined>;
 
     /**
      * Clears the package manager's cache.
@@ -735,6 +808,17 @@ export interface DidChangePythonProjectsEventArgs {
     removed: PythonProject[];
 }
 
+/**
+ * Options for retrieving packages from a package manager.
+ */
+export interface GetPackagesOptions {
+    /**
+     * When `true`, bypasses the cache and fetches the latest packages from the underlying tool.
+     * Defaults to `false`.
+     */
+    skipCache?: boolean;
+}
+
 export type PackageManagementOptions =
     | {
           /**
@@ -836,10 +920,13 @@ export interface PythonEnvironmentManagerRegistrationApi {
      * Register an environment manager implementation.
      *
      * @param manager Environment Manager implementation to register.
+     * @param options Optional registration options.
+     * @param options.extensionId The extension ID of the calling extension. When this is not specified,
+     * or when the specified extension cannot be found, the extension ID will be automatically detected.
      * @returns A disposable that can be used to unregister the environment manager.
      * @see {@link EnvironmentManager}
      */
-    registerEnvironmentManager(manager: EnvironmentManager): Disposable;
+    registerEnvironmentManager(manager: EnvironmentManager, options?: { extensionId?: string }): Disposable;
 }
 
 export interface PythonEnvironmentItemApi {
@@ -941,10 +1028,13 @@ export interface PythonPackageManagerRegistrationApi {
      * Register a package manager implementation.
      *
      * @param manager Package Manager implementation to register.
+     * @param options Optional registration options.
+     * @param options.extensionId The extension ID of the calling extension. When this is not specified,
+     * or when the specified extension cannot be found, the extension ID will be automatically detected.
      * @returns A disposable that can be used to unregister the package manager.
      * @see {@link PackageManager}
      */
-    registerPackageManager(manager: PackageManager): Disposable;
+    registerPackageManager(manager: PackageManager, options?: { extensionId?: string }): Disposable;
 }
 
 export interface PythonPackageGetterApi {
@@ -952,17 +1042,18 @@ export interface PythonPackageGetterApi {
      * Refresh the list of packages in a Python Environment.
      *
      * @param environment The Python Environment for which the list of packages is to be refreshed.
-     * @returns A promise that resolves when the list of packages has been refreshed.
+     * @returns A promise that resolves with the refreshed list of packages, or undefined.
      */
-    refreshPackages(environment: PythonEnvironment): Promise<void>;
+    refreshPackages(environment: PythonEnvironment): Promise<Package[] | undefined>;
 
     /**
      * Get the list of packages in a Python Environment.
      *
      * @param environment The Python Environment for which the list of packages is required.
+     * @param options Optional settings for package retrieval.
      * @returns The list of packages in the Python Environment.
      */
-    getPackages(environment: PythonEnvironment): Promise<Package[] | undefined>;
+    getPackages(environment: PythonEnvironment, options?: GetPackagesOptions): Promise<Package[] | undefined>;
 
     /**
      * Event raised when the list of packages in a Python Environment changes.

--- a/_integrations/vscode-tally/tests-ui/code-actions.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/code-actions.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "./fixtures";
-import { openFile, openWorkspace, runCommand } from "./utils";
+import { openFile, openWorkspace, problemRows, runCommand } from "./utils";
 
 test("the quick-fix menu offers a tally code action", async ({
   sharedCodeServer,
@@ -12,7 +12,7 @@ test("the quick-fix menu offers a tally code action", async ({
   // Wait until diagnostics exist before asking for fixes, otherwise the action
   // widget may open with nothing to offer.
   await runCommand(page, "Problems: Focus on Problems View");
-  const rows = page.locator(".markers-panel-container .monaco-list-row");
+  const rows = problemRows(page);
   await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
 
   // Clicking the casing diagnostic row navigates the editor cursor straight to
@@ -27,7 +27,10 @@ test("the quick-fix menu offers a tally code action", async ({
   const actions = page.locator(".action-widget .monaco-list-row.action");
   await expect(actions.first()).toBeVisible({ timeout: 15_000 });
 
-  // At least one action should be a tally fix — the casing fix uppercases the
-  // instruction, or the "fix all" entry is present.
-  await expect(actions.filter({ hasText: /tally|uppercase|COPY|fix all/i }).first()).toBeVisible();
+  // Require a Tally-specific action so a generic editor action can't satisfy
+  // the assertion. The casing fix's title is "Change 'copy' to 'COPY' to match
+  // majority casing"; tally also contributes "Suppress tally/<rule>" actions.
+  await expect(
+    actions.filter({ hasText: /match majority casing|Suppress tally\//i }).first(),
+  ).toBeVisible();
 });

--- a/_integrations/vscode-tally/tests-ui/code-actions.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/code-actions.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "./fixtures";
+import { openFile, openWorkspace, runCommand } from "./utils";
+
+test("the quick-fix menu offers a tally code action", async ({
+  sharedCodeServer,
+  projectDir,
+  page,
+}) => {
+  await openWorkspace(page, sharedCodeServer.url, projectDir);
+  await openFile(page, "Dockerfile");
+
+  // Wait until diagnostics exist before asking for fixes, otherwise the action
+  // widget may open with nothing to offer.
+  await runCommand(page, "Problems: Focus on Problems View");
+  const rows = page.locator(".markers-panel-container .monaco-list-row");
+  await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
+
+  // Clicking the casing diagnostic row navigates the editor cursor straight to
+  // it — more robust than hunting for a token in the virtualized editor.
+  const casingRow = rows.filter({ hasText: /casing|uppercase/i }).first();
+  await expect(casingRow).toBeVisible({ timeout: 15_000 });
+  await casingRow.click();
+
+  await runCommand(page, "Quick Fix...");
+
+  // The code-action widget lists actions as `.monaco-list-row.action`.
+  const actions = page.locator(".action-widget .monaco-list-row.action");
+  await expect(actions.first()).toBeVisible({ timeout: 15_000 });
+
+  // At least one action should be a tally fix — the casing fix uppercases the
+  // instruction, or the "fix all" entry is present.
+  await expect(actions.filter({ hasText: /tally|uppercase|COPY|fix all/i }).first()).toBeVisible();
+});

--- a/_integrations/vscode-tally/tests-ui/diagnostics.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/diagnostics.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "./fixtures";
+import { openFile, openWorkspace, runCommand } from "./utils";
+
+test("tally diagnostics surface in the Problems panel", async ({
+  sharedCodeServer,
+  projectDir,
+  page,
+}) => {
+  await openWorkspace(page, sharedCodeServer.url, projectDir);
+  await openFile(page, "Dockerfile");
+
+  await runCommand(page, "Problems: Focus on Problems View");
+
+  // Primary: the markers panel list rows. Fall back to the broader markers
+  // panel container in case the tree/table inner class differs by version.
+  const rows = page
+    .locator(".markers-panel-container .monaco-list-row")
+    .or(page.locator(".markers-panel .monaco-list-row"));
+
+  // Absorb LSP startup latency by polling rather than sleeping.
+  await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
+  await expect(rows.first()).toBeVisible();
+
+  // Bind the assertion to a real tally message: lowercase instructions trip the
+  // casing rule, whose message mentions matching the majority casing.
+  await expect(rows.filter({ hasText: /casing|uppercase/i }).first()).toBeVisible();
+});

--- a/_integrations/vscode-tally/tests-ui/diagnostics.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/diagnostics.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "./fixtures";
-import { openFile, openWorkspace, runCommand } from "./utils";
+import { openFile, openWorkspace, problemRows, runCommand } from "./utils";
 
 test("tally diagnostics surface in the Problems panel", async ({
   sharedCodeServer,
@@ -11,11 +11,7 @@ test("tally diagnostics surface in the Problems panel", async ({
 
   await runCommand(page, "Problems: Focus on Problems View");
 
-  // Primary: the markers panel list rows. Fall back to the broader markers
-  // panel container in case the tree/table inner class differs by version.
-  const rows = page
-    .locator(".markers-panel-container .monaco-list-row")
-    .or(page.locator(".markers-panel .monaco-list-row"));
+  const rows = problemRows(page);
 
   // Absorb LSP startup latency by polling rather than sleeping.
   await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);

--- a/_integrations/vscode-tally/tests-ui/extension.setup.ts
+++ b/_integrations/vscode-tally/tests-ui/extension.setup.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { test as setup } from "@playwright/test";
+
+import { CODE_SERVER_BIN } from "./utils_code_server";
+
+const EXTENSION_ROOT = join(__dirname, "..");
+const REPO_ROOT = join(EXTENSION_ROOT, "..", "..");
+const SETUP_DIR = join(EXTENSION_ROOT, ".test_setup");
+const EXTENSIONS_DIR = join(SETUP_DIR, "extensions");
+const HASH_FILE = join(SETUP_DIR, "vsix.sha256");
+const TALLY_BIN = join(SETUP_DIR, process.platform === "win32" ? "tally.exe" : "tally");
+
+// Build flags required to compile tally with the image-handling stubs (see
+// CLAUDE.md). The electron smoke test passes the same set indirectly via make.
+const GO_BUILD_TAGS =
+  "containers_image_openpgp,containers_image_storage_stub,containers_image_docker_daemon_stub";
+
+setup("build tally LSP binary + install vsix into code-server", () => {
+  // A cold `go build` (downloading modules + compiling) can take a few minutes,
+  // well beyond the global 60s test timeout.
+  setup.setTimeout(600_000);
+
+  mkdirSync(EXTENSIONS_DIR, { recursive: true });
+
+  buildTallyBinary();
+  installVsix();
+});
+
+function buildTallyBinary(): void {
+  const args = ["build"];
+  // Collect coverage from the live LSP process when CI asks for it.
+  if (process.env.GOCOVERDIR) {
+    args.push("-cover");
+  }
+  args.push("-tags", GO_BUILD_TAGS, "-o", TALLY_BIN, "github.com/wharflab/tally");
+
+  execFileSync("go", args, {
+    cwd: REPO_ROOT,
+    env: { ...process.env, GOEXPERIMENT: "jsonv2" },
+    stdio: "inherit",
+  });
+}
+
+function installVsix(): void {
+  const pkg = JSON.parse(readFileSync(join(EXTENSION_ROOT, "package.json"), "utf8")) as {
+    version: string;
+  };
+  const vsix = process.env.VSIX_PATH
+    ? join(EXTENSION_ROOT, process.env.VSIX_PATH)
+    : join(EXTENSION_ROOT, `tally-${pkg.version}.vsix`);
+
+  if (!existsSync(vsix)) {
+    throw new Error(`vsix not found at ${vsix}; run "bun run vsce:package" first`);
+  }
+
+  // Skip the (slow) reinstall when the packaged extension is byte-identical.
+  const hash = createHash("sha256").update(readFileSync(vsix)).digest("hex");
+  if (existsSync(HASH_FILE) && readFileSync(HASH_FILE, "utf8").trim() === hash) {
+    return;
+  }
+
+  // Launch via the current node binary when we resolved the entrypoint; the
+  // shim is invoked directly otherwise (see CODE_SERVER_BIN resolution).
+  const isEntry = CODE_SERVER_BIN.endsWith(".js");
+  const installArgs = ["--install-extension", vsix, "--extensions-dir", EXTENSIONS_DIR, "--force"];
+  if (isEntry) {
+    execFileSync(process.execPath, [CODE_SERVER_BIN, ...installArgs], {
+      stdio: "inherit",
+      env: { ...process.env, DISPLAY: "" },
+    });
+  } else {
+    execFileSync(CODE_SERVER_BIN, installArgs, {
+      stdio: "inherit",
+      env: { ...process.env, DISPLAY: "" },
+    });
+  }
+
+  writeFileSync(HASH_FILE, hash);
+}

--- a/_integrations/vscode-tally/tests-ui/extension.setup.ts
+++ b/_integrations/vscode-tally/tests-ui/extension.setup.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 import { test as setup } from "@playwright/test";
 
@@ -62,8 +62,12 @@ function installVsix(): void {
   const pkg = JSON.parse(readFileSync(join(EXTENSION_ROOT, "package.json"), "utf8")) as {
     version: string;
   };
+  // node's path.join does not treat a leading "/" as an absolute override, so
+  // an absolute VSIX_PATH must be used verbatim rather than joined.
   const vsix = process.env.VSIX_PATH
-    ? join(EXTENSION_ROOT, process.env.VSIX_PATH)
+    ? isAbsolute(process.env.VSIX_PATH)
+      ? process.env.VSIX_PATH
+      : join(EXTENSION_ROOT, process.env.VSIX_PATH)
     : join(EXTENSION_ROOT, `tally-${pkg.version}.vsix`);
 
   if (!existsSync(vsix)) {

--- a/_integrations/vscode-tally/tests-ui/extension.setup.ts
+++ b/_integrations/vscode-tally/tests-ui/extension.setup.ts
@@ -12,7 +12,10 @@ const REPO_ROOT = join(EXTENSION_ROOT, "..", "..");
 const SETUP_DIR = join(EXTENSION_ROOT, ".test_setup");
 const EXTENSIONS_DIR = join(SETUP_DIR, "extensions");
 const HASH_FILE = join(SETUP_DIR, "vsix.sha256");
-const TALLY_BIN = join(SETUP_DIR, process.platform === "win32" ? "tally.exe" : "tally");
+// Mirror the resolution in fixtures.ts: an explicit TALLY_BIN override wins,
+// otherwise we build into the scratch dir.
+const DEFAULT_TALLY_BIN = join(SETUP_DIR, process.platform === "win32" ? "tally.exe" : "tally");
+const TALLY_BIN = process.env.TALLY_BIN ?? DEFAULT_TALLY_BIN;
 
 // Build flags required to compile tally with the image-handling stubs (see
 // CLAUDE.md). The electron smoke test passes the same set indirectly via make.
@@ -31,6 +34,16 @@ setup("build tally LSP binary + install vsix into code-server", () => {
 });
 
 function buildTallyBinary(): void {
+  // Honor an explicit TALLY_BIN override (documented in DEVELOPMENT.md): reuse
+  // the prebuilt binary instead of running `go build`, which also lets the
+  // suite run where Go/modules are unavailable.
+  if (process.env.TALLY_BIN) {
+    if (!existsSync(TALLY_BIN)) {
+      throw new Error(`TALLY_BIN points at a missing binary: ${TALLY_BIN}`);
+    }
+    return;
+  }
+
   const args = ["build"];
   // Collect coverage from the live LSP process when CI asks for it.
   if (process.env.GOCOVERDIR) {

--- a/_integrations/vscode-tally/tests-ui/extension.teardown.ts
+++ b/_integrations/vscode-tally/tests-ui/extension.teardown.ts
@@ -1,0 +1,8 @@
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { test as teardown } from "@playwright/test";
+
+teardown("remove .test_setup scratch dir", () => {
+  rmSync(join(__dirname, "..", ".test_setup"), { recursive: true, force: true });
+});

--- a/_integrations/vscode-tally/tests-ui/fix-all.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/fix-all.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "./fixtures";
+import { openFile, openWorkspace, readEditorText, runCommand } from "./utils";
+
+test("'Tally: Fix all auto-fixable issues' applies fixes to the document", async ({
+  sharedCodeServer,
+  projectDir,
+  page,
+}) => {
+  await openWorkspace(page, sharedCodeServer.url, projectDir);
+  await openFile(page, "Dockerfile");
+
+  // Make sure diagnostics have been computed before invoking the fix command.
+  await runCommand(page, "Problems: Focus on Problems View");
+  const rows = page.locator(".markers-panel-container .monaco-list-row");
+  await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
+  const before = await rows.count();
+
+  await runCommand(page, "Tally: Fix all auto-fixable issues");
+
+  // The casing fix is FixSafe, so the minority lowercase instructions become
+  // uppercase to match the majority (copy -> COPY).
+  await expect
+    .poll(async () => await readEditorText(page), { timeout: 20_000 })
+    .toContain("COPY . /app");
+
+  // ...and the number of reported problems should drop once fixes land.
+  await expect.poll(() => rows.count(), { timeout: 20_000 }).toBeLessThan(before);
+});

--- a/_integrations/vscode-tally/tests-ui/fix-all.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/fix-all.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "./fixtures";
-import { openFile, openWorkspace, readEditorText, runCommand } from "./utils";
+import { openFile, openWorkspace, problemRows, readEditorText, runCommand } from "./utils";
 
 test("'Tally: Fix all auto-fixable issues' applies fixes to the document", async ({
   sharedCodeServer,
@@ -11,7 +11,7 @@ test("'Tally: Fix all auto-fixable issues' applies fixes to the document", async
 
   // Make sure diagnostics have been computed before invoking the fix command.
   await runCommand(page, "Problems: Focus on Problems View");
-  const rows = page.locator(".markers-panel-container .monaco-list-row");
+  const rows = problemRows(page);
   await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
   const before = await rows.count();
 

--- a/_integrations/vscode-tally/tests-ui/fixtures.ts
+++ b/_integrations/vscode-tally/tests-ui/fixtures.ts
@@ -1,0 +1,53 @@
+import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { test as base } from "@playwright/test";
+
+import { type CodeServerContext, startCodeServer, stopCodeServer } from "./utils_code_server";
+
+// Shared scratch dir populated by extension.setup.ts: the installed extension
+// and the freshly built tally LSP binary.
+const SETUP_DIR = join(__dirname, "..", ".test_setup");
+const EXTENSIONS_DIR = join(SETUP_DIR, "extensions");
+const TALLY_BIN =
+  process.env.TALLY_BIN ?? join(SETUP_DIR, process.platform === "win32" ? "tally.exe" : "tally");
+const FIXTURE_DOCKERFILE = join(__dirname, "fixtures", "Dockerfile");
+
+interface WorkerFixtures {
+  sharedCodeServer: CodeServerContext;
+}
+
+interface TestFixtures {
+  /** An isolated workspace folder seeded with the lint-bait Dockerfile. */
+  projectDir: string;
+}
+
+export const test = base.extend<TestFixtures, WorkerFixtures>({
+  // One code-server per worker (workers:1 → effectively once per run), using a
+  // throwaway user-data dir. The extensions dir is shared and read-only here.
+  sharedCodeServer: [
+    async ({}, use) => {
+      const userDataDir = mkdtempSync(join(tmpdir(), "tally-e2e-udd-"));
+      const ctx = await startCodeServer({
+        extensionsDir: EXTENSIONS_DIR,
+        userDataDir,
+        tallyBinaryPath: TALLY_BIN,
+      });
+      await use(ctx);
+      await stopCodeServer(ctx);
+      rmSync(userDataDir, { recursive: true, force: true });
+    },
+    { scope: "worker" },
+  ],
+
+  // A fresh project folder per test so edits/fixes never bleed across cases.
+  projectDir: async ({}, use) => {
+    const dir = mkdtempSync(join(tmpdir(), "tally-e2e-proj-"));
+    cpSync(FIXTURE_DOCKERFILE, join(dir, "Dockerfile"));
+    await use(dir);
+    rmSync(dir, { recursive: true, force: true });
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/_integrations/vscode-tally/tests-ui/fixtures.ts
+++ b/_integrations/vscode-tally/tests-ui/fixtures.ts
@@ -4,7 +4,23 @@ import { join } from "node:path";
 
 import { test as base } from "@playwright/test";
 
-import { type CodeServerContext, startCodeServer, stopCodeServer } from "./utils_code_server";
+import { type CodeServerContext, startCodeServer } from "./utils_code_server";
+
+interface TempDir extends Disposable {
+  path: string;
+}
+
+// A temp dir that removes itself when it leaves a `using` scope, even if the
+// surrounding fixture throws.
+function makeTempDir(prefix: string): TempDir {
+  const path = mkdtempSync(join(tmpdir(), prefix));
+  return {
+    path,
+    [Symbol.dispose]() {
+      rmSync(path, { recursive: true, force: true });
+    },
+  };
+}
 
 // Shared scratch dir populated by extension.setup.ts: the installed extension
 // and the freshly built tally LSP binary.
@@ -28,25 +44,24 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   // throwaway user-data dir. The extensions dir is shared and read-only here.
   sharedCodeServer: [
     async ({}, use) => {
-      const userDataDir = mkdtempSync(join(tmpdir(), "tally-e2e-udd-"));
-      const ctx = await startCodeServer({
+      // `using`/`await using` guarantee the temp dir is removed and the server
+      // stopped on scope exit, even if startCodeServer or the test throws.
+      using userData = makeTempDir("tally-e2e-udd-");
+      await using ctx = await startCodeServer({
         extensionsDir: EXTENSIONS_DIR,
-        userDataDir,
+        userDataDir: userData.path,
         tallyBinaryPath: TALLY_BIN,
       });
       await use(ctx);
-      await stopCodeServer(ctx);
-      rmSync(userDataDir, { recursive: true, force: true });
     },
     { scope: "worker" },
   ],
 
   // A fresh project folder per test so edits/fixes never bleed across cases.
   projectDir: async ({}, use) => {
-    const dir = mkdtempSync(join(tmpdir(), "tally-e2e-proj-"));
-    cpSync(FIXTURE_DOCKERFILE, join(dir, "Dockerfile"));
-    await use(dir);
-    rmSync(dir, { recursive: true, force: true });
+    using project = makeTempDir("tally-e2e-proj-");
+    cpSync(FIXTURE_DOCKERFILE, join(project.path, "Dockerfile"));
+    await use(project.path);
   },
 });
 

--- a/_integrations/vscode-tally/tests-ui/fixtures/Dockerfile
+++ b/_integrations/vscode-tally/tests-ui/fixtures/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+# Most instructions are uppercase so the lone lowercase `copy`/`workdir` are the
+# minority case: tally's ConsistentInstructionCasing rule flags them and offers a
+# FixSafe quick-fix that uppercases them (copy -> COPY, workdir -> WORKDIR).
+FROM ubuntu:latest
+RUN apt-get update && apt-get install -y curl
+copy . /app
+workdir /app
+CMD echo hello

--- a/_integrations/vscode-tally/tests-ui/format.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/format.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "./fixtures";
+import { openFile, openWorkspace, readEditorText, runCommand } from "./utils";
+
+test("Format Document rewrites the Dockerfile via the tally formatter", async ({
+  sharedCodeServer,
+  projectDir,
+  page,
+}) => {
+  await openWorkspace(page, sharedCodeServer.url, projectDir);
+  await openFile(page, "Dockerfile");
+
+  // Wait until the language server is ready (diagnostics published) before
+  // formatting — otherwise Format Document fires before tally has registered
+  // its formatting provider and returns no edits.
+  await runCommand(page, "Problems: Focus on Problems View");
+  const rows = page.locator(".markers-panel-container .monaco-list-row");
+  await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
+
+  const before = await readEditorText(page);
+  // The fixture's lone lowercase instructions are the minority case.
+  expect(before).toContain("copy . /app");
+
+  // Re-issue Format Document inside the poll: the formatter routes through the
+  // tally provider (configured as the default Dockerfile formatter) and
+  // uppercases the minority-case instructions to match the majority.
+  await expect
+    .poll(
+      async () => {
+        await runCommand(page, "Format Document");
+        return await readEditorText(page);
+      },
+      { timeout: 20_000 },
+    )
+    .toContain("COPY . /app");
+
+  const after = await readEditorText(page);
+  expect(after).not.toEqual(before);
+});

--- a/_integrations/vscode-tally/tests-ui/format.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/format.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "./fixtures";
-import { openFile, openWorkspace, readEditorText, runCommand } from "./utils";
+import { openFile, openWorkspace, problemRows, readEditorText, runCommand } from "./utils";
 
 test("Format Document rewrites the Dockerfile via the tally formatter", async ({
   sharedCodeServer,
@@ -13,7 +13,7 @@ test("Format Document rewrites the Dockerfile via the tally formatter", async ({
   // formatting — otherwise Format Document fires before tally has registered
   // its formatting provider and returns no edits.
   await runCommand(page, "Problems: Focus on Problems View");
-  const rows = page.locator(".markers-panel-container .monaco-list-row");
+  const rows = problemRows(page);
   await expect.poll(() => rows.count(), { timeout: 30_000 }).toBeGreaterThan(0);
 
   const before = await readEditorText(page);

--- a/_integrations/vscode-tally/tests-ui/run-playwright.mjs
+++ b/_integrations/vscode-tally/tests-ui/run-playwright.mjs
@@ -1,0 +1,45 @@
+// Launches the Playwright CLI under the real Node.js runtime.
+//
+// This package's bunfig.toml sets `[run] bun = true`, which makes `bun run`
+// scripts execute under Bun and prepend a `node` shim (a temp dir like
+// /private/tmp/bun-node-*) to PATH that points back at Bun. Playwright's test
+// runner cannot transform the TypeScript specs under the Bun runtime — it dies
+// with "AggregateError: N errors building ...". So we locate the real `node`
+// on PATH (skipping Bun's shim) and exec the Playwright CLI with it.
+//
+// Running this file under Bun is fine; it only spawns a child. Running it under
+// Node also works (process.execPath is already real Node, found first below).
+import { spawnSync } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { createRequire } from "node:module";
+import { delimiter, join } from "node:path";
+
+function findRealNode() {
+  const exe = process.platform === "win32" ? "node.exe" : "node";
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir || dir.includes("bun-node")) {
+      continue; // skip Bun's `node` shim
+    }
+    const candidate = join(dir, exe);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // not here; keep looking
+    }
+  }
+  // Fall back to whatever launched us (real Node when invoked directly).
+  return process.execPath;
+}
+
+const require = createRequire(import.meta.url);
+const cli = require.resolve("@playwright/test/cli");
+
+const result = spawnSync(findRealNode(), [cli, "test", ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+if (result.error) {
+  throw result.error;
+}
+process.exit(result.status ?? 1);

--- a/_integrations/vscode-tally/tests-ui/status-bar.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/status-bar.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "./fixtures";
+import { openFile, openWorkspace } from "./utils";
+
+test("the tally status bar item is shown for Dockerfiles", async ({
+  sharedCodeServer,
+  projectDir,
+  page,
+}) => {
+  await openWorkspace(page, sharedCodeServer.url, projectDir);
+  await openFile(page, "Dockerfile");
+
+  // The regular StatusBarItem renders `$(check) tally` — the codicon is a span
+  // inside the `<a>` label and the visible text is "tally". This is the stable
+  // primary assertion.
+  const statusItem = page.locator(".statusbar-item").filter({ hasText: "tally" });
+  await expect(statusItem.first()).toBeVisible({ timeout: 30_000 });
+
+  // Secondary (soft) check: the LanguageStatusItem only reveals "tally <version>"
+  // on hover, and the hover popup is the flakiest selector in the suite — keep
+  // it non-blocking so a hover miss never fails the run.
+  try {
+    await page.locator("#status\\.languageStatus").hover({ timeout: 5_000 });
+    const hover = page
+      .locator(".hover-language-status .element .left")
+      .filter({ hasText: /tally/i });
+    await expect.soft(hover.first()).toBeVisible({ timeout: 5_000 });
+  } catch {
+    // Language-status hover unavailable in this build; the primary check stands.
+  }
+});

--- a/_integrations/vscode-tally/tests-ui/status-bar.spec.ts
+++ b/_integrations/vscode-tally/tests-ui/status-bar.spec.ts
@@ -15,16 +15,22 @@ test("the tally status bar item is shown for Dockerfiles", async ({
   const statusItem = page.locator(".statusbar-item").filter({ hasText: "tally" });
   await expect(statusItem.first()).toBeVisible({ timeout: 30_000 });
 
-  // Secondary (soft) check: the LanguageStatusItem only reveals "tally <version>"
-  // on hover, and the hover popup is the flakiest selector in the suite — keep
-  // it non-blocking so a hover miss never fails the run.
+  // Secondary check: the LanguageStatusItem only reveals "tally <version>" on
+  // hover, and the hover popup is the flakiest selector in the suite — keep it
+  // non-blocking. `expect.soft` is deliberately avoided here: it registers a
+  // failure with the runner even inside try/catch (soft assertions never
+  // throw), which would fail the run. `waitFor` throws on miss so the catch
+  // can swallow it and keep the primary assertion authoritative.
   try {
     await page.locator("#status\\.languageStatus").hover({ timeout: 5_000 });
     const hover = page
       .locator(".hover-language-status .element .left")
       .filter({ hasText: /tally/i });
-    await expect.soft(hover.first()).toBeVisible({ timeout: 5_000 });
-  } catch {
-    // Language-status hover unavailable in this build; the primary check stands.
+    await hover.first().waitFor({ state: "visible", timeout: 5_000 });
+  } catch (e) {
+    console.error(
+      "optional language-status hover check skipped:",
+      e instanceof Error ? e.message : String(e),
+    );
   }
 });

--- a/_integrations/vscode-tally/tests-ui/tsconfig.json
+++ b/_integrations/vscode-tally/tests-ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["fixtures"]
+}

--- a/_integrations/vscode-tally/tests-ui/utils.ts
+++ b/_integrations/vscode-tally/tests-ui/utils.ts
@@ -1,0 +1,94 @@
+import { type Locator, type Page } from "@playwright/test";
+
+const isMac = process.platform === "darwin";
+
+/**
+ * Navigate code-server to a workspace folder and wait for the workbench to be
+ * interactive. The readiness gate is a DOM chain (`[role="application"]` →
+ * `.monaco-workbench` → `.statusbar`), never `networkidle` — code-server holds
+ * a persistent websocket so the network never goes idle.
+ */
+export async function openWorkspace(page: Page, baseUrl: string, folder: string): Promise<void> {
+  await page.goto(`${baseUrl}/?folder=${encodeURIComponent(folder)}`);
+  await page.waitForSelector('[role="application"]', { timeout: 30_000 });
+  await page.locator(".monaco-workbench").waitFor({ state: "visible", timeout: 30_000 });
+  // The status bar is one of the last workbench parts to render.
+  await page.locator(".statusbar").waitFor({ state: "visible", timeout: 30_000 });
+
+  // Workspace trust is pre-disabled in settings, so the dialog should not
+  // appear; dismiss it best-effort in case a build still shows it.
+  try {
+    await page.getByRole("button", { name: /trust the authors/i }).click({ timeout: 3_000 });
+  } catch {
+    // Expected path: dialog absent.
+  }
+}
+
+/** Open the command palette and run `command` by its visible label. */
+export async function runCommand(page: Page, command: string): Promise<void> {
+  await withPaletteRetry(page, async () => {
+    await page.keyboard.press(isMac ? "Meta+Shift+P" : "Control+Shift+P");
+    const input = commandPaletteInput(page);
+    await input.waitFor({ state: "visible", timeout: 5_000 });
+    // Leading ">" forces command mode regardless of any sticky quick-open state.
+    await input.fill(`>${command}`);
+    await quickInputRow(page, command).click({ timeout: 5_000 });
+  });
+}
+
+/** Open a file via Quick Open (Ctrl/Cmd+P) and wait for the editor to mount. */
+export async function openFile(page: Page, filename: string): Promise<void> {
+  await withPaletteRetry(page, async () => {
+    await page.keyboard.press(isMac ? "Meta+P" : "Control+P");
+    const input = page
+      .getByRole("textbox", { name: /Search files by name/ })
+      .or(page.locator(".quick-input-box input"));
+    await input.waitFor({ state: "visible", timeout: 5_000 });
+    await input.fill(filename);
+    await quickInputRow(page, filename).click({ timeout: 5_000 });
+    await page.locator(".monaco-editor").first().waitFor({ state: "visible" });
+  });
+}
+
+/**
+ * Read the active editor's text via the clipboard. Monaco virtualizes
+ * `.view-line` (only the visible window exists in the DOM and spaces render as
+ * NBSP), so a clipboard round-trip is the robust way to read full content.
+ * Uses the command-palette "Select All" to avoid OS-chord focus flakiness.
+ */
+export async function readEditorText(page: Page): Promise<string> {
+  await page.getByRole("code").first().click();
+  await runCommand(page, "Select All");
+  await page.keyboard.press(isMac ? "Meta+C" : "Control+C");
+  const text = await page.evaluate(() => navigator.clipboard.readText());
+  // Normalize the NBSP (U+00A0) that Monaco uses for rendered whitespace.
+  return text.replaceAll("\u00a0", " ");
+}
+
+function commandPaletteInput(page: Page): Locator {
+  // The explicit role="textbox" was removed upstream, but the aria-label
+  // placeholder is stable; fall back to the quick-input box container.
+  return page
+    .locator('input[aria-label="Type the name of a command to run."]')
+    .or(page.locator(".quick-input-box input"));
+}
+
+function quickInputRow(page: Page, label: string): Locator {
+  return page.locator(".quick-input-list .monaco-list-row").filter({ hasText: label }).first();
+}
+
+/** Retry a palette/quick-open interaction up to 3 times, pressing Escape between attempts. */
+async function withPaletteRetry(page: Page, action: () => Promise<void>): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await action();
+      return;
+    } catch (err) {
+      if (attempt === 2) {
+        throw err;
+      }
+      await page.keyboard.press("Escape");
+      await page.waitForTimeout(500);
+    }
+  }
+}

--- a/_integrations/vscode-tally/tests-ui/utils.ts
+++ b/_integrations/vscode-tally/tests-ui/utils.ts
@@ -3,6 +3,16 @@ import { type Locator, type Page } from "@playwright/test";
 const isMac = process.platform === "darwin";
 
 /**
+ * Rows in the Problems panel. Uses a defensive OR over the markers panel
+ * container classes so the selector survives VS Code version differences.
+ */
+export function problemRows(page: Page): Locator {
+  return page
+    .locator(".markers-panel-container .monaco-list-row")
+    .or(page.locator(".markers-panel .monaco-list-row"));
+}
+
+/**
  * Navigate code-server to a workspace folder and wait for the workbench to be
  * interactive. The readiness gate is a DOM chain (`[role="application"]` →
  * `.monaco-workbench` → `.statusbar`), never `networkidle` — code-server holds

--- a/_integrations/vscode-tally/tests-ui/utils_code_server.ts
+++ b/_integrations/vscode-tally/tests-ui/utils_code_server.ts
@@ -154,8 +154,14 @@ async function stopCodeServer(proc: ChildProcess): Promise<void> {
   try {
     await exited;
   } catch {
-    // Didn't exit within the grace period — force it and wait for the real exit.
+    // Didn't exit within the grace period — force it. Attach the listener
+    // before signalling (and re-check exitCode) so the one-shot exit event
+    // can't fire before we're listening and hang the await forever.
+    if (proc.exitCode !== null) {
+      return;
+    }
+    const forcedExit = once(proc, "exit");
     proc.kill("SIGKILL");
-    await once(proc, "exit");
+    await forcedExit;
   }
 }

--- a/_integrations/vscode-tally/tests-ui/utils_code_server.ts
+++ b/_integrations/vscode-tally/tests-ui/utils_code_server.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { type AddressInfo, createServer } from "node:net";
 import { join } from "node:path";
 
 // Prefer the published entrypoint; fall back to the `.bin` shim. Launching the
@@ -17,9 +18,24 @@ export interface CodeServerContext {
   userDataDir: string;
 }
 
-function randomPort(): number {
-  // High ephemeral range; collisions across the single worker are unlikely.
-  return 50_000 + Math.floor(Math.random() * 10_000);
+// Ask the OS for a free port by binding to :0, then release it for code-server.
+// There is a small TOCTOU window, but it is far less collision-prone than a
+// random pick and keeps the launch deterministic.
+async function getFreePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo | null;
+      const port = address?.port;
+      if (port) {
+        server.close(() => resolve(port));
+      } else {
+        server.close(() => reject(new Error("failed to allocate a free port")));
+      }
+    });
+  });
 }
 
 function writeSettings(userDataDir: string, tallyBinaryPath: string): void {
@@ -49,7 +65,7 @@ export interface StartCodeServerOptions {
 }
 
 export async function startCodeServer(opts: StartCodeServerOptions): Promise<CodeServerContext> {
-  const port = randomPort();
+  const port = await getFreePort();
   writeSettings(opts.userDataDir, opts.tallyBinaryPath);
 
   const args = [
@@ -121,15 +137,17 @@ export async function stopCodeServer(ctx: CodeServerContext): Promise<void> {
   if (ctx.proc.exitCode !== null || ctx.proc.killed) {
     return;
   }
-  ctx.proc.kill("SIGTERM");
   await new Promise<void>((resolve) => {
     const timer = setTimeout(() => {
       ctx.proc.kill("SIGKILL");
       resolve();
     }, 5_000);
+    // Register the exit listener BEFORE signalling, so an instant exit cannot
+    // fire before we are listening (which would hang until the SIGKILL fallback).
     ctx.proc.once("exit", () => {
       clearTimeout(timer);
       resolve();
     });
+    ctx.proc.kill("SIGTERM");
   });
 }

--- a/_integrations/vscode-tally/tests-ui/utils_code_server.ts
+++ b/_integrations/vscode-tally/tests-ui/utils_code_server.ts
@@ -1,61 +1,28 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { once } from "node:events";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { type AddressInfo, createServer } from "node:net";
 import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const STARTUP_TIMEOUT_MS = 30_000;
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+const HEALTHZ_POLL_MS = 150;
+const HEALTHZ_REQUEST_TIMEOUT_MS = 2_000;
 
 // Prefer the published entrypoint; fall back to the `.bin` shim. Launching the
-// entrypoint directly with the current node binary avoids depending on the
-// shim's shebang resolving to a node 22 on PATH.
+// entrypoint with the current node binary avoids depending on the shim's
+// shebang resolving to a node 22 on PATH.
 const ENTRY = join(__dirname, "..", "node_modules", "code-server", "out", "node", "entry.js");
 const BIN_SHIM = join(__dirname, "..", "node_modules", ".bin", "code-server");
 const useEntry = existsSync(ENTRY);
 export const CODE_SERVER_BIN = useEntry ? ENTRY : BIN_SHIM;
 
-export interface CodeServerContext {
+export interface CodeServerContext extends AsyncDisposable {
   proc: ChildProcess;
   port: number;
   url: string;
   userDataDir: string;
-}
-
-// Ask the OS for a free port by binding to :0, then release it for code-server.
-// There is a small TOCTOU window, but it is far less collision-prone than a
-// random pick and keeps the launch deterministic.
-async function getFreePort(): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
-    const server = createServer();
-    server.unref();
-    server.on("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address() as AddressInfo | null;
-      const port = address?.port;
-      if (port) {
-        server.close(() => resolve(port));
-      } else {
-        server.close(() => reject(new Error("failed to allocate a free port")));
-      }
-    });
-  });
-}
-
-function writeSettings(userDataDir: string, tallyBinaryPath: string): void {
-  // code-server reads both Machine and User scopes; seed both so the workbench
-  // comes up trusted, quiet, and already pointed at our built tally binary.
-  const settings = {
-    "security.workspace.trust.enabled": false,
-    "workbench.startupEditor": "none",
-    "telemetry.telemetryLevel": "off",
-    "tally.enable": true,
-    "tally.path": [tallyBinaryPath],
-    "tally.configurationPreference": "editorOnly",
-    "[dockerfile]": { "editor.defaultFormatter": "wharflab.tally" },
-  };
-  const serialized = JSON.stringify(settings, null, 2);
-  for (const sub of ["Machine", "User"]) {
-    const dir = join(userDataDir, sub);
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, "settings.json"), serialized);
-  }
 }
 
 export interface StartCodeServerOptions {
@@ -66,88 +33,129 @@ export interface StartCodeServerOptions {
 
 export async function startCodeServer(opts: StartCodeServerOptions): Promise<CodeServerContext> {
   const port = await getFreePort();
+  const url = `http://127.0.0.1:${port}`;
   writeSettings(opts.userDataDir, opts.tallyBinaryPath);
 
   const args = [
-    "--bind-addr",
-    `127.0.0.1:${port}`,
-    "--auth",
-    "none",
-    "--extensions-dir",
-    opts.extensionsDir,
-    "--user-data-dir",
-    opts.userDataDir,
+    "--bind-addr", `127.0.0.1:${port}`,
+    "--auth", "none",
+    "--extensions-dir", opts.extensionsDir,
+    "--user-data-dir", opts.userDataDir,
     "--disable-telemetry",
     "--disable-update-check",
     "--disable-workspace-trust",
     "--disable-getting-started-override",
-  ];
+  ]; // prettier-ignore
   const command = useEntry ? process.execPath : CODE_SERVER_BIN;
-  const argv = useEntry ? [CODE_SERVER_BIN, ...args] : args;
-
-  const proc = spawn(command, argv, {
-    stdio: "pipe",
-    // code-server is browser-served; an empty DISPLAY keeps any child from
-    // trying to reach an X server that does not exist in CI.
+  const proc = spawn(command, useEntry ? [CODE_SERVER_BIN, ...args] : args, {
+    // No stdout scraping (we poll /healthz), so inherit the streams: it both
+    // surfaces code-server logs in CI and avoids the deadlock an undrained
+    // pipe would cause. DISPLAY="" keeps any child off a non-existent X server.
+    stdio: ["ignore", "inherit", "inherit"],
     env: { ...process.env, DISPLAY: "" },
   });
 
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      cleanup();
-      reject(new Error(`code-server did not start within 30s on port ${port}`));
-    }, 30_000);
+  // Become ready when /healthz answers, fail fast if the process dies first,
+  // and give up at the deadline — whichever happens first.
+  const deadline = new AbortController();
+  const signal = AbortSignal.any([deadline.signal, AbortSignal.timeout(STARTUP_TIMEOUT_MS)]);
+  const pending = [waitForHealthz(url, signal), rejectWhenProcessExits(proc, signal)];
+  try {
+    await Promise.race(pending);
+  } catch (cause) {
+    await stopCodeServer(proc);
+    throw new Error(`code-server did not become ready on port ${port}`, { cause });
+  } finally {
+    // Cancel the loser of the race and drain both so neither lingers as an
+    // unhandled rejection once startup has settled.
+    deadline.abort();
+    await Promise.allSettled(pending);
+  }
 
-    const onData = (chunk: Buffer): void => {
-      const text = chunk.toString();
-      // Readiness gate: the stdout banner, NOT networkidle. code-server keeps a
-      // websocket open forever, so networkidle never fires.
-      if (text.includes("HTTP server listening on")) {
-        cleanup();
-        resolve();
-      }
-    };
-    const onError = (err: Error): void => {
-      cleanup();
-      reject(err);
-    };
-    const onExit = (code: number | null): void => {
-      cleanup();
-      reject(new Error(`code-server exited early with code ${code}`));
-    };
-    function cleanup(): void {
-      clearTimeout(timer);
-      proc.stdout?.off("data", onData);
-      proc.stderr?.off("data", onData);
-      proc.off("error", onError);
-      proc.off("exit", onExit);
-    }
-
-    proc.stdout?.on("data", onData);
-    // Some builds log the listening banner to stderr.
-    proc.stderr?.on("data", onData);
-    proc.once("error", onError);
-    proc.once("exit", onExit);
-  });
-
-  return { proc, port, url: `http://127.0.0.1:${port}`, userDataDir: opts.userDataDir };
+  return {
+    proc,
+    port,
+    url,
+    userDataDir: opts.userDataDir,
+    // `await using` stops the server on scope exit — callers never have to.
+    [Symbol.asyncDispose]: () => stopCodeServer(proc),
+  };
 }
 
-export async function stopCodeServer(ctx: CodeServerContext): Promise<void> {
-  if (ctx.proc.exitCode !== null || ctx.proc.killed) {
+// Ask the OS for a free port by binding to :0, then release it for code-server.
+// A small TOCTOU window remains, but it is far less collision-prone than a
+// random pick and keeps the launch deterministic.
+async function getFreePort(): Promise<number> {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+// Poll GET /healthz until code-server answers 200. The overall `signal` bounds
+// the whole wait; each request also gets its own short timeout so one hung
+// connection can't stall the loop.
+async function waitForHealthz(url: string, signal: AbortSignal): Promise<void> {
+  while (true) {
+    try {
+      const response = await fetch(`${url}/healthz`, {
+        signal: AbortSignal.any([signal, AbortSignal.timeout(HEALTHZ_REQUEST_TIMEOUT_MS)]),
+      });
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Connection refused or per-request timeout while still starting up.
+    }
+    // Back off, but wake immediately (and reject) when the deadline aborts.
+    await sleep(HEALTHZ_POLL_MS, undefined, { signal });
+  }
+}
+
+async function rejectWhenProcessExits(proc: ChildProcess, signal: AbortSignal): Promise<never> {
+  const [code] = (await once(proc, "exit", { signal })) as [number | null];
+  throw new Error(`code-server exited during startup (code ${String(code)})`);
+}
+
+function writeSettings(userDataDir: string, tallyBinaryPath: string): void {
+  // code-server reads both Machine and User scopes; seed both so the workbench
+  // comes up trusted, quiet, and already pointed at our built tally binary.
+  const settings = JSON.stringify(
+    {
+      "security.workspace.trust.enabled": false,
+      "workbench.startupEditor": "none",
+      "telemetry.telemetryLevel": "off",
+      "tally.enable": true,
+      "tally.path": [tallyBinaryPath],
+      "tally.configurationPreference": "editorOnly",
+      "[dockerfile]": { "editor.defaultFormatter": "wharflab.tally" },
+    },
+    null,
+    2,
+  );
+  for (const scope of ["Machine", "User"]) {
+    const dir = join(userDataDir, scope);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "settings.json"), settings);
+  }
+}
+
+async function stopCodeServer(proc: ChildProcess): Promise<void> {
+  if (proc.exitCode !== null || proc.killed) {
     return;
   }
-  await new Promise<void>((resolve) => {
-    const timer = setTimeout(() => {
-      ctx.proc.kill("SIGKILL");
-      resolve();
-    }, 5_000);
-    // Register the exit listener BEFORE signalling, so an instant exit cannot
-    // fire before we are listening (which would hang until the SIGKILL fallback).
-    ctx.proc.once("exit", () => {
-      clearTimeout(timer);
-      resolve();
-    });
-    ctx.proc.kill("SIGTERM");
-  });
+  // Attach the exit listener before signalling so an instant exit can't slip
+  // through before we are listening.
+  const exited = once(proc, "exit", { signal: AbortSignal.timeout(SHUTDOWN_TIMEOUT_MS) });
+  proc.kill("SIGTERM");
+  try {
+    await exited;
+  } catch {
+    // Didn't exit within the grace period — force it and wait for the real exit.
+    proc.kill("SIGKILL");
+    await once(proc, "exit");
+  }
 }

--- a/_integrations/vscode-tally/tests-ui/utils_code_server.ts
+++ b/_integrations/vscode-tally/tests-ui/utils_code_server.ts
@@ -1,0 +1,135 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Prefer the published entrypoint; fall back to the `.bin` shim. Launching the
+// entrypoint directly with the current node binary avoids depending on the
+// shim's shebang resolving to a node 22 on PATH.
+const ENTRY = join(__dirname, "..", "node_modules", "code-server", "out", "node", "entry.js");
+const BIN_SHIM = join(__dirname, "..", "node_modules", ".bin", "code-server");
+const useEntry = existsSync(ENTRY);
+export const CODE_SERVER_BIN = useEntry ? ENTRY : BIN_SHIM;
+
+export interface CodeServerContext {
+  proc: ChildProcess;
+  port: number;
+  url: string;
+  userDataDir: string;
+}
+
+function randomPort(): number {
+  // High ephemeral range; collisions across the single worker are unlikely.
+  return 50_000 + Math.floor(Math.random() * 10_000);
+}
+
+function writeSettings(userDataDir: string, tallyBinaryPath: string): void {
+  // code-server reads both Machine and User scopes; seed both so the workbench
+  // comes up trusted, quiet, and already pointed at our built tally binary.
+  const settings = {
+    "security.workspace.trust.enabled": false,
+    "workbench.startupEditor": "none",
+    "telemetry.telemetryLevel": "off",
+    "tally.enable": true,
+    "tally.path": [tallyBinaryPath],
+    "tally.configurationPreference": "editorOnly",
+    "[dockerfile]": { "editor.defaultFormatter": "wharflab.tally" },
+  };
+  const serialized = JSON.stringify(settings, null, 2);
+  for (const sub of ["Machine", "User"]) {
+    const dir = join(userDataDir, sub);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "settings.json"), serialized);
+  }
+}
+
+export interface StartCodeServerOptions {
+  extensionsDir: string;
+  userDataDir: string;
+  tallyBinaryPath: string;
+}
+
+export async function startCodeServer(opts: StartCodeServerOptions): Promise<CodeServerContext> {
+  const port = randomPort();
+  writeSettings(opts.userDataDir, opts.tallyBinaryPath);
+
+  const args = [
+    "--bind-addr",
+    `127.0.0.1:${port}`,
+    "--auth",
+    "none",
+    "--extensions-dir",
+    opts.extensionsDir,
+    "--user-data-dir",
+    opts.userDataDir,
+    "--disable-telemetry",
+    "--disable-update-check",
+    "--disable-workspace-trust",
+    "--disable-getting-started-override",
+  ];
+  const command = useEntry ? process.execPath : CODE_SERVER_BIN;
+  const argv = useEntry ? [CODE_SERVER_BIN, ...args] : args;
+
+  const proc = spawn(command, argv, {
+    stdio: "pipe",
+    // code-server is browser-served; an empty DISPLAY keeps any child from
+    // trying to reach an X server that does not exist in CI.
+    env: { ...process.env, DISPLAY: "" },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`code-server did not start within 30s on port ${port}`));
+    }, 30_000);
+
+    const onData = (chunk: Buffer): void => {
+      const text = chunk.toString();
+      // Readiness gate: the stdout banner, NOT networkidle. code-server keeps a
+      // websocket open forever, so networkidle never fires.
+      if (text.includes("HTTP server listening on")) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onError = (err: Error): void => {
+      cleanup();
+      reject(err);
+    };
+    const onExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`code-server exited early with code ${code}`));
+    };
+    function cleanup(): void {
+      clearTimeout(timer);
+      proc.stdout?.off("data", onData);
+      proc.stderr?.off("data", onData);
+      proc.off("error", onError);
+      proc.off("exit", onExit);
+    }
+
+    proc.stdout?.on("data", onData);
+    // Some builds log the listening banner to stderr.
+    proc.stderr?.on("data", onData);
+    proc.once("error", onError);
+    proc.once("exit", onExit);
+  });
+
+  return { proc, port, url: `http://127.0.0.1:${port}`, userDataDir: opts.userDataDir };
+}
+
+export async function stopCodeServer(ctx: CodeServerContext): Promise<void> {
+  if (ctx.proc.exitCode !== null || ctx.proc.killed) {
+    return;
+  }
+  ctx.proc.kill("SIGTERM");
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      ctx.proc.kill("SIGKILL");
+      resolve();
+    }, 5_000);
+    ctx.proc.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end **UI** test layer for the VS Code extension that drives a *rendered* VS Code (via headless [code-server](https://github.com/coder/code-server)) using [`@playwright/test`](https://playwright.dev). Modeled on [quarylabs/sqruff#2447](https://github.com/quarylabs/sqruff/pull/2447), adapted to tally's stack (bun, Go LSP, richer extension surface).

This **complements** (does not replace) the existing `@vscode/test-electron` smoke test in `test/`:

| Layer | Surface | What it proves |
|---|---|---|
| `test/` (existing, `test:e2e`) | extension host | programmatic LSP contract — exact diagnostic counts, snapshot-equal formatting, `tally.applyAllFixes` output |
| `tests-ui/` (new, `test:e2e:ui`) | rendered workbench DOM | behaviour actually surfaces in the UI a user sees |

## What the new suite covers

5 specs against a private code-server with the packaged `.vsix` installed:

1. **diagnostics** surface in the Problems panel
2. **Format Document** rewrites the Dockerfile via the tally formatter
3. the **quick-fix menu** offers a tally code action
4. **"Tally: Fix all auto-fixable issues"** applies fixes
5. the **tally status bar item** is shown for Dockerfiles

A `setup` Playwright project builds the tally LSP binary + installs the vsix (sha256-cached); a `cleanup` project removes the scratch dir. One worker-scoped code-server is shared; each test gets an isolated temp project dir.

## Implementation notes

- **code-server** pinned to `4.106.3` (VS Code 1.106, matching `engines.vscode ^1.106.0`). It requires **Node 22**; its postinstall is gated behind bun `trustedDependencies` + an `npm_config_user_agent` override (the CI job sets both).
- **`run-playwright.mjs`** execs the Playwright CLI under the real Node runtime — `bunfig.toml`'s `[run] bun = true` otherwise shims `node`→bun, which Playwright's TS transform cannot tolerate (`AggregateError: N errors building`).
- Selectors were verified against live VS Code 1.106 / code-server 4.106.3 source (Problems panel `.markers-panel-container`, code-action `.action-widget`, status bar), with fallbacks where fragile. Editor content is read via the clipboard (Monaco virtualizes `.view-line`).
- The fixture Dockerfile uses **majority-uppercase** casing so the lowercase minority (`copy`/`workdir`) triggers `ConsistentInstructionCasing` and its FixSafe quick-fix.

## CI

New `vscode-ui-tests` job in `vscode-extension.yml` (ubuntu-latest, Node 22, full chromium via `--with-deps`, no xvfb). Uploads the Playwright report always and traces/videos on failure; collects Go coverage from the live LSP process.

## Test plan

- [x] `bun run test:e2e:ui` — **7 passed** (setup + 5 specs + cleanup) from a cold checkout
- [x] `bun run typecheck` (src + tests-ui) green
- [x] `bun run format:check` green
- [x] verified code-server 4.106.3 launches and serves HTTP 200 locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Playwright-based VS Code UI end-to-end coverage for diagnostics, code actions, document formatting, fix-all behavior, and the status bar.
  * Introduced a dedicated UI test runner configuration and local test harness for running against code-server.

* **Documentation**
  * Expanded the extension development guide with UI e2e test commands and local setup/run instructions (including Node 22 notes).

* **Chores**
  * Updated CI smoke/UI testing workflows to support code-server’s Node 22 requirement and improved artifact reporting/coverage handling.
  * Adjusted VS Code packaging ignores to exclude generated UI test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->