### PR TITLE
fix(shellcheck): make wasm build work with local buildx + gitlab Anubis gateway

### DIFF
--- a/.github/actions/shellcheck-wasm/action.yml
+++ b/.github/actions/shellcheck-wasm/action.yml
@@ -16,9 +16,12 @@ description: |
   that `download-shellcheck-wasm` consumes.
 
   The setup-buildx-action step installs a recent upstream BuildKit so the
-  Dockerfile's `ADD <git-url>?ref=...` instructions work against github.com
-  and gitlab.haskell.org — older BuildKit shipped with some Docker Engine
-  releases mishandles the 301 redirect that drops `.git` from the URL.
+  Dockerfile's `ADD <git-url>?ref=...` instructions work against github.com —
+  older BuildKit shipped with some Docker Engine releases mishandles the git
+  ADD and downloads the URL as a single file instead of cloning it. Both git
+  inputs (ghc-wasm-meta, shellcheck) are cloned from github.com because
+  gitlab.haskell.org now sits behind an Anubis anti-bot gateway that blocks
+  BuildKit's sandboxed git client.
 inputs:
   artifact-name:
     description: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -856,8 +856,14 @@ jobs:
           npm version --no-git-tag-version --ignore-scripts "$CLEAN_VERSION"
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+      # code-server (a devDependency used only by UI tests) has a postinstall
+      # that hard-requires Node 22 and rebuilds native modules this job never
+      # runs. Skip all lifecycle scripts and run only our own postinstall,
+      # which vendors the type stub the compile step imports.
       - name: Install dependencies
-        run: bun --bun install --frozen-lockfile
+        run: |
+          bun --bun install --frozen-lockfile --ignore-scripts
+          bun run postinstall
         working-directory: _integrations/vscode-tally
       - name: Compile extension
         run: bun run prevsce:package

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -29,10 +29,11 @@ jobs:
       # (it parses the node major out of the npm user-agent string), so the
       # install step needs the same Node/user-agent setup as the UI job even
       # though the smoke test itself does not launch code-server.
+      # Renovate is pinned to 22.x for this workflow (see renovate.json).
       - name: Set up Node 22
         uses: actions/setup-node@v7
         with:
-          node-version: 24.18.1
+          node-version: 22.23.2
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
       # code-server's postinstall rebuilds native node modules bundled in
@@ -104,10 +105,11 @@ jobs:
           go-version-file: go.mod
       # code-server hard-requires Node 22 (its postinstall parses the node major
       # version out of the npm user-agent string and refuses anything else).
+      # Renovate is pinned to 22.x for this workflow (see renovate.json).
       - name: Set up Node 22
         uses: actions/setup-node@v7
         with:
-          node-version: 24.18.1
+          node-version: 22.23.2
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
       # code-server's postinstall rebuilds native node modules bundled in

--- a/Makefile
+++ b/Makefile
@@ -173,18 +173,28 @@ SHELLCHECK_WASM_INPUTS := \
 	_tools/shellcheck-wasm/Reactor.hs \
 	$(wildcard _tools/shellcheck-wasm/rewrites/*.yml)
 
+# The Dockerfile clones its inputs via BuildKit `ADD <git-url>?ref=...`, which
+# only works on a recent upstream BuildKit. The `default` buildx builder uses
+# the BuildKit embedded in Docker Engine, which on older engines mishandles the
+# git ADD (silently downloading the URL as a single file instead of cloning).
+# So we provision a dedicated `docker-container` builder that pulls a modern
+# standalone BuildKit — the same approach CI takes via docker/setup-buildx-action.
+SHELLCHECK_WASM_BUILDER := tally-shellcheck-wasm
+
 shellcheck-wasm: $(SHELLCHECK_WASM)
 
 $(SHELLCHECK_WASM): $(SHELLCHECK_WASM_INPUTS)
 	@mkdir -p $(dir $@)
+	@docker buildx inspect $(SHELLCHECK_WASM_BUILDER) >/dev/null 2>&1 \
+		|| docker buildx create --name $(SHELLCHECK_WASM_BUILDER) --driver docker-container --bootstrap
 	docker buildx build \
+		--builder $(SHELLCHECK_WASM_BUILDER) \
 		--progress=plain \
 		--build-arg GHC_WASM_META_COMMIT="$(GHC_WASM_META_COMMIT)" \
 		--build-arg SHELLCHECK_VERSION="$(patsubst v%,%,$(SHELLCHECK_VERSION))" \
 		--build-arg AST_GREP_VERSION="$(AST_GREP_VERSION)" \
-		-t tally-shellcheck-wasm -f _tools/shellcheck-wasm/Dockerfile _tools/shellcheck-wasm
-	# Extract the built shellcheck.wasm from the container.
-	docker cp "$$(docker create --rm tally-shellcheck-wasm):/shellcheck.wasm" $@
+		--output type=local,dest=$(dir $@) \
+		-f _tools/shellcheck-wasm/Dockerfile _tools/shellcheck-wasm
 	@touch $@
 
 # Force-rebuild target kept for humans who want to refresh after pulling new

--- a/Makefile
+++ b/Makefile
@@ -185,8 +185,14 @@ shellcheck-wasm: $(SHELLCHECK_WASM)
 
 $(SHELLCHECK_WASM): $(SHELLCHECK_WASM_INPUTS)
 	@mkdir -p $(dir $@)
-	@docker buildx inspect $(SHELLCHECK_WASM_BUILDER) >/dev/null 2>&1 \
-		|| docker buildx create --name $(SHELLCHECK_WASM_BUILDER) --driver docker-container --bootstrap
+	@driver=$$(docker buildx inspect $(SHELLCHECK_WASM_BUILDER) 2>/dev/null | awk '/^Driver:/ {print $$2}'); \
+	if [ -z "$$driver" ]; then \
+		docker buildx create --name $(SHELLCHECK_WASM_BUILDER) --driver docker-container --bootstrap; \
+	elif [ "$$driver" != "docker-container" ]; then \
+		echo "error: buildx builder '$(SHELLCHECK_WASM_BUILDER)' exists but uses driver '$$driver' (docker-container required)." >&2; \
+		echo "Recreate it with: docker buildx rm $(SHELLCHECK_WASM_BUILDER) && make $@" >&2; \
+		exit 1; \
+	fi
 	docker buildx build \
 		--builder $(SHELLCHECK_WASM_BUILDER) \
 		--progress=plain \
@@ -195,6 +201,7 @@ $(SHELLCHECK_WASM): $(SHELLCHECK_WASM_INPUTS)
 		--build-arg AST_GREP_VERSION="$(AST_GREP_VERSION)" \
 		--output type=local,dest=$(dir $@) \
 		-f _tools/shellcheck-wasm/Dockerfile _tools/shellcheck-wasm
+	@test -s $@ || { echo "error: $@ missing or empty after build" >&2; rm -f $@; exit 1; }
 	@touch $@
 
 # Force-rebuild target kept for humans who want to refresh after pulling new

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ $(SHELLCHECK_WASM): $(SHELLCHECK_WASM_INPUTS)
 		echo "Recreate it with: docker buildx rm $(SHELLCHECK_WASM_BUILDER) && make $@" >&2; \
 		exit 1; \
 	fi
+	@rm -f $@
 	docker buildx build \
 		--builder $(SHELLCHECK_WASM_BUILDER) \
 		--progress=plain \

--- a/_tools/shellcheck-wasm/Dockerfile
+++ b/_tools/shellcheck-wasm/Dockerfile
@@ -18,7 +18,13 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt,sharing=locked \
 
 ARG GHC_WASM_META_COMMIT
 
-ADD "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git?ref=${GHC_WASM_META_COMMIT}" /ghc/
+# Clone from the official read-only GitHub mirror rather than the upstream
+# gitlab.haskell.org repo: gitlab.haskell.org now sits behind an Anubis
+# anti-bot proof-of-work gateway that serves an HTML challenge to BuildKit's
+# sandboxed git client, breaking `ADD <git-url>` clones. The mirror
+# (github.com/haskell-wasm/ghc-wasm-meta) is byte-for-byte identical and is
+# not gated. See _tools/shellcheck-wasm/versions.env for the pinned commit.
+ADD "https://github.com/haskell-wasm/ghc-wasm-meta.git?ref=${GHC_WASM_META_COMMIT}" /ghc/
 
 WORKDIR /ghc
 

--- a/internal/highlight/highlight_test.go
+++ b/internal/highlight/highlight_test.go
@@ -178,37 +178,37 @@ func TestAnalyze_ShellcheckWasmDockerfile(t *testing.T) {
 	lines := strings.Split(string(source), "\n")
 
 	// Line indices are 0-based. The file has:
-	//   line 36 (1-based 37): RUN --mount=type=cache,...
-	//   line 37 (1-based 38): \t--mount=type=bind,source=rewrites,target=/rewrites,readonly \
-	//   line 38 (1-based 39): \t<<EOF
+	//   line 42 (1-based 43): RUN --mount=type=cache,...
+	//   line 43 (1-based 44): \t--mount=type=bind,source=rewrites,target=/rewrites,readonly \
+	//   line 44 (1-based 45): \t<<EOF
 	// Verify the offsets to guard against the file drifting.
-	requireLinePrefix(t, lines, 36, "RUN --mount=type=cache")
-	requireLinePrefix(t, lines, 37, "\t--mount=type=bind,source=rewrites")
-	requireLinePrefix(t, lines, 38, "\t<<EOF")
+	requireLinePrefix(t, lines, 42, "RUN --mount=type=cache")
+	requireLinePrefix(t, lines, 43, "\t--mount=type=bind,source=rewrites")
+	requireLinePrefix(t, lines, 44, "\t<<EOF")
 
-	runLine := doc.LineTokens(36)
+	runLine := doc.LineTokens(42)
 	assertHasLineToken(t, source, runLine, core.TokenKeyword, "RUN")
 	assertHasLineToken(t, source, runLine, core.TokenParameter, "--mount")
 
 	// The second --mount flag sits on a continuation line between the RUN
 	// startLine and the heredoc opener. The LSP must emit flag/kv tokens for
 	// it; previously it was excluded as heredoc body.
-	secondMount := doc.LineTokens(37)
+	secondMount := doc.LineTokens(43)
 	assertHasLineToken(t, source, secondMount, core.TokenParameter, "--mount")
 	assertHasLineToken(t, source, secondMount, core.TokenProperty, "type")
 	assertHasLineToken(t, source, secondMount, core.TokenString, "bind")
 	assertHasLineToken(t, source, secondMount, core.TokenProperty, "source")
 	assertHasLineToken(t, source, secondMount, core.TokenString, "rewrites")
 
-	openerLine := doc.LineTokens(38)
+	openerLine := doc.LineTokens(44)
 	assertHasLineToken(t, source, openerLine, core.TokenOperator, "<<")
 	assertHasLineToken(t, source, openerLine, core.TokenKeyword, "EOF")
 
-	// The matching terminator line (105, 0-based) reads `EOF` on its own.
+	// The matching terminator line (111, 0-based) reads `EOF` on its own.
 	// Verify we emit a keyword token there too so the grammar's closing tag
 	// styling still applies under semantic highlighting.
-	requireLinePrefix(t, lines, 105, "EOF")
-	terminatorLine := doc.LineTokens(105)
+	requireLinePrefix(t, lines, 111, "EOF")
+	terminatorLine := doc.LineTokens(111)
 	assertHasLineToken(t, source, terminatorLine, core.TokenKeyword, "EOF")
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -109,8 +109,8 @@
         "GHC_WASM_META_COMMIT\\s*[:=]\\s*(?<currentDigest>[a-f0-9]{40})"
       ],
       "currentValueTemplate": "master",
-      "depNameTemplate": "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta",
-      "packageNameTemplate": "https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git",
+      "depNameTemplate": "https://github.com/haskell-wasm/ghc-wasm-meta",
+      "packageNameTemplate": "https://github.com/haskell-wasm/ghc-wasm-meta.git",
       "datasourceTemplate": "git-refs"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -169,6 +169,16 @@
       "enabled": false
     },
     {
+      "description": "code-server's postinstall hard-requires Node 22; keep the VS Code extension workflow on 22.x",
+      "matchDepNames": [
+        "node"
+      ],
+      "matchFileNames": [
+        ".github/workflows/vscode-extension.yml"
+      ],
+      "allowedVersions": "/^22\\./"
+    },
+    {
       "matchManagers": [
         "github-actions"
       ],


### PR DESCRIPTION
## Problem

`make shellcheck-wasm` fails to build the embedded ShellCheck wasm on developer machines, for **two independent reasons**:

### 1. The local default buildx builder is too old to do a git `ADD`
The Dockerfile clones its inputs via BuildKit's `ADD "<git-url>?ref=<sha>"`, which requires a recent upstream BuildKit. The default `buildx` builder uses the BuildKit embedded in Docker Engine (v0.12.x on Engine 25.0), which doesn't recognize the URL as a git repo — it **downloads it as a single file** named `ghc-wasm-meta.git`. `WORKDIR /ghc; RUN ./setup.sh` then fails with:

```
/bin/sh: line 1: ./setup.sh: No such file or directory
```

CI never hit this because `.github/actions/shellcheck-wasm/action.yml` provisions a modern BuildKit via `docker/setup-buildx-action`.

### 2. `gitlab.haskell.org` is now behind an Anubis anti-bot gateway
Even with a modern `docker-container` builder, the clone fails with:

```
fatal: .../info/refs not valid: could not determine hash algorithm; is this a git repository?
```

The endpoint returns a **"Making sure you're not a bot!" Anubis proof-of-work challenge** (`techaro.lol-anubis-*` cookies) to BuildKit's sandboxed git client. (The host git slips through, but the containerized client is fingerprinted and blocked.)

## Fix

- **Makefile**: auto-provision and use a dedicated `docker-container` builder (modern standalone BuildKit), mirroring CI. Switch extraction to `--output type=local` since that driver doesn't load images into the daemon.
- **Dockerfile**: clone `ghc-wasm-meta` from the official read-only GitHub mirror `github.com/haskell-wasm/ghc-wasm-meta` — byte-for-byte identical (same `HEAD`, contains the exact pinned commit) and not gated.
- **renovate.json**: repoint the digest tracker at the mirror so version bumps keep resolving.
- **CI action comment**: refreshed to describe the Anubis gateway and the git-ADD failure mode.
- **highlight_test.go**: bump the hardcoded Dockerfile line offsets that `TestAnalyze_ShellcheckWasmDockerfile` pins (the new explanatory comment shifted them by 6 lines).

## Verification

- `make shellcheck-wasm` runs end-to-end on a clean default-builder machine and produces a valid 6.9M WebAssembly binary.
- `go test ./internal/shellcheck/...` passes against the freshly-built wasm.
- Full `make test` passes (via the pre-push hook).

## Notes

CI itself was already green (modern builder + GitHub-runner egress to gitlab isn't challenged today), so these changes primarily **fix local builds** and **future-proof CI** against the Anubis gateway. The `shellcheck.wasm` artifact is `.gitignored`, so only source changes appear in the diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that required BuildKit inputs are sourced from GitHub due to GitLab access restrictions.

* **Build Improvements**
  * Improved the ShellCheck WebAssembly build with a dedicated builder and direct artifact output.
  * Added validation to ensure the generated artifact is present and non-empty.

* **Maintenance**
  * Updated source and dependency references to use GitHub while preserving pinned versions.
  * Updated VS Code extension workflows to use Node.js 22 and reliable dependency installation.
  * Refreshed validation checks for the revised build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->