### PR TITLE
fix(release): restore Zed grammar submodule metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Verify submodule metadata
+        run: git submodule status --recursive
       - uses: ./.github/actions/shellcheck-wasm
       - name: Set up Go
         uses: actions/setup-go@v7

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_integrations/zed-tally/grammars/dockerfile"]
+	path = _integrations/zed-tally/grammars/dockerfile
+	url = https://github.com/wharflab/tree-sitter-containerfile.git

--- a/_integrations/zed-tally/extension.toml
+++ b/_integrations/zed-tally/extension.toml
@@ -6,9 +6,9 @@ repository     = "https://github.com/wharflab/tally"
 schema_version = 1
 version        = "0.1.0"
 
-[grammars.dockerfile]
-commit     = "971acdd908568b4531b0ba28a445bf0bb720aba5"
-repository = "https://github.com/camdencheek/tree-sitter-dockerfile"
+[grammars.containerfile]
+commit     = "49ad7af2aefffc5ac226995a8bea754f06ef7901"
+repository = "https://github.com/wharflab/tree-sitter-containerfile"
 
 [language_servers.tally]
 code_actions_kind = ["quickfix", "source.fixAll.tally"]

--- a/_integrations/zed-tally/languages/dockerfile/config.toml
+++ b/_integrations/zed-tally/languages/dockerfile/config.toml
@@ -1,5 +1,5 @@
 name = "Dockerfile"
-grammar = "dockerfile"
+grammar = "containerfile"
 path_suffixes = ["Dockerfile", "Containerfile", "dockerfile"]
 line_comments = ["# "]
 brackets = [

--- a/_integrations/zed-tally/languages/dockerfile/highlights.scm
+++ b/_integrations/zed-tally/languages/dockerfile/highlights.scm
@@ -1,6 +1,6 @@
 ; Dockerfile instructions set taken from:
 ; https://docs.docker.com/engine/reference/builder/#overview
-; https://github.com/camdencheek/tree-sitter-dockerfile/blob/main/queries/highlights.scm
+; https://github.com/wharflab/tree-sitter-containerfile/blob/main/queries/highlights.scm
 [
 	"FROM"
 	"AS"

--- a/scripts/release/publish_vsix.sh
+++ b/scripts/release/publish_vsix.sh
@@ -51,6 +51,18 @@ esac
 
 already_published_pattern='already published|already exists'
 transient_pattern='RequestBlockedException|resource .Concurrency.|exceeding usage|rate.?limit|too many requests|HTTP (408|409|425|429|5[0-9][0-9])|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|temporary unavailable|temporarily unavailable|service unavailable|gateway timeout'
+persistent_vsid_pattern='resource .Concurrency. in namespace .VSID.'
+
+report_persistent_vsid_block() {
+  local output_file="$1"
+  if [[ "$registry" != "vscode" ]] || ! grep -Eqi "$persistent_vsid_pattern" "$output_file"; then
+    return
+  fi
+
+  echo "::error::Visual Studio Marketplace is persistently blocking the publisher identity with VSID Concurrency."
+  echo "::error::Stop automated retries and contact VSMarketplace@microsoft.com to clear the publisher/account block."
+  echo "Include publisher 'wharflab', extension 'wharflab.tally', event ID 3000, and the failed workflow URL."
+}
 
 publish_one() {
   local vsix="$1"
@@ -95,6 +107,7 @@ for index in "${!vsixes[@]}"; do
     fi
 
     if (( attempt >= max_attempts )) || ! grep -Eqi "$transient_pattern" "$output_file"; then
+      report_persistent_vsid_block "$output_file"
       rm -f "$output_file"
       exit "$status"
     fi


### PR DESCRIPTION
## Summary

- restore valid Git submodule metadata so `actions/checkout` credential cleanup no longer aborts release publishing
- replace the Zed grammar with `wharflab/tree-sitter-containerfile` at `49ad7af2`
- align the Zed grammar ID with the parser's `tree_sitter_containerfile` export
- add a CI guard that validates all gitlinks have submodule metadata

## Root cause

The repository contained a gitlink at `_integrations/zed-tally/grammars/dockerfile` but no `.gitmodules` entry. The Marketplace jobs use `persist-credentials: false`; `actions/checkout` runs `git submodule foreach --recursive` while removing credentials and failed before publishing began.

## Validation

- `git submodule status --recursive`
- `git submodule foreach --recursive true`
- WharfLab grammar `cargo test`
- Zed extension `cargo test`
- Zed extension WASM check
- Zed extension clippy with warnings denied
- Zed extension formatting check
- actionlint, yamllint, Taplo, and git diff checks

## Recovery

The existing `v0.45.0` release already contains all six VSIX assets. The manual publish workflow can run from this branch and publish both registries without moving the release tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved syntax highlighting and language support for Dockerfiles and Containerfiles.
  * Updated grammar support to recognize Containerfile syntax more accurately.

* **Bug Fixes**
  * Added validation to ensure recursive repository metadata is available during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->